### PR TITLE
Improve <labels>_names methods

### DIFF
--- a/metatensor-torch/include/metatensor/torch/tensor.hpp
+++ b/metatensor-torch/include/metatensor/torch/tensor.hpp
@@ -118,14 +118,17 @@ public:
     /// strings.
     TorchTensorMap components_to_properties(torch::IValue dimensions) const;
 
-    /// Get the sample names used for all block in this `TensorMap`
-    std::vector<std::string> sample_names();
+    /// Get the names of the samples dimensions for all blocks in this
+    /// `TensorMap`
+    std::vector<std::string> samples_names();
 
-    /// Get the components names used for all block in this `TensorMap`
-    std::vector<std::vector<std::string>> components_names();
+    /// Get the names of the components dimensions for all blocks in this
+    /// `TensorMap`
+    std::vector<std::string> components_names();
 
-    /// Get the property names used for all block in this `TensorMap`
-    std::vector<std::string> property_names();
+    /// Get the names of the properties dimensions for all blocks in this
+    /// `TensorMap`
+    std::vector<std::string> properties_names();
 
     /// Get all (key => block) pairs in this `TensorMap`
     std::vector<std::tuple<TorchLabelsEntry, TorchTensorBlock>> items();

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -180,9 +180,9 @@ TORCH_LIBRARY(metatensor, m) {
         .def("components_to_properties", &TensorMapHolder::components_to_properties, DOCSTRING,
             {torch::arg("dimensions")}
         )
-        .def_property("sample_names", &TensorMapHolder::sample_names)
+        .def_property("samples_names", &TensorMapHolder::samples_names)
         .def_property("components_names", &TensorMapHolder::components_names)
-        .def_property("property_names", &TensorMapHolder::property_names)
+        .def_property("properties_names", &TensorMapHolder::properties_names)
         .def("print", &TensorMapHolder::print, DOCSTRING,
             {torch::arg("max_keys")}
         )

--- a/metatensor-torch/src/tensor.cpp
+++ b/metatensor-torch/src/tensor.cpp
@@ -378,7 +378,7 @@ static std::vector<std::string> labels_names(const metatensor::TensorBlock& bloc
     return result;
 }
 
-std::vector<std::string> TensorMapHolder::sample_names() {
+std::vector<std::string> TensorMapHolder::samples_names() {
     if (tensor_.keys().count() == 0) {
         return {};
     }
@@ -386,22 +386,26 @@ std::vector<std::string> TensorMapHolder::sample_names() {
     return labels_names(this->block_by_id(0)->as_metatensor(), 0);
 }
 
-std::vector<std::vector<std::string>> TensorMapHolder::components_names() {
-    auto result = std::vector<std::vector<std::string>>();
+std::vector<std::string> TensorMapHolder::components_names() {
+    auto result = std::vector<std::string>();
 
     if (tensor_.keys().count() != 0) {
         auto block = this->block_by_id(0);
         auto n_dimensions = block->values().sizes().size();
 
         for (size_t dimension=1; dimension<n_dimensions-1; dimension++) {
-            result.push_back(labels_names(block->as_metatensor(), dimension));
+            const auto& metatensor_block = block->as_metatensor();
+            auto labels = metatensor_block.labels(dimension);
+            assert(labels.names().size() == 1);
+
+            result.push_back(std::string(labels.names()[0]));
         }
     }
 
     return result;
 }
 
-std::vector<std::string> TensorMapHolder::property_names() {
+std::vector<std::string> TensorMapHolder::properties_names() {
     if (tensor_.keys().count() == 0) {
         return {};
     }

--- a/python/metatensor-core/metatensor/core/tensor.py
+++ b/python/metatensor-core/metatensor/core/tensor.py
@@ -1,7 +1,7 @@
 import copy
 import ctypes
 import sys
-from typing import Dict, List, Sequence, Tuple, Union
+from typing import Dict, List, Sequence, Union
 
 
 if (sys.version_info.major >= 3) and (sys.version_info.minor >= 8):
@@ -512,26 +512,32 @@ class TensorMap:
         return TensorMap._from_ptr(ptr)
 
     @property
-    def sample_names(self) -> Tuple[str]:
-        """names of the sample labels for all blocks in this tensor map"""
+    def samples_names(self) -> List[str]:
+        """
+        names of the samples dimensions for all blocks in this :py:class:`TensorMap`
+        """
         if len(self.keys) == 0:
-            return tuple()
+            return []
 
         return self.block(0).samples.names
 
     @property
-    def components_names(self) -> List[Tuple[str]]:
-        """names of the component labels for all blocks in this tensor map"""
+    def components_names(self) -> List[str]:
+        """
+        names of the components dimensions for all blocks in this :py:class:`TensorMap`
+        """
         if len(self.keys) == 0:
             return []
 
-        return [c.names for c in self.block(0).components]
+        return [c.names[0] for c in self.block(0).components]
 
     @property
-    def property_names(self) -> Tuple[str]:
-        """names of the property labels for all blocks in this tensor map"""
+    def properties_names(self) -> List[str]:
+        """
+        names of the properties dimensions for all blocks in this :py:class:`TensorMap`
+        """
         if len(self.keys) == 0:
-            return tuple()
+            return []
 
         return self.block(0).properties.names
 

--- a/python/metatensor-core/tests/tensor.py
+++ b/python/metatensor-core/tests/tensor.py
@@ -90,9 +90,9 @@ keys: key_1  key_2
 
 
 def test_labels_names(tensor):
-    assert tensor.sample_names == ["s"]
-    assert tensor.components_names == [["c"]]
-    assert tensor.property_names == ["p"]
+    assert tensor.samples_names == ["s"]
+    assert tensor.components_names == ["c"]
+    assert tensor.properties_names == ["p"]
 
 
 def test_block(tensor):
@@ -353,9 +353,9 @@ def test_empty_tensor():
 
     assert empty_tensor.keys.names == ["key"]
 
-    assert empty_tensor.sample_names == tuple()
+    assert empty_tensor.samples_names == []
     assert empty_tensor.components_names == []
-    assert empty_tensor.property_names == tuple()
+    assert empty_tensor.properties_names == []
 
     # check the `blocks` function
     assert empty_tensor.blocks() == []

--- a/python/metatensor-operations/metatensor/operations/join.py
+++ b/python/metatensor-operations/metatensor/operations/join.py
@@ -234,9 +234,9 @@ def join(
     # Deduce if sample/property names are the same in all tensors.
     # If this is not the case we have to change unify the corresponding labels later.
     if axis == "samples":
-        names_list = [tensor.sample_names for tensor in tensors]
+        names_list = [tensor.samples_names for tensor in tensors]
     else:
-        names_list = [tensor.property_names for tensor in tensors]
+        names_list = [tensor.properties_names for tensor in tensors]
 
     # We use functools to flatten a list of sublists::
     #

--- a/python/metatensor-operations/metatensor/operations/manipulate_dimension.py
+++ b/python/metatensor-operations/metatensor/operations/manipulate_dimension.py
@@ -72,10 +72,10 @@ def append_dimension(tensor: TensorMap, axis: str, name: str, values) -> TensorM
         index = len(tensor.keys.names)
         return insert_dimension(tensor, axis, index, name, values)
     elif axis == "samples":
-        index = len(tensor.sample_names)
+        index = len(tensor.samples_names)
         return insert_dimension(tensor, axis, index, name, values)
     elif axis == "properties":
-        index = len(tensor.property_names)
+        index = len(tensor.properties_names)
         return insert_dimension(tensor, axis, index, name, values)
     else:
         raise ValueError(

--- a/python/metatensor-operations/tests/join.py
+++ b/python/metatensor-operations/tests/join.py
@@ -127,8 +127,8 @@ def test_join_properties_values(tensor):
             assert_equal(joined_gradient.values, gradient.values)
 
 
-def test_join_properties_with_same_property_names(tensor):
-    """Test join function with three tensor along `properties`"""
+def test_join_properties_with_same_properties_names(tensor):
+    """Test join function with three tensor along properties"""
 
     joined_tensor = metatensor.join([tensor, tensor, tensor], axis="properties")
 
@@ -146,8 +146,8 @@ def test_join_properties_with_same_property_names(tensor):
     )
 
 
-def test_join_properties_with_different_property_names():
-    """Test join function with tensors of different `property` names"""
+def test_join_properties_with_different_properties_names():
+    """Test join function with tensors of different properties names"""
 
     keys = Labels.range("frame_a", 1)
     values = np.zeros([1, 1])
@@ -178,7 +178,7 @@ def test_join_properties_with_different_property_names():
     )
 
     joined_tensor = metatensor.join([tensor_map_a, tensor_map_b], axis="properties")
-    assert joined_tensor.property_names == ["tensor", "property"]
+    assert joined_tensor.properties_names == ["tensor", "property"]
     assert len(joined_tensor[0].properties) == 2
 
 
@@ -229,8 +229,8 @@ def test_join_samples_values(tensor):
             assert_equal(joined_gradient.values, gradient.values)
 
 
-def test_join_samples_with_different_sample_names():
-    """Test join function raises an error with different `sample` names"""
+def test_join_samples_with_different_samples_names():
+    """Test join function raises an error with different samples names"""
     keys = Labels.range("frame_a", 1)
     values = np.zeros([1, 1])
     properties = Labels.range("idx", 1)

--- a/python/metatensor-operations/tests/manipulate_dimension.py
+++ b/python/metatensor-operations/tests/manipulate_dimension.py
@@ -54,7 +54,7 @@ def test_append_samples():
         values=values,
     )
 
-    assert new_tensor.sample_names[-1] == "foo"
+    assert new_tensor.samples_names[-1] == "foo"
 
     for block in new_tensor:
         assert block.samples.values[:, -1] == values
@@ -69,7 +69,7 @@ def test_append_properties():
         values=values,
     )
 
-    assert new_tensor.property_names[-1] == "foo"
+    assert new_tensor.properties_names[-1] == "foo"
 
     for block in new_tensor:
         assert_equal(block.properties.values[:, -1], values)
@@ -110,7 +110,7 @@ def test_insert_samples():
         values=values,
     )
 
-    assert new_tensor.sample_names[index] == "foo"
+    assert new_tensor.samples_names[index] == "foo"
 
     for block in new_tensor:
         assert block.samples.values[:, index] == values
@@ -127,7 +127,7 @@ def test_insert_properties():
         values=values,
     )
 
-    assert new_tensor.property_names[index] == "foo"
+    assert new_tensor.properties_names[index] == "foo"
 
     for block in new_tensor:
         assert_equal(block.properties.values[:, index], values)
@@ -166,7 +166,7 @@ def test_permute_samples():
         ref_tensor, axis="samples", dimensions_indexes=dimensions_indexes
     )
 
-    assert new_tensor.sample_names == ["center", "structure"]
+    assert new_tensor.samples_names == ["center", "structure"]
 
     for key, block in new_tensor.items():
         ref_block = ref_tensor.block(key)
@@ -175,10 +175,10 @@ def test_permute_samples():
         )
         for parameter, gradient in block.gradients():
             if parameter == "positions":
