### PR TITLE
make LabelsEntry available to import from core

### DIFF
--- a/python/metatensor-core/metatensor/__init__.py
+++ b/python/metatensor-core/metatensor/__init__.py
@@ -18,7 +18,7 @@
 from .version import __version__  # noqa
 from . import utils  # noqa
 from .block import TensorBlock  # noqa
-from .labels import Labels  # noqa
+from .labels import Labels, LabelsEntry  # noqa
 from .status import MetatensorError  # noqa
 from .tensor import TensorMap  # noqa
 


### PR DESCRIPTION
Minor issue, low, but seems like an easy fix. To import the LabelsEntry from core one has to do
```python
from metatensor.core.labels import LabelsEntry
```
while from torch it can be imported like
```python
from metatensor.torch import LabelsEntry
```
To me it seems intuitive if we could also import LabelsEntry from core like this
```python
from metatensor.core import LabelsEntry
```

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--373.org.readthedocs.build/en/373/

<!-- readthedocs-preview metatensor end -->