### PR TITLE
De-duplicate cargo default libs

### DIFF
--- a/metatensor-core/CMakeLists.txt
+++ b/metatensor-core/CMakeLists.txt
@@ -192,9 +192,13 @@ if (CARGO_VERSION_CHANGED)
         endforeach()
         # Special case `msvcrt` to link with the debug version in Debug mode.
         list(TRANSFORM stripped_lib_list REPLACE "^msvcrt$" "\$<\$<CONFIG:Debug>:msvcrtd>")
+        list(REMOVE_DUPLICATES stripped_lib_list)
 
         set(CARGO_DEFAULT_LIBRARIES "${stripped_lib_list}" CACHE INTERNAL "list of implicitly linked libraries")
-        message(STATUS "Cargo default link libraries are: ${CARGO_DEFAULT_LIBRARIES}")
+
+        if (${METATENSOR_MAIN_PROJECT})
+            message(STATUS "Cargo default link libraries are: ${CARGO_DEFAULT_LIBRARIES}")
+        endif()
     else()
         message(FATAL_ERROR "could not find default static libs: `native-static-libs` not found in: `${cargo_build_error_message}`")
     endif()


### PR DESCRIPTION
On windows, the list looks like

```
kernel32;advapi32;advapi32;bcrypt;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;kernel32;ntdll;ntdll;ntdll;ntdll;userenv;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;ws2_32;kernel32;ws2_32;kernel32;kernel32
```

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--347.org.readthedocs.build/en/347/

<!-- readthedocs-preview metatensor end -->