### PR TITLE
Keep a reference to the parent in torch's TensorBlock

### DIFF
--- a/metatensor-core/include/metatensor.hpp
+++ b/metatensor-core/include/metatensor.hpp
@@ -957,6 +957,9 @@ public:
     DataArrayBase& operator=(DataArrayBase&&) noexcept = default;
 
     /// Convert a concrete `DataArrayBase` to a C-compatible `mts_array_t`
+    ///
+    /// The `mts_array_t` takes ownership of the data, which should be released
+    /// with `mts_array_t::destroy`.
     static mts_array_t to_mts_array_t(std::unique_ptr<DataArrayBase> data) {
         mts_array_t array;
         std::memset(&array, 0, sizeof(array));
@@ -1601,10 +1604,6 @@ public:
         return Labels(labels);
     }
 
-private:
-    /// Constructor of a TensorBlock not associated with anything
-    TensorBlock(): block_(nullptr), is_view_(true) {}
-
     /// Get the shape of the value array for this block
     std::vector<uintptr_t> values_shape() const {
         auto array = this->const_mts_array();
@@ -1616,6 +1615,10 @@ private:
 
         return {shape, shape + shape_count};
     }
+
+private:
+    /// Constructor of a TensorBlock not associated with anything
+    TensorBlock(): block_(nullptr), is_view_(true) {}
 
     /// Get the `mts_array_t` for this block.
     ///

--- a/metatensor-torch/include/metatensor/torch/labels.hpp
+++ b/metatensor-torch/include/metatensor/torch/labels.hpp
@@ -67,7 +67,7 @@ public:
     static TorchLabels range(std::string name, int64_t end);
 
     /// Create a `LabelsHolder` from a pre-existing `metatensor::Labels`