-                gradient_sample_names = ["sample", "structure", "atom"]
+                gradient_samples_names = ["sample", "structure", "atom"]
             elif parameter == "cell":
-                gradient_sample_names = ["sample"]
-            assert gradient.samples.names == gradient_sample_names
+                gradient_samples_names = ["sample"]
+            assert gradient.samples.names == gradient_samples_names
 
 
 def test_permute_properties():
@@ -188,7 +188,7 @@ def test_permute_properties():
         ref_tensor, axis="properties", dimensions_indexes=dimensions_indexes
     )
 
-    assert new_tensor.property_names == ["n2", "l", "n1"]
+    assert new_tensor.properties_names == ["n2", "l", "n1"]
 
     for key, block in new_tensor.items():
         ref_block = ref_tensor.block(key)
@@ -216,19 +216,19 @@ def test_rename_samples():
         old="structure",
         new="foo",
     )
-    assert new_tensor.sample_names[0] == "foo"
+    assert new_tensor.samples_names[0] == "foo"
 
     for block in new_tensor:
         for parameter, gradient in block.gradients():
             if parameter == "positions":
-                gradient_sample_names = ["sample", "foo", "atom"]
+                gradient_samples_names = ["sample", "foo", "atom"]
             elif parameter == "cell":
-                gradient_sample_names = ["sample"]
-            assert gradient.samples.names == gradient_sample_names
+                gradient_samples_names = ["sample"]
+            assert gradient.samples.names == gradient_samples_names
 
 
 def test_rename_properties():
