### PR TITLE
Move labels to device in `to()`

### DIFF
--- a/metatensor-torch/include/metatensor/torch/labels.hpp
+++ b/metatensor-torch/include/metatensor/torch/labels.hpp
@@ -25,6 +25,10 @@ namespace details {
     /// strings or a tuple of strings into a `std::vector<std::string>`.
     /// `argument_name` is used in the error message.
     std::vector<std::string> normalize_names(torch::IValue names, const std::string& argument_name);
+
+    /// Transform a torch::IValue into a torch::Device. The input torch::IValue
+    /// must be either a string or a torch.device, otherwise a runtime error
+    /// will be raised.
     torch::Device normalize_device(torch::IValue device);
 }
 
@@ -99,7 +103,7 @@ public:
     TorchLabels rename(std::string old_name, std::string new_name) const;
 
     /// Move the values for these Labels to the given `device`
-    TorchLabels to(torch::Device device) const;
+    TorchLabels to(torch::IValue device) const;
 
     /// Get the values associated with a single dimension (i.e. a single column
     /// of `values()`) in these labels.

--- a/metatensor-torch/include/metatensor/torch/labels.hpp
+++ b/metatensor-torch/include/metatensor/torch/labels.hpp
@@ -25,6 +25,7 @@ namespace details {
     /// strings or a tuple of strings into a `std::vector<std::string>`.
     /// `argument_name` is used in the error message.
     std::vector<std::string> normalize_names(torch::IValue names, const std::string& argument_name);
+    torch::Device normalize_device(torch::IValue device);
 }
 
 /// Wrapper around `metatensor::Labels` for integration with TorchScript
@@ -98,7 +99,7 @@ public:
     TorchLabels rename(std::string old_name, std::string new_name) const;
 
     /// Move the values for these Labels to the given `device`
-    void to(torch::Device device);
+    TorchLabels to(torch::Device device) const;
 
     /// Get the values associated with a single dimension (i.e. a single column
     /// of `values()`) in these labels.

--- a/metatensor-torch/src/labels.cpp
+++ b/metatensor-torch/src/labels.cpp
@@ -379,10 +379,10 @@ TorchLabels LabelsHolder::rename(std::string old_name, std::string new_name) con
 
 TorchLabels LabelsHolder::to(torch::Device device) const {
     // first move the values
-    torch::Tensor new_values = values_.to(device);
+    auto new_values = values_.to(device);
 
     // copy the names
-    std::vector<std::string> new_names = this->names();
+    auto new_names = this->names();
 
     return torch::make_intrusive<LabelsHolder>(std::move(new_names), std::move(new_values));
 }

--- a/metatensor-torch/src/labels.cpp
+++ b/metatensor-torch/src/labels.cpp
@@ -85,6 +85,18 @@ std::vector<std::string> metatensor_torch::details::normalize_names(torch::IValu
     return results;
 }
 
+torch::Device metatensor_torch::details::normalize_device(torch::IValue device) {
+    if (device.isString()) {
+        return torch::Device(device.toStringRef());
+    } else if (device.isDevice()) {
+        return device.toDevice();
+    } else {
+        C10_THROW_ERROR(TypeError,
+            "'device' must be a string or a torch.device, got '" + device.type()->str() + "' instead"
+        );
+    }
+}
+
 static mts_labels_t labels_from_torch(const std::vector<std::string>& names, const torch::Tensor& values) {
     // extract the names from the Python IValue
     auto c_names = std::vector<const char*>();
@@ -365,18 +377,14 @@ TorchLabels LabelsHolder::rename(std::string old_name, std::string new_name) con
     return torch::make_intrusive<LabelsHolder>(std::move(names), std::move(this->values()));
 }
 
