### PR TITLE
Run clang-tidy on all the C++ code

### DIFF
--- a/metatensor-torch/include/metatensor/torch.hpp
+++ b/metatensor-torch/include/metatensor/torch.hpp
@@ -1,7 +1,7 @@
-#include "metatensor/torch/exports.h"
+#include "metatensor/torch/exports.h"   // IWYU pragma: export
 
-#include "metatensor/torch/array.hpp"
-#include "metatensor/torch/labels.hpp"
-#include "metatensor/torch/block.hpp"
-#include "metatensor/torch/tensor.hpp"
-#include "metatensor/torch/misc.hpp"
+#include "metatensor/torch/array.hpp"   // IWYU pragma: export
+#include "metatensor/torch/labels.hpp"  // IWYU pragma: export
+#include "metatensor/torch/block.hpp"   // IWYU pragma: export
+#include "metatensor/torch/tensor.hpp"  // IWYU pragma: export
+#include "metatensor/torch/misc.hpp"    // IWYU pragma: export

--- a/metatensor-torch/include/metatensor/torch/array.hpp
+++ b/metatensor-torch/include/metatensor/torch/array.hpp
@@ -21,7 +21,7 @@ public:
     /// Create a `TorchDataArray` containing the given `tensor`
     TorchDataArray(torch::Tensor tensor);
 
-    virtual ~TorchDataArray() override = default;
+    ~TorchDataArray() override = default;
 
     /// TorchDataArray can be copy-constructed
     TorchDataArray(const TorchDataArray&) = default;

--- a/metatensor-torch/include/metatensor/torch/block.hpp
+++ b/metatensor-torch/include/metatensor/torch/block.hpp
@@ -115,7 +115,7 @@ public:
     static std::vector<std::tuple<std::string, TorchTensorBlock>> gradients(TorchTensorBlock self);
 
     /// Implementation of __repr__/__str__ for Python
-    std::string __repr__() const;
+    std::string repr() const;
 
     /// Get the underlying metatensor TensorBlock
     const metatensor::TensorBlock& as_metatensor() const {

--- a/metatensor-torch/include/metatensor/torch/labels.hpp
+++ b/metatensor-torch/include/metatensor/torch/labels.hpp
@@ -24,7 +24,7 @@ namespace details {
     /// Transform a torch::IValue containing either a single string, a list of
     /// strings or a tuple of strings into a `std::vector<std::string>`.
     /// `argument_name` is used in the error message.
-    std::vector<std::string> normalize_names(torch::IValue names, std::string argument_name);
+    std::vector<std::string> normalize_names(torch::IValue names, const std::string& argument_name);
 }
 
 /// Wrapper around `metatensor::Labels` for integration with TorchScript
@@ -50,7 +50,7 @@ public:
     /// `metatensor::Labels`.
     static TorchLabels create(
         const std::vector<std::string>& names,
-        std::vector<std::initializer_list<int32_t>> values
+        const std::vector<std::initializer_list<int32_t>>& values
     );
 
     /// Get a view of `labels` corresponding to only the given columns names
@@ -79,20 +79,23 @@ public:
         return values_;
     }
 
-    /// Append a new dimension with the given `name` and `values`  to the end of these `Labels`
-    TorchLabels append(std::string name, torch::Tensor values);
+    /// Create new `Labels` with a new dimension with the given `name` and
+    /// `values` added to the end of the dimensions list.
+    TorchLabels append(std::string name, torch::Tensor values) const;
 
-    /// Insert a new dimension with the given `name` and `values` before `index` in these `Labels`
-    TorchLabels insert(int64_t index, std::string name, torch::Tensor values);
+    /// Create new `Labels` with a new dimension with the given `name` and
+    /// `values` before `index`.
+    TorchLabels insert(int64_t index, std::string name, torch::Tensor values) const;
 
-    /// Permute dimensions of these `Labels`
-    TorchLabels permute(std::vector<int64_t> dimensions_indexes);
+    /// Create new `Labels` with permuted dimensions
+    TorchLabels permute(std::vector<int64_t> dimensions_indexes) const;
 
