### PR TITLE
New tensor `transpose` operation

### DIFF
--- a/docs/src/operations/reference/linear_algebra/index.rst
+++ b/docs/src/operations/reference/linear_algebra/index.rst
@@ -7,3 +7,4 @@ Linear algebra
     dot() <dot>
     lstsq() <lstsq>
     solve() <solve>
+    transpose() <transpose>

--- a/docs/src/operations/reference/linear_algebra/transpose.rst
+++ b/docs/src/operations/reference/linear_algebra/transpose.rst
@@ -1,0 +1,6 @@
+transpose
+=========
+
+.. autofunction:: equistore.transpose
+
+.. autofunction:: equistore.transpose_block

--- a/python/metatensor-operations/metatensor/operations/transpose.py
+++ b/python/metatensor-operations/metatensor/operations/transpose.py
@@ -1,0 +1,84 @@
+"""
+Module to transpose a :py:class:`TensorMap` or :py:class:`TensorBlock`.
+"""
+import numpy as np
+
+from ..block import TensorBlock
+from ..labels import Labels
+from ..tensor import TensorMap
+from . import _dispatch
+
+
+def transpose(tensor: TensorMap) -> TensorMap:
+    """
+    Transposes a :py:class:`TensorMap`.
+    """
+    # Check input
+    if not isinstance(tensor, TensorMap):
+        raise TypeError(f"Expected a TensorMap, got {type(tensor)}.")
+    # Transpose TensorMap
+    keys = tensor.keys
+    return TensorMap(keys, [transpose_block(tensor[key]) for key in keys])
+
+
+def transpose_block(block: TensorBlock) -> TensorBlock:
+    """
+    Transposes a :py:class:`TensorBlock`.
+    """
+    # Check input
+    if not isinstance(block, TensorBlock):
+        raise TypeError(f"Expected a TensorBlock, got {type(block)}.")
+    # Define the new samples and components to use for the output block. The new
+    # samples are just the original blocks's properties and the new components
+    # are just the originals, reversed.
+    new_samples = block.properties
+    new_components = block.components[::-1]
+
+    # Define the shape that is common to this block and all of its
+    # gradients. This is the size of all components, and the properties,
+    # i.e. (c1, c2, ..., cn, p), but not the samples
+    common_shape = block.values.shape[1:]
+
+    # Transpose the values and store in an array
+    transposed_block_values = _dispatch.transpose(block.values)
+
+    # Define number of properties in the transposed block. This will be
+    # increased by the length of the new properties of each gradient and used as
+    # a numeric index for the properties in the returned block.
+    q_max = transposed_block_values.shape[-1]
+
+    # Iterate over the gradients. Reshape, transpose and store the gradient data
+    arrays_to_join = [transposed_block_values]
+    for _, gradient in block.gradients():
+        # Reshape the gradient data such that the gradient specific samples are
+        # moved to the samples dimension, but the components common with the
+        # associated values block are kept in the components dimension. For
+        # instance, if the gradient has shape (100, 3, 3, 5, 6, 400), where (3,
+        # 3) are the gradient-specific components, the reshaped gradient should
+        # have shape (900, 5, 6, 400).
+        n_grad_samples = np.prod(gradient.data.shape[: -len(common_shape)])
+        reshaped_grad_data = gradient.data.reshape(n_grad_samples, *common_shape)
+
+        # Transpose the gradient data and store. For instance, (900, 5, 6, 400)
+        # becomes (400, 6, 5, 900).
+        tranposed_grad_data = _dispatch.transpose(reshaped_grad_data)
+        arrays_to_join.append(tranposed_grad_data)
+
+        # Update q_max for the next gradient
+        q_max += tranposed_grad_data.shape[-1]
+
+    # Concatenate block values and gradients data tensors along the properties
+    # (final) axis.
+    joined_values = _dispatch.concatenate(
+        arrays_to_join, axis=len(arrays_to_join[0].shape) - 1
+    )
+
+    return TensorBlock(
+        values=joined_values,
+        samples=new_samples,
+        components=new_components,
+        properties=Labels(
+            names=("q",),
+            values=np.arange(q_max).reshape(-1, 1),
+        ),
+    )