-    LabelsHolder(metatensor::Labels labels);
+    explicit LabelsHolder(metatensor::Labels labels);
 
     /// Get the names of the dimensions/columns of these Labels
     std::vector<std::string> names() const {

--- a/metatensor-torch/include/metatensor/torch/tensor.hpp
+++ b/metatensor-torch/include/metatensor/torch/tensor.hpp
@@ -25,7 +25,7 @@ using TorchTensorMap = torch::intrusive_ptr<TensorMapHolder>;
 class METATENSOR_TORCH_EXPORT TensorMapHolder: public torch::CustomClassHolder {
 public:
     /// Wrap an existing `metatensor::TensorMap` into a `TensorMapHolder`
-    TensorMapHolder(metatensor::TensorMap tensor);
+    explicit TensorMapHolder(metatensor::TensorMap tensor);
 
     /// Create a new `TensorMapHolder` for TorchScript.
     ///
@@ -51,42 +51,42 @@ public:
     ///
     /// The returned `TensorBlock` is a view inside memory owned by this
     /// `TensorMap`, and is only valid as long as the `TensorMap` is kept alive.
-    TorchTensorBlock block_by_id(int64_t index);
+    static TorchTensorBlock block_by_id(TorchTensorMap self, int64_t index);
 
     /// Get the block in this `TensorMap` with the key matching the name=>values
     /// passed in `selection`
-    TorchTensorBlock block(const std::map<std::string, int32_t>& selection);
+    static TorchTensorBlock block(TorchTensorMap self, const std::map<std::string, int32_t>& selection);
 
     /// Get the block in this `TensorMap` with the key matching the name=>values
     /// passed in `selection`. The `selection` must contain a single entry.
-    TorchTensorBlock block(TorchLabels selection);
+    static TorchTensorBlock block(TorchTensorMap self, TorchLabels selection);
 
     /// Get the block in this `TensorMap` with the key matching the name=>values
     /// passed in `selection`
-    TorchTensorBlock block(TorchLabelsEntry selection);
+    static TorchTensorBlock block(TorchTensorMap self, TorchLabelsEntry selection);
 
     /// TorchScript implementation of `block`, dispatching to one of the
     /// functions above
-    TorchTensorBlock block_torch(torch::IValue index);
+    static TorchTensorBlock block_torch(TorchTensorMap self, torch::IValue index);
 
     /// Similar to `block_by_id`, but get all blocks with the given indices
-    std::vector<TorchTensorBlock> blocks_by_id(const std::vector<int64_t>& indices);
+    static std::vector<TorchTensorBlock> blocks_by_id(TorchTensorMap self, const std::vector<int64_t>& indices);
 
     /// Get all blocks in this TensorMap
-    std::vector<TorchTensorBlock> blocks();
+    static std::vector<TorchTensorBlock> blocks(TorchTensorMap self);
 
     /// Similar to `block`, but allow getting multiple matching blocks
-    std::vector<TorchTensorBlock> blocks(const std::map<std::string, int32_t>& selection);
+    static std::vector<TorchTensorBlock> blocks(TorchTensorMap self, const std::map<std::string, int32_t>& selection);
 
     /// Similar to `block`, but allow getting multiple matching blocks
-    std::vector<TorchTensorBlock> blocks(TorchLabels selection);
+    static std::vector<TorchTensorBlock> blocks(TorchTensorMap self, TorchLabels selection);
 
     /// Similar to `block`, but allow getting multiple matching blocks
-    std::vector<TorchTensorBlock> blocks(TorchLabelsEntry selection);
+    static std::vector<TorchTensorBlock> blocks(TorchTensorMap self, TorchLabelsEntry selection);
 
     /// TorchScript implementation of `blocks`, dispatching to one of the
     /// functions above.
-    std::vector<TorchTensorBlock> blocks_torch(torch::IValue index);
+    static std::vector<TorchTensorBlock> blocks_torch(TorchTensorMap self, torch::IValue index);
 
     /// Merge blocks with the same value for selected keys dimensions along the
     /// property axis.
@@ -131,7 +131,7 @@ public:
     std::vector<std::string> properties_names();
 
     /// Get all (key => block) pairs in this `TensorMap`
-    std::vector<std::tuple<TorchLabelsEntry, TorchTensorBlock>> items();
+    static std::vector<std::tuple<TorchLabelsEntry, TorchTensorBlock>> items(TorchTensorMap self);
 
     /// Print this TensorMap to a string, including at most `max_keys` in the
     /// output (-1 to include all keys).

--- a/metatensor-torch/tests/block.cpp
+++ b/metatensor-torch/tests/block.cpp
@@ -45,27 +45,27 @@ TEST_CASE("Blocks") {
     }
 
     SECTION("gradients") {
-        auto block = TensorBlockHolder(
+        auto block = torch::make_intrusive<TensorBlockHolder>(
             torch::full({3, 2}, 11.0),
             LabelsHolder::create({"s"}, {{0}, {2}, {1}}),
-            {},
+            std::vector<TorchLabels>{},
             LabelsHolder::create({"p"}, {{0}, {1}})
         );
 
-        CHECK(block.gradients_list().empty());
+        CHECK(block->gradients_list().empty());
 
-        block.add_gradient("g", torch::make_intrusive<TensorBlockHolder>(
+        block->add_gradient("g", torch::make_intrusive<TensorBlockHolder>(
             torch::full({1, 3, 2}, 1.0),
             LabelsHolder::create({"sample", "g"}, {{0, 1}}),
             std::vector<TorchLabels>{LabelsHolder::create({"c"}, {{0}, {1}, {2}})},
-            block.properties()
+            block->properties()
         ));
 
-        CHECK((block.gradients_list() == std::vector<std::string>{"g"}));
-        CHECK(block.has_gradient("g"));
-        CHECK_FALSE(block.has_gradient("not-there"));
+        CHECK((block->gradients_list() == std::vector<std::string>{"g"}));
+        CHECK(block->has_gradient("g"));
+        CHECK_FALSE(block->has_gradient("not-there"));
 
-        auto gradient = block.gradient("g");
+        auto gradient = TensorBlockHolder::gradient(block, "g");
         CHECK((gradient->values().sizes() == std::vector<int64_t>{1, 3, 2}));
 
         auto sample_names = gradient->samples()->names();
@@ -73,7 +73,7 @@ TEST_CASE("Blocks") {
         CHECK(sample_names[0] == "sample");
         CHECK(sample_names[1] == "g");
 
-        for (const auto& entry: block.gradients()) {
+        for (const auto& entry: TensorBlockHolder::gradients(block)) {
             CHECK(std::get<0>(entry) == "g");
         }
     }


### PR DESCRIPTION
We are already doing this for Python and it is required to avoid use after free if a function just extract a block out of a tensor map.

Fix #349 

This was surfaced by what I think is a bug in torch script compiler, but we want to do something like this anyway. The issue appears in the test code when looping over elements of a `torch.nn.ModuleDict`, which I think is executed differently than a normal loop by torch script. A similar problem (but easier to debug) would happen with a function like 

```py
def kaboom():
    tensor = create_new_tensor()
    return tensor.block(0)
```

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--356.org.readthedocs.build/en/356/

<!-- readthedocs-preview metatensor end -->