### PR TITLE
Fix performance issues coming from backtrace collection

### DIFF
--- a/metatensor-torch/include/metatensor/torch/labels.hpp
+++ b/metatensor-torch/include/metatensor/torch/labels.hpp
@@ -234,11 +234,7 @@ class METATENSOR_TORCH_EXPORT LabelsEntryHolder: public torch::CustomClassHolder
 public:
     /// Create a new `LabelsEntryHolder` corresponding to the entry at the given
     /// `index` in the given `labels`
-    LabelsEntryHolder(TorchLabels labels, int64_t index):
-        labels_(std::move(labels))
-    {
-        values_ = labels_->values()[index];
-    }
+    LabelsEntryHolder(TorchLabels labels, int64_t index);
 
     /// Get the names of the dimensions/columns of these Labels
     std::vector<std::string> names() const {

--- a/metatensor-torch/src/labels.cpp
+++ b/metatensor-torch/src/labels.cpp
@@ -702,6 +702,30 @@ std::string LabelsHolder::repr() const {
 
 /******************************************************************************/
 
+LabelsEntryHolder::LabelsEntryHolder(TorchLabels labels, int64_t index):
+    labels_(std::move(labels))
+{
+    auto size = labels_->values().size(0);
+    if (index < -size || index >= size) {
+        // We prefer not using `C10_THROW_ERROR` here since this is an expected
+        // error (it will and must happen once per iteration over the labels),
+        // and `C10_THROW_ERROR` is quite expensive since it construct a full
+        // backtrace of the C++ code.
+        //
+        // Unfortunately, the `IndexError` constructor is not exported on
+        // Windows, so we can not call it. In this case, we let the indexing
+        // code below construct and throw the full error.
+#ifndef _WIN32
+        std::ostringstream ss;
+        ss << "out of range for tensor of size " << labels_->values().sizes();
+        ss << " at dimension 0";
+        throw torch::IndexError(ss.str(), "<no backtrace>");
+#endif
+    }
+
+    values_ = labels_->values()[index];
+}
+
 std::string LabelsEntryHolder::print() const {
     auto output = std::stringstream();
 


### PR DESCRIPTION
Both during iteration over labels and `tensor.block(key)`. This brings this code

```py
for key in tensor.keys:
    block = tensor.block(key)
```

from 40 ms to 2.5 ms (with a tensor containing 30 block) when using metatensor-torch. This is still a bit slower than metatensor-core at 600 us, but I can't find obvious performance problem in a profiler.

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--380.org.readthedocs.build/en/380/

<!-- readthedocs-preview metatensor end -->