-    /// Remove `name` from the dimensions of these `Labels`
-    TorchLabels remove(std::string name);
+    /// Create new `Labels` with `name` removed from the dimensions list
+    TorchLabels remove(std::string name) const;
 
-    /// Rename `old_name` dimensions in these Labels to `new_name`
-    TorchLabels rename(std::string old_name, std::string new_name);
+    /// Create new `Labels` with `old_name` renamed to `new_name` in the
+    /// dimensions list
+    TorchLabels rename(std::string old_name, std::string new_name) const;
 
     /// Move the values for these Labels to the given `device`
     void to(torch::Device device);
@@ -131,10 +134,10 @@ public:
     std::string print(int64_t max_entries, int64_t indent) const;
 
     /// Implementation of `__str__` for Python
-    std::string __str__() const;
+    std::string str() const;
 
     /// Implementation of `__repr__` for Python
-    std::string __repr__() const;
+    std::string repr() const;
 
     /// Get the underlying metatensor::Labels
     const metatensor::Labels& as_metatensor() const;
@@ -258,13 +261,13 @@ public:
     int32_t operator[](const std::string& name) const;
 
     /// implementation of __getitem__, forwarding to one of the operator[]
-    int64_t __getitem__(torch::IValue index) const;
+    int64_t getitem(torch::IValue index) const;
 
     /// Print this entry as a named tuple (i.e. `(key=value, key=value)`).
     std::string print() const;
 
     /// Implementation of __repr__ for Python
-    std::string __repr__() const;
+    std::string repr() const;
 
 private:
     torch::Tensor values_;

--- a/metatensor-torch/src/block.cpp
+++ b/metatensor-torch/src/block.cpp
@@ -60,8 +60,8 @@ torch::Tensor TensorBlockHolder::values() {
         );
     }
 
