### PR TITLE
Test operations notorch

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -146,14 +146,15 @@ subset of Python tests, for example:
 
 .. code-block:: bash
 
-    tox -e core-tests           # unit tests for metatensor-core
-    tox -e operations-tests     # unit tests for metatensor-operations
-    tox -e torch-tests          # unit tests for metatensor-torch
-    tox -e docs-tests           # doctests (checking inline examples) for all packages
-    tox -e lint                 # code style
-    tox -e build-python         # python packaging
+    tox -e core-tests                     # unit tests for metatensor-core
+    tox -e operations-notorch-tests       # unit tests for metatensor-operations without torch
+    tox -e operations-torch-tests         # unit tests for metatensor-operations with torch
+    tox -e torch-tests                    # unit tests for metatensor-torch
+    tox -e docs-tests                     # doctests (checking inline examples) for all packages
+    tox -e lint                           # code style
+    tox -e build-python                   # python packaging
 
-    tox -e format               # format all files
+    tox -e format                         # format all files
 
 The last command ``tox -e format`` will use tox to do actual formatting instead
 of just checking it, you can use to automatically fix some of the issues

--- a/python/metatensor-operations/metatensor/operations/_dispatch.py
+++ b/python/metatensor-operations/metatensor/operations/_dispatch.py
@@ -496,14 +496,14 @@ def rand_like(array, shape: Optional[List[int]] = None, requires_grad: bool = Fa
 def to(
     array,
     backend: Optional[str] = None,
-    dtype: Optional[torch.dtype] = None,
-    device: Optional[Union[str, torch.device]] = None,
+    dtype: Optional[torch_dtype] = None,
+    device: Optional[Union[str, torch_device]] = None,
     requires_grad: Optional[bool] = None,
 ):
     """Convert the array to the specified backend."""
 
     # Convert torch Tensor
-    if isinstance(array, torch.Tensor):
+    if isinstance(array, TorchTensor):
         if backend is None:  # Infer the target backend
             backend = "torch"
         if dtype is None:

--- a/python/metatensor-operations/tests/to.py
+++ b/python/metatensor-operations/tests/to.py
@@ -1,6 +1,16 @@
 import numpy as np
 import pytest
-import torch
+
+
+try:
+    import torch
+
+    HAS_TORCH = True
+    HAS_CUDA = torch.cuda.is_available()
+except ImportError:
+    HAS_TORCH = False
+    HAS_CUDA = None
+
 
 import metatensor
 from metatensor import Labels, TensorBlock, TensorMap
@@ -50,6 +60,7 @@ def test_wrong_arguments_block(block):
         metatensor.block_to(block, backend="jax")
 
 
+@pytest.mark.skipif(not (HAS_TORCH), reason="requires torch to be run")
 def test_numpy_to_torch_block(block):
     """Test a `block_to` conversion from numpy to torch."""
     new_block = metatensor.block_to(block, backend="torch")
@@ -77,6 +88,7 @@ def test_numpy_to_torch_block(block):
             )
 
 
+@pytest.mark.skipif(not HAS_TORCH, reason="requires torch to be run")
 def test_torch_to_numpy_block(block):
     """Test a `block_to` conversion from torch to numpy."""
     block = metatensor.block_to(block, backend="torch")
@@ -108,7 +120,8 @@ def test_torch_to_numpy_block(block):
             )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires cuda")
+@pytest.mark.skipif(not HAS_TORCH, reason="requires torch to be run")
+@pytest.mark.skipif(not HAS_CUDA, reason="requires cuda")
 def test_numpy_to_torch_gpu_block(block):
     """Test a `block_to` conversion from numpy to a torch GPU tensor."""
     new_block = metatensor.block_to(block, backend="torch", device="cuda")
@@ -137,7 +150,8 @@ def test_numpy_to_torch_gpu_block(block):
             )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires cuda")