--- a/python/metatensor-operations/tests/transpose.py
+++ b/python/metatensor-operations/tests/transpose.py
@@ -1,0 +1,99 @@
+import os
+
+import numpy as np
+import pytest
+
+import equistore
+from equistore import Labels, TensorBlock
+
+
+DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
+TEST_FILE = "qm7-spherical-expansion.npz"
+
+
+@pytest.fixture
+def tensorblock():
+    block = TensorBlock(
+        samples=Labels(["s"], np.array([[0], [1], [2], [3]])),
+        components=[
+            Labels(["c3"], np.array([[0], [1], [2]])),
+            Labels(["c4"], np.array([[4], [5], [6]])),
+            Labels(["c5"], np.array([[7], [8], [9]])),
+        ],
+        properties=Labels(["p"], np.array([[-1]])),
+        values=np.full((4, 3, 3, 3, 1), 1),
+    )
+    return block
+
+
+@pytest.fixture
+def tensorblock_with_gradient():
+    block = TensorBlock(
+        samples=Labels(["s"], np.array([[0], [1], [2], [3]])),
+        components=[
+            Labels(["c3"], np.array([[0], [1], [2]])),
+            Labels(["c4"], np.array([[4], [5], [6]])),
+            Labels(["c5"], np.array([[7], [8], [9]])),
+        ],
+        properties=Labels(["p"], np.array([[-1]])),
+        values=np.full((4, 3, 3, 3, 1), 1),
+    )
+    block.add_gradient(
+        "parameter",
+        samples=Labels(["sample", "ds"], np.array([[0, 0], [1, 1], [2, 2], [3, 3]])),
+        components=[
+            Labels(
+                ["c1"],
+                np.array(
+                    [
+                        [0],
+                        [1],
+                    ]
+                ),
+            ),
+            Labels(
+                ["c2"],
+                np.array(
+                    [
+                        [2],
+                        [3],
+                    ]
+                ),
+            ),
+            Labels(["c3"], np.array([[0], [1], [2]])),
+            Labels(["c4"], np.array([[4], [5], [6]])),
+            Labels(["c5"], np.array([[7], [8], [9]])),
+        ],
+        data=np.full((4, 2, 2, 3, 3, 3, 1), -1),
+    )
+    return block
+
+
+@pytest.fixture
+def tensormap():
+    return equistore.load(os.path.join(DATA_ROOT, TEST_FILE), use_numpy=True)
+
+
+class TestTranspose:
+    def test_transpose_block(self, tensorblock):
+        """
+        Tests :py:func:`tranpose_block` for a block without a gradient.
+        """
+        block_T = equistore.transpose_block(tensorblock)
+        # Check shape
+        assert block_T.values.shape == (1, 3, 3, 3, 4)
+        # Check values
+
+    def transpose_block_with_gradient(self, tensorblock_with_gradient):
+        """
+        Tests :py:func:`tranpose_block` with a block that has a gradient.
+        """
+        # Check shape
+        # Check values
+
+    def test_transpose(self, tensormap):
+        """
+        Tests :py:func:`tranpose` for a TensorMap.
+        """
+        # Check shape
+        # Check values


### PR DESCRIPTION
COSMO day collaboration: @DivyaSuman14,@SanggyuChong, and I. Closes #191.

New `transpose` function for TensorMaps and TensorBlocks. Returns a new TensorMap where axes have been transposed. Each returned block has samples that correspond to the original block's properties. Components axes are reversed. Properties correspond to the original block's samples. 

In the case where the blocks of a tensor have gradients, the transposed block is joined along the new properties (previously samples) axis with all of its transposed gradients. Due to clashing dimensions of values and gradients samples, a new hybrid label "q" is created and used as the metadata for the returned blocks, joined along the properties.

Collapsing of the properties axis labels to a single numeric index "q" results in information loss. We should also think about providing a user flag for the function that allows the samples metadata of the original TensorMap to be returned, such that the original TensorMap can be constructed. In other words, one need to retain the original samples metadata if one wants be able to call transpose twice on a TensorMap and reclaim the original TensorMap. With the loss of information associated with creation of the "q" index, this is not yet possible.


To Do:
- [x] Test the function for usability
- [ ] Write unit tests
- [ ] Write function docstrings
- [ ] Properly document the action of the operation and the meaning of the new axes, in particular the "q" label used for the new properties
- [ ] EXTRA: provide a user flag for returning the original TensorMap's sample metadata., as well as functionality (and tests_ to allow users to transpose twice and reclaim their original TensorMap.
- [ ] All functions that involve taking transposes of block values (i.e. `dot` and `solve`) should be updated to use `equistore.transpose()` instead.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--197.org.readthedocs.build/en/197/

<!-- readthedocs-preview equistore end -->