-    auto ptr = static_cast<metatensor::DataArrayBase*>(array.ptr);
-    auto wrapper = dynamic_cast<TorchDataArray*>(ptr);
+    auto* ptr = static_cast<metatensor::DataArrayBase*>(array.ptr);
+    auto* wrapper = dynamic_cast<TorchDataArray*>(ptr);
     if (wrapper == nullptr) {
         C10_THROW_ERROR(ValueError,
             "this TensorBlock does not contain a C++ torch Tensor"
@@ -112,7 +112,7 @@ TorchTensorBlock TensorBlockHolder::gradient(TorchTensorBlock self, const std::s
 std::vector<std::tuple<std::string, TorchTensorBlock>> TensorBlockHolder::gradients(TorchTensorBlock self) {
     auto result = std::vector<std::tuple<std::string, TorchTensorBlock>>();
     for (const auto& parameter: self->gradients_list()) {
-        result.push_back(std::make_tuple(parameter, TensorBlockHolder::gradient(self, parameter)));
+        result.emplace_back(parameter, TensorBlockHolder::gradient(self, parameter));
     }
     return result;
 }
@@ -131,7 +131,7 @@ static void print_labels(std::ostringstream& output, const metatensor::Labels& l
     output << "]\n";
 }
 
-std::string TensorBlockHolder::__repr__() const {
+std::string TensorBlockHolder::repr() const {
     auto output = std::ostringstream();
 
     if (parameter_.empty()) {

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -37,14 +37,14 @@ TORCH_LIBRARY(metatensor, m) {
     // Whenever this file is changed, please also reproduce the changes in
     // python/metatensor-torch/metatensor/torch/documentation.py, and include the
     // docstring over there
-    const std::string DOCSTRING = "";
+    const std::string DOCSTRING;
 
 
     m.class_<LabelsEntryHolder>("LabelsEntry")
-        .def("__str__", &LabelsEntryHolder::__repr__)
-        .def("__repr__", &LabelsEntryHolder::__repr__)
+        .def("__str__", &LabelsEntryHolder::repr)
+        .def("__repr__", &LabelsEntryHolder::repr)
         .def("__len__", &LabelsEntryHolder::size)
-        .def("__getitem__", &LabelsEntryHolder::__getitem__, DOCSTRING,
+        .def("__getitem__", &LabelsEntryHolder::getitem, DOCSTRING,
             {torch::arg("index")}
         )
         .def("__eq__", [](const TorchLabelsEntry& self, const TorchLabelsEntry& other){ return *self == *other; },
@@ -65,10 +65,10 @@ TORCH_LIBRARY(metatensor, m) {
             torch::init<torch::IValue, torch::Tensor>(), DOCSTRING,
             {torch::arg("names"), torch::arg("values")}
         )
-        .def("__str__", &LabelsHolder::__str__)
+        .def("__str__", &LabelsHolder::str)
         // __repr__ is ignored for now, until we can use
         // https://github.com/pytorch/pytorch/pull/100724 (hopefully torch 2.1)
-        .def("__repr__", &LabelsHolder::__repr__)
+        .def("__repr__", &LabelsHolder::repr)
         .def("__len__", &LabelsHolder::count)
         .def("__contains__", [](const TorchLabels& self, torch::IValue entry) {
                 return self->position(entry).has_value();
@@ -122,8 +122,8 @@ TORCH_LIBRARY(metatensor, m) {
             torch::init<torch::Tensor, TorchLabels, std::vector<TorchLabels>, TorchLabels>(), DOCSTRING,
             {torch::arg("values"), torch::arg("samples"), torch::arg("components"), torch::arg("properties")}
         )
-        .def("__repr__", &TensorBlockHolder::__repr__)
-        .def("__str__", &TensorBlockHolder::__repr__)
+        .def("__repr__", &TensorBlockHolder::repr)
+        .def("__str__", &TensorBlockHolder::repr)
         .def("copy", &TensorBlockHolder::copy)
         .def_property("values", &TensorBlockHolder::values)
         .def_property("samples", &TensorBlockHolder::samples)
@@ -194,7 +194,7 @@ TORCH_LIBRARY(metatensor, m) {
                 // `torch::from_blob` does not take ownership of the data,
                 // so we need to register a custom deleter to clean up when
                 // the tensor is no longer used
-                auto buffer_data = new std::vector<uint8_t>(std::move(buffer));
+                auto* buffer_data = new std::vector<uint8_t>(std::move(buffer));
 
                 auto options = torch::TensorOptions().dtype(torch::kU8).device(torch::kCPU);
                 auto deleter = [=](void* data) {

--- a/metatensor-torch/tests/array.cpp
+++ b/metatensor-torch/tests/array.cpp
@@ -12,10 +12,10 @@ TEST_CASE("Arrays") {
     SECTION("origin") {
         auto origin = array.origin();
 
-        char buffer[64] = {0};
-        auto status = mts_get_data_origin(origin, buffer, 64);
+        std::array<char, 64> buffer = {0};
+        auto status = mts_get_data_origin(origin, buffer.data(), buffer.size());
         CHECK(status == MTS_SUCCESS);
-        CHECK(std::string(buffer) == "metatensor_torch::TorchDataArray");
+        CHECK(std::string(buffer.data()) == "metatensor_torch::TorchDataArray");
     }
 
     SECTION("shape") {
@@ -50,14 +50,14 @@ TEST_CASE("Arrays") {
 
     SECTION("new arrays") {
         auto copy = array.copy();
-        auto copy_ptr = dynamic_cast<TorchDataArray*>(copy.get());
+        auto* copy_ptr = dynamic_cast<TorchDataArray*>(copy.get());
 
         CHECK(copy_ptr->tensor().data_ptr() != array.tensor().data_ptr());
         CHECK((copy_ptr->tensor().sizes() == std::vector<int64_t>{2, 3, 4}));
         CHECK(copy_ptr->tensor().dtype() == torch::kF64);
 
         auto created = array.create({5, 6});
-        auto created_ptr = dynamic_cast<TorchDataArray*>(created.get());
+        auto* created_ptr = dynamic_cast<TorchDataArray*>(created.get());
 
         CHECK((created_ptr->tensor().sizes() == std::vector<int64_t>{5, 6}));
         CHECK(created_ptr->tensor().dtype() == torch::kF64);

--- a/metatensor-torch/tests/labels.cpp
+++ b/metatensor-torch/tests/labels.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Labels") {
         CHECK(labels.values()[3][1].item<int64_t>() == -2);
 
         // and the underlying metatensor::Labels
-        auto& metatensor_labels = labels.as_metatensor();
+        const auto& metatensor_labels = labels.as_metatensor();
         CHECK(metatensor_labels.names().size() == 2);
         CHECK(metatensor_labels.names()[0] == std::string("a"));
         CHECK(metatensor_labels.names()[1] == std::string("bb"));
@@ -52,9 +52,7 @@ TEST_CASE("Labels") {
 
     SECTION("print") {
         auto labels = LabelsHolder::create({"aaa", "bbb"}, {{1, 2}, {3, 4}});
-
-        auto expected = " aaa  bbb\n     1    2\n     3    4";
-        CHECK(labels->print(-1, 3) == expected);
+        CHECK(labels->print(-1, 3) == " aaa  bbb\n     1    2\n     3    4");
     }
 
     SECTION("create views") {
@@ -164,7 +162,7 @@ TEST_CASE("LabelsEntry") {
     CHECK(entry.values()[0].item<int32_t>() == 1);
     CHECK(entry.values()[1].item<int32_t>() == 2);
 
-    CHECK(entry.__repr__() == "LabelsEntry(aaa=1, bbb=2)");
+    CHECK(entry.repr() == "LabelsEntry(aaa=1, bbb=2)");
 
     CHECK(entry[0] == 1);
     CHECK(entry[1] == 2);

--- a/metatensor-torch/tests/tensor.cpp
+++ b/metatensor-torch/tests/tensor.cpp
@@ -153,7 +153,7 @@ TEST_CASE("TensorMap") {
         CHECK(*block->samples() == metatensor::Labels({"samples"}, {{0}, {2}, {4}}));
 
         auto components = block->components();
-        CHECK(components.size() == 0);
+        CHECK(components.empty());
 
         CHECK(*block->properties() == metatensor::Labels({"component", "properties"}, {{0, 0}}));
     }


### PR DESCRIPTION
For reference, here is my clangd config:

```
If:
  PathMatch: metatensor-core/.*

CompileFlags:
  CompilationDatabase: target/tmp/cxx-tests


Diagnostics:
  UnusedIncludes: Strict

  ClangTidy:
    Add:
      - bugprone-*
      - modernize-*
      - performance-*
      - readability-*
    Remove:
      - modernize-use-trailing-return-type
      - modernize-return-braced-init-list
      - readability-magic-numbers
      - readability-else-after-return
      - readability-simplify-boolean-expr
      - readability-identifier-length
      - readability-function-cognitive-complexity
      - readability-named-parameter
      - bugprone-easily-swappable-parameters
      # add back when https://github.com/llvm/llvm-project/issues/54668 hits a
      # release
      - bugprone-exception-escape

    CheckOptions:
      performance-unnecessary-value-param.AllowedTypes: metatensor::Labels

---

If:
  PathMatch: metatensor-torch/.*

CompileFlags:
  CompilationDatabase: target/tmp/torch-tests

Diagnostics:
  UnusedIncludes: Strict

  ClangTidy:
    Add:
      - bugprone-*
      - modernize-*
      - performance-*
      - readability-*
    Remove:
      - modernize-use-trailing-return-type
      - modernize-return-braced-init-list
      - readability-magic-numbers
      - readability-else-after-return
      - readability-identifier-length
      - readability-function-cognitive-complexity
      - readability-named-parameter
      - bugprone-easily-swappable-parameters
      - performance-unnecessary-value-param
```