+@pytest.mark.skipif(not HAS_TORCH, reason="requires torch to be run")
+@pytest.mark.skipif(not HAS_CUDA, reason="requires cuda")
 def test_torch_to_gpu_block(block):
     """Test a `block_to` conversion from a torch CPU tensor to a torch GPU tensor."""
     block = metatensor.block_to(block, backend="torch")
@@ -225,6 +239,7 @@ def test_wrong_arguments(tensor):
         metatensor.to(tensor, backend="jax")
 
 
+@pytest.mark.skipif(not HAS_TORCH, reason="requires torch to be run")
 def test_numpy_to_torch(tensor):
     """Test a `to` conversion from numpy to torch."""
     new_tensor = metatensor.to(tensor, backend="torch")
@@ -233,6 +248,7 @@ def test_numpy_to_torch(tensor):
         assert isinstance(new_block.values, torch.Tensor)
 
 
+@pytest.mark.skipif(not (HAS_TORCH), reason="requires torch to be run")
 def test_numpy_to_torch_switching_requires_grad(tensor):
     """
     Test a `to` conversion from numpy to torch, switching requires_grad on and off.
@@ -251,6 +267,7 @@ def test_numpy_to_torch_switching_requires_grad(tensor):
         assert not new_block.values.requires_grad
 
 
+@pytest.mark.skipif(not (HAS_TORCH), reason="requires torch to be run")
 def test_torch_to_numpy(tensor):
     """Test a `to` conversion from torch to numpy."""
     tensor = metatensor.to(tensor, backend="torch")
@@ -260,7 +277,8 @@ def test_torch_to_numpy(tensor):
         assert isinstance(new_block.values, np.ndarray)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires cuda")
+@pytest.mark.skipif(not (HAS_TORCH), reason="requires torch to be run")
+@pytest.mark.skipif(not HAS_CUDA, reason="requires cuda")
 def test_numpy_to_torch_gpu(tensor):
     """Test a `to` conversion from numpy to a torch GPU tensor."""
     new_tensor = metatensor.to(tensor, backend="torch", device="cuda")
@@ -270,7 +288,8 @@ def test_numpy_to_torch_gpu(tensor):
         assert new_block.values.is_cuda
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires cuda")
+@pytest.mark.skipif(not (HAS_TORCH), reason="requires torch to be run")
+@pytest.mark.skipif(not HAS_CUDA, reason="requires cuda")
 def test_torch_to_gpu(tensor):
     """Test a `to` conversion from a torch CPU tensor to a torch GPU tensor."""
     tensor = metatensor.to(tensor, backend="torch")

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ min_version = 4.0
 # execute `tox` in the command-line without anything else
 envlist =
     core-tests
-    operations-tests
+    operations-notorch-tests
+    operations-torch-tests
     torch-tests
     docs-tests
     lint
@@ -46,13 +47,12 @@ changedir = python/metatensor-core
 commands =
     pytest --import-mode=append {posargs}
 
-
-[testenv:operations-tests]
+[testenv:operations-notorch-tests]
 # this environement runs the tests of the metatensor-operations Python package
+# without torch functionalities
 deps =
     pytest
     numpy
-    torch
 
 changedir = python/metatensor-operations
 commands =
@@ -65,6 +65,18 @@ commands =
     # run the unit tests
     pytest --import-mode=append {posargs}
 
+[testenv:operations-torch-tests]
+# this environement runs the tests of the metatensor-operations Python package
+# with torch functionalities
+deps =
+    torch
+    {[testenv:operations-notorch-tests]deps}
+
+commands =
+    {[testenv:operations-notorch-tests]commands}
+
+changedir =
+    {[testenv:operations-notorch-tests]changedir}
 
 [testenv:torch-tests]
 # this environement runs the tests of the metatensor-torch Python package


### PR DESCRIPTION
The first two commits are removing the existing dependencies on torch in the operations. The last commit adds another tox environment that does not have torch as dependency. I updated the CONTRIBUTING.rst, that was the only occurrence of `operations-tests` I could find.

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--365.org.readthedocs.build/en/365/

<!-- readthedocs-preview metatensor end -->