-void LabelsHolder::to(torch::Device device) {
+TorchLabels LabelsHolder::to(torch::Device device) const {
     // first move the values
-    values_ = values_.to(device);
+    torch::Tensor new_values = values_.to(device);
 
-    // then make sure that when accessing these labels again we still have the
-    // values on the same device by updating the registered user data
-    auto user_data = metatensor::LabelsUserData(
-        new torch::Tensor(values_),
-        [](void* tensor) { delete static_cast<torch::Tensor*>(tensor); }
-    );
+    // copy the names
+    std::vector<std::string> new_names = this->names();
 
-    labels_->set_user_data(std::move(user_data));
+    return torch::make_intrusive<LabelsHolder>(std::move(new_names), std::move(new_values));
 }
 
 torch::optional<int64_t> LabelsHolder::position(torch::IValue entry) const {

--- a/metatensor-torch/src/labels.cpp
+++ b/metatensor-torch/src/labels.cpp
@@ -377,9 +377,12 @@ TorchLabels LabelsHolder::rename(std::string old_name, std::string new_name) con
     return torch::make_intrusive<LabelsHolder>(std::move(names), std::move(this->values()));
 }
 
-TorchLabels LabelsHolder::to(torch::Device device) const {
-    // first move the values
-    auto new_values = values_.to(device);
+TorchLabels LabelsHolder::to(torch::IValue device) const {
+    // transform torch::IValue into torch::Device
+    auto normalized_device = details::normalize_device(device);
+
+    // move the values
+    auto new_values = values_.to(normalized_device);
 
     // copy the names
     auto new_names = this->names();

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -101,7 +101,7 @@ TORCH_LIBRARY(metatensor, m) {
         .def("remove", &LabelsHolder::remove, DOCSTRING, {torch::arg("name")})
         .def("rename", &LabelsHolder::rename, DOCSTRING, {torch::arg("old"), torch::arg("new")})
         .def("to", [](const TorchLabels& self, torch::IValue device) {
-            torch::Device normalized_device = metatensor_torch::details::normalize_device(std::move(device));
+            auto normalized_device = metatensor_torch::details::normalize_device(std::move(device));
             return self->to(normalized_device);
         }, DOCSTRING, {torch::arg("device")})
         .def("position", &LabelsHolder::position, DOCSTRING,

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -100,10 +100,7 @@ TORCH_LIBRARY(metatensor, m) {
         .def("permute", &LabelsHolder::permute, DOCSTRING, {torch::arg("dimensions_indexes")})
         .def("remove", &LabelsHolder::remove, DOCSTRING, {torch::arg("name")})
         .def("rename", &LabelsHolder::rename, DOCSTRING, {torch::arg("old"), torch::arg("new")})
-        .def("to", [](const TorchLabels& self, torch::IValue device) {
-            auto normalized_device = metatensor_torch::details::normalize_device(std::move(device));
-            return self->to(normalized_device);
-        }, DOCSTRING, {torch::arg("device")})
+        .def("to", &LabelsHolder::to, DOCSTRING, {torch::arg("device")})
         .def("position", &LabelsHolder::position, DOCSTRING,
             {torch::arg("entry")}
         )

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -100,9 +100,10 @@ TORCH_LIBRARY(metatensor, m) {
         .def("permute", &LabelsHolder::permute, DOCSTRING, {torch::arg("dimensions_indexes")})
         .def("remove", &LabelsHolder::remove, DOCSTRING, {torch::arg("name")})
         .def("rename", &LabelsHolder::rename, DOCSTRING, {torch::arg("old"), torch::arg("new")})
-        .def("to", &LabelsHolder::to, DOCSTRING,
-            {torch::arg("device")}
-        )
+        .def("to", [](const TorchLabels& self, torch::IValue device) {
+            torch::Device normalized_device = metatensor_torch::details::normalize_device(std::move(device));
+            return self->to(normalized_device);
+        }, DOCSTRING, {torch::arg("device")})
         .def("position", &LabelsHolder::position, DOCSTRING,
             {torch::arg("entry")}
         )

--- a/python/metatensor-core/metatensor/core/labels.py
+++ b/python/metatensor-core/metatensor/core/labels.py
@@ -652,7 +652,7 @@ class Labels:
         Move the values for these Labels to the given ``device``.
 
         In the Python version of metatensor, this returns the original labels.
-        Defined forcompatibility with the TorchScript version of metatensor.
+        Defined for compatibility with the TorchScript version of metatensor.
         """
         return self
 

--- a/python/metatensor-core/metatensor/core/labels.py
+++ b/python/metatensor-core/metatensor/core/labels.py
@@ -647,13 +647,14 @@ class Labels:
 
         return Labels(names=names, values=self.values)
 
-    def to(self, device):
+    def to(self, device) -> "Labels":
         """
         Move the values for these Labels to the given ``device``.
 
-        This is a no-op for the Python version of metatensor, and is only defined for
-        compatibility with the TorchScript version of metatensor.
+        In the Python version of metatensor, this returns the original labels.
+        Defined forcompatibility with the TorchScript version of metatensor.
         """
+        return self
 
     def position(self, entry: Union[LabelsEntry, Sequence[int]]) -> Optional[int]:
         """

--- a/python/metatensor-operations/metatensor/operations/to.py
+++ b/python/metatensor-operations/metatensor/operations/to.py
@@ -220,7 +220,7 @@ def _block_to(
     ``backend``, dtype and/or device.
     """
     # Create new block, with the values tensor converted
-    # The labels will also me moved if a new device is requested
+    # The labels will also be moved if a new device is requested
     # (this will only happen in the case of metatensor.torch.Labels)
     values = _dispatch.to(
         array=block.values,

--- a/python/metatensor-operations/metatensor/operations/to.py
+++ b/python/metatensor-operations/metatensor/operations/to.py
@@ -62,8 +62,7 @@ def to(
     ]
 
     if device is not None:
-        new_keys = tensor.keys.view(tensor.keys.names).to_owned()
-        new_keys.to(new_blocks[0].values.device)
+        new_keys = tensor.keys.to(device)
     else:
         new_keys = tensor.keys
 
@@ -231,17 +230,11 @@ def _block_to(
         requires_grad=requires_grad,
     )
 
-    if values.device != block.values.device:
-        samples = block.samples.view(block.samples.names).to_owned()
-        samples.to(values.device)
-        components = [
-            component.view(component.names).to_owned() for component in block.components
-        ]
-        for component in components:
-            component.to(values.device)
-        properties = block.properties.view(block.properties.names).to_owned()
-        properties.to(values.device)
-    else:  # avoid copies
+    if device is not None:
+        samples = block.samples.to(device)
+        components = [component.to(device) for component in block.components]
+        properties = block.properties.to(device)
+    else:
         samples = block.samples
         components = block.components
         properties = block.properties

--- a/python/metatensor-operations/metatensor/operations/to.py
+++ b/python/metatensor-operations/metatensor/operations/to.py
@@ -49,7 +49,7 @@ def to(
             )
 
     # Convert each block and build the return TensorMap
-    
+
     new_blocks = [
         block_to(
             tensor.block(tensor.keys.entry(i)).copy(),
@@ -234,9 +234,11 @@ def _block_to(
     if values.device != block.values.device:
         samples = block.samples.view(block.samples.names).to_owned()
         samples.to(values.device)
-        components = [component.view(component.names).to_owned() for component in block.components]
+        components = [
+            component.view(component.names).to_owned() for component in block.components
+        ]
         for component in components:
-            component.to(values.device) 
+            component.to(values.device)
         properties = block.properties.view(block.properties.names).to_owned()
         properties.to(values.device)
     else:  # avoid copies

--- a/python/metatensor-torch/metatensor/torch/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/documentation.py
@@ -427,7 +427,12 @@ class Labels:
         )
         """
 
-    def to(self, device):
+    @overload
+    def to(self, str) -> "Labels":
+        """move the values for these Labels to the given ``device``"""
+
+    @overload
+    def to(self, device) -> "Labels":
         """move the values for these Labels to the given ``device``"""
 
     def position(

--- a/python/metatensor-torch/tests/labels.py
+++ b/python/metatensor-torch/tests/labels.py
@@ -308,7 +308,7 @@ def test_to():
         labels = Labels(names=("a", "b"), values=torch.IntTensor([[0, 0], [0, 1]]))
         assert labels.values.device.type == "cpu"
 
-        labels.to(device)
+        labels = labels.to(device)
         assert labels.values.device.type == torch.device(device).type
 
 
@@ -472,7 +472,7 @@ class LabelsWrap:
     def values(self) -> Tensor:
         return self._c.values
 
-    def to(self, device: torch.device):
+    def to(self, device: torch.device) -> Labels:
         return self._c.to(device)
 
     def position(self, entry: Union[List[int], LabelsEntry]) -> Optional[int]:

--- a/python/metatensor-torch/tests/operations/to.py
+++ b/python/metatensor-torch/tests/operations/to.py
@@ -37,11 +37,9 @@ def check_to_cuda(to):
         for _, gradient in block.gradients():
             assert gradient.samples.values.device.type == "cuda"
             for component in gradient.components:
-                assert gradient.values.device.type == "cuda"
+                assert component.device.type == "cuda"
             assert gradient.properties.values.device.type == "cuda"
             assert gradient.values.device.type == "cuda"
-
-
 
 
 def check_to_dtype(to):
@@ -69,4 +67,3 @@ def test_operations_as_torch_script():
     check_to_dtype(torch.jit.script(metatensor.torch.to))
     if torch.cuda.is_available():
         check_to_cuda(torch.jit.script(metatensor.torch.to))
-

--- a/python/metatensor-torch/tests/operations/to.py
+++ b/python/metatensor-torch/tests/operations/to.py
@@ -37,7 +37,7 @@ def check_to_cuda(to):
         for _, gradient in block.gradients():
             assert gradient.samples.values.device.type == "cuda"
             for component in gradient.components:
-                assert component.device.type == "cuda"
+                assert component.values.device.type == "cuda"
             assert gradient.properties.values.device.type == "cuda"
             assert gradient.values.device.type == "cuda"
 

--- a/python/metatensor-torch/tests/operations/to.py
+++ b/python/metatensor-torch/tests/operations/to.py
@@ -1,4 +1,5 @@
 import torch
+from packaging import version
 
 import metatensor.torch
 
@@ -7,16 +8,51 @@ from .data import load_data
 
 def check_to_cpu(to):
     tensor = load_data("qm7-power-spectrum.npz")
-    print(tensor.block(0).gradients_list())
     assert tensor.block(0).values.device.type == "cpu"
     tensor_to = to(tensor, device="cpu")
+
+    assert isinstance(tensor_to, torch.ScriptObject)
+    if version.parse(torch.__version__) >= version.parse("2.1"):
+        assert tensor_to._type().name() == "TensorMap"
+
     assert tensor_to.block(0).values.device.type == "cpu"
+
+
+def check_to_cuda(to):
+    tensor = load_data("qm7-power-spectrum.npz")
+    assert tensor.block(0).values.device.type == "cpu"
+    tensor_to = to(tensor, device="cuda")
+
+    assert isinstance(tensor_to, torch.ScriptObject)
+    if version.parse(torch.__version__) >= version.parse("2.1"):
+        assert tensor_to._type().name() == "TensorMap"
+
+    assert tensor_to.keys.values.device.type == "cuda"
+    for block in tensor_to.blocks():
+        assert block.samples.values.device.type == "cuda"
+        for component in block.components:
+            assert component.values.device.type == "cuda"
+        assert block.properties.values.device.type == "cuda"
+        assert block.values.device.type == "cuda"
+        for _, gradient in block.gradients():
+            assert gradient.samples.values.device.type == "cuda"
+            for component in gradient.components:
+                assert gradient.values.device.type == "cuda"
+            assert gradient.properties.values.device.type == "cuda"
+            assert gradient.values.device.type == "cuda"
+
+
 
 
 def check_to_dtype(to):
     tensor = load_data("qm7-power-spectrum.npz")
     assert tensor.block(0).values.dtype == torch.float64
     tensor_to = to(tensor, dtype=torch.float32)
+
+    assert isinstance(tensor_to, torch.ScriptObject)
+    if version.parse(torch.__version__) >= version.parse("2.1"):
+        assert tensor_to._type().name() == "TensorMap"
+
     assert tensor_to.block(0).values.dtype == torch.float32
     assert tensor_to.block(0).gradient("positions").values.dtype == torch.float32
 
@@ -24,8 +60,13 @@ def check_to_dtype(to):
 def test_operations_as_python():
     check_to_cpu(metatensor.torch.to)
     check_to_dtype(metatensor.torch.to)
+    if torch.cuda.is_available():
+        check_to_cuda(metatensor.torch.to)
 
 
 def test_operations_as_torch_script():
     check_to_cpu(torch.jit.script(metatensor.torch.to))
     check_to_dtype(torch.jit.script(metatensor.torch.to))
+    if torch.cuda.is_available():
+        check_to_cuda(torch.jit.script(metatensor.torch.to))
+


### PR DESCRIPTION
The code is a bit complicated:
- `view().to_owned()` used to make copies of labels (`Labels.to()` works in-place for now, perhaps it should return a different object like `Tensor.to()`)
- `Labels.to()` only accepts `torch.device` (not str), so I'm having to use a `torch.device` from a block

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--361.org.readthedocs.build/en/361/

<!-- readthedocs-preview metatensor end -->