-    old = tensor().property_names[0]
+    old = tensor().properties_names[0]
 
     new_tensor = metatensor.rename_dimension(
         tensor(),
@@ -236,7 +236,7 @@ def test_rename_properties():
         old=old,
         new="foo",
     )
-    assert new_tensor.property_names[0] == "foo"
+    assert new_tensor.properties_names[0] == "foo"
 
     for block in new_tensor:
         for _, gradient in block.gradients():
@@ -259,7 +259,7 @@ def test_remove_samples():
         axis="samples",
         name="extra",
     )
-    assert new_tensor.sample_names == ["sample"]
+    assert new_tensor.samples_names == ["sample"]
 
 
 def test_remove_properties():
@@ -268,7 +268,7 @@ def test_remove_properties():
         axis="properties",
         name="extra",
     )
-    assert new_tensor.property_names == ["properties"]
+    assert new_tensor.properties_names == ["properties"]
 
     for block in new_tensor:
         for _, gradient in block.gradients():

--- a/python/metatensor-operations/tests/reduce_mean.py
+++ b/python/metatensor-operations/tests/reduce_mean.py
@@ -20,9 +20,9 @@ def test_mean_samples_block():
     )
     bl1 = tensor_ps[0]
 
-    # check both passing a list and a single string for sample_names
-    reduce_tensor_se = metatensor.mean_over_samples(tensor_se, sample_names="center")
-    reduce_tensor_ps = metatensor.mean_over_samples(tensor_ps, sample_names=["center"])
+    # check both passing a list and a single string for samples_names
+    reduce_tensor_se = metatensor.mean_over_samples(tensor_se, samples_names="center")
+    reduce_tensor_ps = metatensor.mean_over_samples(tensor_ps, samples_names=["center"])
 
     assert np.all(
         np.mean(bl1.values[:4], axis=0) == reduce_tensor_ps.block(0).values[0]
@@ -147,9 +147,9 @@ def test_reduction_block_two_samples():
     keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
     X = TensorMap(keys, [block_1])
 
-    reduce_X_12 = metatensor.mean_over_samples(X, sample_names=["samples3"])
-    reduce_X_23 = metatensor.mean_over_samples(X, sample_names="samples1")
-    reduce_X_2 = metatensor.mean_over_samples(X, sample_names=["samples1", "samples3"])
+    reduce_X_12 = metatensor.mean_over_samples(X, samples_names=["samples3"])
+    reduce_X_23 = metatensor.mean_over_samples(X, samples_names="samples1")
+    reduce_X_2 = metatensor.mean_over_samples(X, samples_names=["samples1", "samples3"])
 
     assert np.allclose(
         np.mean(X.block(0).values[:3], axis=0),

--- a/python/metatensor-operations/tests/reduce_special_cases.py
+++ b/python/metatensor-operations/tests/reduce_special_cases.py
@@ -25,10 +25,10 @@ def test_reduction_all_samples():
     keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
     X = TensorMap(keys, [block_1])
 
-    sum_X = metatensor.sum_over_samples(X, sample_names=["s"])
-    mean_X = metatensor.mean_over_samples(X, sample_names=["s"])
-    var_X = metatensor.var_over_samples(X, sample_names=["s"])
-    std_X = metatensor.std_over_samples(X, sample_names=["s"])
+    sum_X = metatensor.sum_over_samples(X, samples_names=["s"])
+    mean_X = metatensor.mean_over_samples(X, samples_names=["s"])
+    var_X = metatensor.var_over_samples(X, samples_names=["s"])
+    std_X = metatensor.std_over_samples(X, samples_names=["s"])
 
     assert metatensor.equal_metadata(sum_X, mean_X)
     assert metatensor.equal_metadata(sum_X, std_X)

--- a/python/metatensor-operations/tests/reduce_std.py
+++ b/python/metatensor-operations/tests/reduce_std.py
@@ -22,9 +22,9 @@ def test_std_samples_block():
 
     bl1 = tensor_ps[0]
 
-    # check both passing a list and a single string for sample_names
-    reduce_tensor_se = metatensor.std_over_samples(tensor_se, sample_names="center")
-    reduce_tensor_ps = metatensor.std_over_samples(tensor_ps, sample_names=["center"])
+    # check both passing a list and a single string for samples_names
+    reduce_tensor_se = metatensor.std_over_samples(tensor_se, samples_names="center")
+    reduce_tensor_ps = metatensor.std_over_samples(tensor_ps, samples_names=["center"])
 
     assert np.allclose(
         np.std(bl1.values[:4], axis=0),
@@ -176,9 +176,9 @@ def test_reduction_block_two_samples():
     keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
     X = TensorMap(keys, [block_1])
 
-    reduce_X_12 = metatensor.std_over_samples(X, sample_names=["s_3"])
-    reduce_X_23 = metatensor.std_over_samples(X, sample_names="s_1")
-    reduce_X_2 = metatensor.std_over_samples(X, sample_names=["s_1", "s_3"])
+    reduce_X_12 = metatensor.std_over_samples(X, samples_names=["s_3"])
+    reduce_X_23 = metatensor.std_over_samples(X, samples_names="s_1")
+    reduce_X_2 = metatensor.std_over_samples(X, samples_names=["s_1", "s_3"])
 
     assert np.allclose(
         np.std(X.block(0).values[:3], axis=0),
@@ -259,10 +259,10 @@ def test_reduction_of_one_element():
     keys = Labels(names=["key_1"], values=np.array([[0]]))
     X = TensorMap(keys, [block_1])
 
-    add_X = metatensor.sum_over_samples(X, sample_names=["s_1"])
-    mean_X = metatensor.mean_over_samples(X, sample_names=["s_1"])
-    var_X = metatensor.var_over_samples(X, sample_names=["s_1"])
-    std_X = metatensor.std_over_samples(X, sample_names=["s_1"])
+    add_X = metatensor.sum_over_samples(X, samples_names=["s_1"])
+    mean_X = metatensor.mean_over_samples(X, samples_names=["s_1"])
+    var_X = metatensor.var_over_samples(X, samples_names=["s_1"])
+    std_X = metatensor.std_over_samples(X, samples_names=["s_1"])
 
     # print(add_X[0])
     # print(X[0].values, add_X[0].values)

--- a/python/metatensor-operations/tests/reduce_sum.py
+++ b/python/metatensor-operations/tests/reduce_sum.py
@@ -20,13 +20,13 @@ def test_sum_samples_block():
     )
     bl1 = tensor_ps[0]
 
-    # check both passing a list and a single string for sample_names
-    reduce_tensor_se = metatensor.sum_over_samples(tensor_se, sample_names=["center"])
-    reduce_tensor_ps = metatensor.sum_over_samples(tensor_ps, sample_names="center")
+    # check both passing a list and a single string for samples_names
+    reduce_tensor_se = metatensor.sum_over_samples(tensor_se, samples_names=["center"])
+    reduce_tensor_ps = metatensor.sum_over_samples(tensor_ps, samples_names="center")
 
     # checks that reduction over a block is the same as the tensormap operation
     reduce_block_se = metatensor.sum_over_samples_block(
-        tensor_se.block(0), sample_names="center"
+        tensor_se.block(0), samples_names="center"
     )
     assert np.allclose(reduce_block_se.values, reduce_tensor_se.block(0).values)
 
@@ -132,9 +132,9 @@ def test_reduction_block_two_samples():
     keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
     X = TensorMap(keys, [block_1])
 
-    reduce_X_12 = metatensor.sum_over_samples(X, sample_names="samples3")
-    reduce_X_23 = metatensor.sum_over_samples(X, sample_names=["samples1"])
-    reduce_X_2 = metatensor.sum_over_samples(X, sample_names=["samples1", "samples3"])
+    reduce_X_12 = metatensor.sum_over_samples(X, samples_names="samples3")
+    reduce_X_23 = metatensor.sum_over_samples(X, samples_names=["samples1"])
+    reduce_X_2 = metatensor.sum_over_samples(X, samples_names=["samples1", "samples3"])
 
     assert np.all(
         np.sum(X.block(0).values[:3], axis=0) == reduce_X_12.block(0).values[0]

--- a/python/metatensor-operations/tests/slice.py
+++ b/python/metatensor-operations/tests/slice.py
@@ -415,7 +415,7 @@ def test_slice_block_samples_and_properties(tensor):
 
 
 def test_slicing_by_empty(tensor):
-    empty_labels_samples = Labels.empty(tensor.sample_names)
+    empty_labels_samples = Labels.empty(tensor.samples_names)
 
     # Empty block returned if no samples to slice by are passed
     reference_block = _construct_empty_slice_block(
@@ -439,7 +439,7 @@ def test_slicing_by_empty(tensor):
         reference_tensor,
     )
 
-    empty_labels_properties = Labels.empty(tensor.property_names)
+    empty_labels_properties = Labels.empty(tensor.properties_names)
     # Empty block returned if no properties to slice by are passed
     reference_block = _construct_empty_slice_block(
         tensor.block(0), "properties", empty_labels_properties
@@ -470,7 +470,7 @@ def test_slicing_all(tensor):
             tensor.block(0),
             axis="samples",
             labels=metatensor.unique_metadata(
-                tensor, axis="samples", names=tensor.sample_names
+                tensor, axis="samples", names=tensor.samples_names
             ),
         ),
         tensor.block(0),
@@ -482,7 +482,7 @@ def test_slicing_all(tensor):
             tensor,
             axis="samples",
             labels=metatensor.unique_metadata(
-                tensor, axis="samples", names=tensor.sample_names
+                tensor, axis="samples", names=tensor.samples_names
             ),
         ),
         tensor,
@@ -496,7 +496,7 @@ def test_slicing_all(tensor):
             labels=metatensor.unique_metadata(
                 tensor,
                 axis="properties",
-                names=tensor.property_names,
+                names=tensor.properties_names,
             ),
         ),
         tensor.block(0),
@@ -508,7 +508,7 @@ def test_slicing_all(tensor):
             tensor,
             axis="properties",
             labels=metatensor.unique_metadata(
-                tensor, axis="properties", names=tensor.property_names
+                tensor, axis="properties", names=tensor.properties_names
             ),
         ),
         tensor,

--- a/python/metatensor-torch/tests/operations/manipulate_dimension.py
+++ b/python/metatensor-torch/tests/operations/manipulate_dimension.py
@@ -25,58 +25,58 @@ def get_tensor_map():
 def check_append(append):
     tensor = get_tensor_map()
 
-    assert tensor.sample_names == ["structure", "center"]
+    assert tensor.samples_names == ["structure", "center"]
     new_tensor = append(
         tensor, "samples", "center_2", tensor.block(0).samples.column("center")
     )
 
     assert isinstance(new_tensor, torch.ScriptObject)
-    assert new_tensor.sample_names == ["structure", "center", "center_2"]
+    assert new_tensor.samples_names == ["structure", "center", "center_2"]
 
 
 def check_insert(insert):
     tensor = get_tensor_map()
 
-    assert tensor.sample_names == ["structure", "center"]
+    assert tensor.samples_names == ["structure", "center"]
     new_tensor = insert(
         tensor, "samples", 1, "center_2", tensor.block(0).samples.column("center")
     )
 
     assert isinstance(new_tensor, torch.ScriptObject)
-    assert new_tensor.sample_names == ["structure", "center_2", "center"]
+    assert new_tensor.samples_names == ["structure", "center_2", "center"]
 
 
 def check_permute(permute):
     tensor = get_tensor_map()
 
-    assert tensor.sample_names == ["structure", "center"]
+    assert tensor.samples_names == ["structure", "center"]
     new_tensor = permute(tensor, "samples", [1, 0])
 
     assert isinstance(new_tensor, torch.ScriptObject)
-    assert new_tensor.sample_names == ["center", "structure"]
+    assert new_tensor.samples_names == ["center", "structure"]
 
 
 def check_remove(remove):
     tensor = get_tensor_map()
 
-    assert tensor.sample_names == ["structure", "center"]
+    assert tensor.samples_names == ["structure", "center"]
     new_tensor = metatensor.torch.append_dimension(
         tensor, "samples", "center_2", tensor.block(0).samples.column("center")
     )
     new_tensor = remove(new_tensor, "samples", "center_2")
 
     assert isinstance(new_tensor, torch.ScriptObject)
-    assert new_tensor.sample_names == ["structure", "center"]
+    assert new_tensor.samples_names == ["structure", "center"]
 
 
 def check_rename(rename):
     tensor = get_tensor_map()
 
-    assert tensor.sample_names == ["structure", "center"]
+    assert tensor.samples_names == ["structure", "center"]
     new_tensor = rename(tensor, "samples", "center", "center_2")
 
     assert isinstance(new_tensor, torch.ScriptObject)
-    assert new_tensor.sample_names == ["structure", "center_2"]
+    assert new_tensor.samples_names == ["structure", "center_2"]
 
 
 def test_operations_as_python():

--- a/python/metatensor-torch/tests/operations/reduce_over_samples.py
+++ b/python/metatensor-torch/tests/operations/reduce_over_samples.py
@@ -8,11 +8,11 @@ from .data import load_data
 def check_operation(reduce_over_samples):
     tensor = load_data("qm7-power-spectrum.npz")
 
-    assert tensor.sample_names == ["structure", "center"]
+    assert tensor.samples_names == ["structure", "center"]
     reduced_tensor = reduce_over_samples(tensor, "center")
 
     assert isinstance(reduced_tensor, torch.ScriptObject)
-    assert reduced_tensor.sample_names == ["structure"]
+    assert reduced_tensor.samples_names == ["structure"]
 
 
 def test_operations_as_python():

--- a/python/metatensor-torch/tests/tensor.py
+++ b/python/metatensor-torch/tests/tensor.py
@@ -61,9 +61,9 @@ keys: key_1  key_2
 
 
 def test_labels_names(tensor):
-    assert tensor.sample_names == ["s"]
-    assert tensor.components_names == [["c"]]
-    assert tensor.property_names == ["p"]
+    assert tensor.samples_names == ["s"]
+    assert tensor.components_names == ["c"]
+    assert tensor.properties_names == ["p"]
 
 
 def test_block(tensor):
@@ -368,9 +368,9 @@ def test_empty_tensor():
 
     assert empty_tensor.keys.names == ["key"]
 
-    assert empty_tensor.sample_names == []
+    assert empty_tensor.samples_names == []
     assert empty_tensor.components_names == []
-    assert empty_tensor.property_names == []
+    assert empty_tensor.properties_names == []
 
     # TODO
     # assert empty_tensor.blocks() == []
@@ -465,14 +465,14 @@ class TensorMapWrap:
     ) -> TensorMap:
         return self._c.components_to_properties(dimensions=dimensions)
 
-    def sample_names(self) -> List[str]:
-        return self._c.sample_names
+    def samples_names(self) -> List[str]:
+        return self._c.samples_names
 
-    def components_names(self) -> List[List[str]]:
+    def components_names(self) -> List[str]:
         return self._c.components_names
 
-    def property_names(self) -> List[str]:
-        return self._c.property_names
+    def properties_names(self) -> List[str]:
+        return self._c.properties_names
 
     def print_(self, max_keys: int) -> str:
         return self._c.print(max_keys=max_keys)


### PR DESCRIPTION
- components_names now return a List[str] instead of List[list[str]]
- properties and samples names are now pluralized


the first change is for better torch script compatibility (the compiler does not know what to do with `components_names == [["something"]]`)

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--348.org.readthedocs.build/en/348/

<!-- readthedocs-preview metatensor end -->