### PR TITLE
Fix wrong directory in installation C/C++ library

### DIFF
--- a/docs/src/get-started/installation.rst
+++ b/docs/src/get-started/installation.rst
@@ -50,7 +50,7 @@ well as CMake files that can be used with ``find_package(metatensor)``.
 .. code-block:: bash
 
     git clone https://github.com/lab-cosmo/metatensor
-    cd metatensor
+    cd metatensor/metatensor-core
     mkdir build && cd build
     cmake ..
     # configure cmake if needed


### PR DESCRIPTION


<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--371.org.readthedocs.build/en/371/

<!-- readthedocs-preview metatensor end -->