### PR TITLE
Pin sphinx for docs again

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx >= 7.2.4
+sphinx == 7.2.4
 sphinx-toggleprompt # hide the prompt (>>>) in python doctests
 pygments >=2.11     # syntax highligthing
 breathe >=4.33      # C and C++ => sphinx through doxygen


### PR DESCRIPTION
I get an error when running `tox -e docs` locally, see also https://github.com/sphinx-doc/sphinx/issues/11662#issuecomment-1710192959.

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--358.org.readthedocs.build/en/358/

<!-- readthedocs-preview metatensor end -->