### PR TITLE
Clone only the metadata of a TensorMap/TensorBlock in C++

### DIFF
--- a/docs/src/reference/cxx/data.rst
+++ b/docs/src/reference/cxx/data.rst
@@ -8,3 +8,6 @@ Data arrays
 
 .. doxygenclass:: metatensor::SimpleDataArray
     :members: SimpleDataArray, operator=, view, from_mts_array
+
+.. doxygenclass:: metatensor::EmptyDataArray
+    :members: EmptyDataArray, operator=

--- a/metatensor-core/CMakeLists.txt
+++ b/metatensor-core/CMakeLists.txt
@@ -138,17 +138,29 @@ endif()
 
 set(CARGO_TARGET_DIR ${CMAKE_CURRENT_BINARY_DIR}/target)
 set(CARGO_BUILD_ARG "${CARGO_BUILD_ARG};--target-dir=${CARGO_TARGET_DIR}")
+
 # Handle cross compilation with RUST_BUILD_TARGET
 if ("${RUST_BUILD_TARGET}" STREQUAL "")
     if (CARGO_VERSION_RAW MATCHES "host: ([a-zA-Z0-9_\\-]*)\n")
-        set(RUST_BUILD_TARGET "${CMAKE_MATCH_1}")
+        set(RUST_HOST_TARGET "${CMAKE_MATCH_1}")
     else()
         message(FATAL_ERROR "failed to determine host target, output was: ${CARGO_VERSION_RAW}")
     endif()
-endif()
 
-set(CARGO_BUILD_ARG "${CARGO_BUILD_ARG};--target=${RUST_BUILD_TARGET}")
-set(CARGO_OUTPUT_DIR "${CARGO_TARGET_DIR}/${RUST_BUILD_TARGET}/${CARGO_BUILD_TYPE}")
+    if (${METATENSOR_MAIN_PROJECT})
+        message(STATUS "Compiling to host (${RUST_HOST_TARGET})")
+    endif()
+
+    set(CARGO_OUTPUT_DIR "${CARGO_TARGET_DIR}/${CARGO_BUILD_TYPE}")
+    set(RUST_BUILD_TARGET ${RUST_HOST_TARGET})
+else()
+    if (${METATENSOR_MAIN_PROJECT})
+        message(STATUS "Cross-compiling to ${RUST_BUILD_TARGET}")
+    endif()
+
+    set(CARGO_BUILD_ARG "${CARGO_BUILD_ARG};--target=${RUST_BUILD_TARGET}")
+    set(CARGO_OUTPUT_DIR "${CARGO_TARGET_DIR}/${RUST_BUILD_TARGET}/${CARGO_BUILD_TYPE}")
+endif()
 
 
 # Get the list of libraries linked by default by cargo/rustc to add when linking
@@ -169,6 +181,7 @@ if (CARGO_VERSION_CHANGED)
 
     file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/_cargo_required_libs/Cargo.toml"
         "[workspace]\nmembers=[]\n[lib]\ncrate-type=[\"staticlib\"]")
+
     execute_process(
         COMMAND ${CARGO_EXE} rustc --verbose --color never --target=${RUST_BUILD_TARGET} -- --print=native-static-libs
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/_cargo_required_libs"

--- a/metatensor-core/include/metatensor.hpp
+++ b/metatensor-core/include/metatensor.hpp
@@ -2167,6 +2167,13 @@ public:
         return tensor_;
     }
 
+    /// Get the const `mts_tensormap_t` pointer corresponding to this `TensorMap`.
+    ///
+    /// The tensor map pointer is still managed by the current `TensorMap`
+    const mts_tensormap_t* as_mts_tensormap_t() const & {
+        return tensor_;
+    }
+
     mts_tensormap_t* as_mts_tensormap_t() && = delete;
 
     /// Create a C++ TensorMap from a C `mts_tensormap_t` pointer. The C++

--- a/metatensor-core/include/metatensor.hpp
+++ b/metatensor-core/include/metatensor.hpp
@@ -522,7 +522,7 @@ public:
     ): Labels(details::labels_from_cxx(names, NDArray(std::move(values), names.size()))) {}
 
     /// Create an empty set of Labels with the given names
-    Labels(const std::vector<std::string>& names):
+    explicit Labels(const std::vector<std::string>& names):
         Labels(details::labels_from_cxx(
             names,
             NDArray(static_cast<const int32_t*>(nullptr), {0, names.size()})
@@ -842,11 +842,11 @@ public:
     }
 
 private:
-    Labels(): NDArray(static_cast<const int32_t*>(nullptr), {0, 0}) {
+    explicit Labels(): NDArray(static_cast<const int32_t*>(nullptr), {0, 0}) {
         std::memset(&labels_, 0, sizeof(labels_));
     }
 
-    Labels(mts_labels_t labels):
+    explicit Labels(mts_labels_t labels):
         NDArray(labels.values, {labels.count, labels.size}),
         labels_(labels)
     {
@@ -857,7 +857,7 @@ private:
         }
     }
 
-    Labels(const std::vector<std::string>& names, const int32_t* values, size_t count):
+    explicit Labels(const std::vector<std::string>& names, const int32_t* values, size_t count):
         Labels(details::labels_from_cxx(names, NDArray(values, {count, names.size()}))) {}
 
     friend Labels details::labels_from_cxx(const std::vector<std::string>&, NDArray<int32_t>);
@@ -1702,7 +1702,7 @@ public:
 
 private:
     /// Constructor of a TensorBlock not associated with anything
-    TensorBlock(): block_(nullptr), is_view_(true) {}
+    explicit TensorBlock(): block_(nullptr), is_view_(true) {}
 
     /// Get the `mts_array_t` for this block.
     ///
@@ -2178,7 +2178,7 @@ public:
 
     /// Create a C++ TensorMap from a C `mts_tensormap_t` pointer. The C++
     /// tensor map takes ownership of the C pointer.
-    TensorMap(mts_tensormap_t* tensor): tensor_(tensor) {}
+    explicit TensorMap(mts_tensormap_t* tensor): tensor_(tensor) {}
 
 private:
     mts_tensormap_t* tensor_;

--- a/metatensor-core/tests/cpp/tensor.cpp
+++ b/metatensor-core/tests/cpp/tensor.cpp
@@ -203,6 +203,16 @@ TEST_CASE("TensorMap") {
 
         CHECK_THROWS_WITH(tensor.clone(), "external error: calling mts_array_t.create failed (status -1)");
     }
+
+    SECTION("clone metadata") {
+        auto tensor = test_tensor_map();
+
+        auto clone = tensor.clone_metadata_only();
+        CHECK(clone.keys() == tensor.keys());
+
+        auto block = clone.block_by_id(0);
+        CHECK_THROWS_WITH(block.values(), "error in C++ callback: can not call `data` for an EmptyDataArray");
+    }
 }
 
 


### PR DESCRIPTION
This is something I need mainly for https://github.com/Luthaf/rascaline/issues/218 which is why I only did it for the C++ API. If other also need this from other languages, we could move the code to the C API.

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--350.org.readthedocs.build/en/350/

<!-- readthedocs-preview metatensor end -->