### PR TITLE
Add Python coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+    patch: off
+  ignore:
+    - "tests/.*"
+    - "**/documentation.py"
+
+comment: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,68 @@
+name: Coverage
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    # Check all PR
+
+concurrency:
+  group: coverage-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  coverage:
+    runs-on: ubuntu-22.04
+    name: collect code coverage
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: install python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox coverage
+
+      - name: cache tox environments
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-${{ hashFiles('pyproject.toml', 'setup.cfg', 'tox.ini') }}
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.3
+
+      - name: Setup sccache environnement variables
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+
+      - name: collect Python coverage
+        run: |
+            tox -e core-tests
+            tox -e operations-notorch-tests
+            tox -e operations-torch-tests
+            tox -e torch-tests
+        env:
+            # Use the CPU only version of torch when building/running the code
+            PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
+
+      - name: combine coverage files
+        run: |
+            coverage combine \
+              python/metatensor-core/.coverage \
+              python/metatensor-operations/.coverage \
+              python/metatensor-torch/.coverage
+            coverage xml
+
+      - name: upload to codecov.io
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          files: coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__
 dist/
 build/
 .tox/
+htmlcov/
+.coverage
+coverage.xml

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -181,6 +181,25 @@ related shells:
 .. _`cargo` : https://doc.rust-lang.org/cargo/
 .. _valgrind: https://valgrind.org/
 
+Inspecting Python code coverage
+-------------------------------
+
+The code coverage is reported at `codecov`_. You can also inspect the coverage locally.
+To get the full coverage first combine all reports and open produced html file in a
+browser
+
+.. code-block:: bash
+
+    tox
+    coverage combine \
+        ./python/metatensor-core/.coverage \
+        ./python/metatensor-torch/.coverage \
+        ./python/metatensor-operations/.coverage
+    coverage html
+    firefox htmlcov/index.html
+
+.. _codecov: https://codecov.io/gh/lab-cosmo/metatensor
+
 Contributing to the documentation
 ---------------------------------
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![tests status](https://img.shields.io/github/checks-status/lab-cosmo/metatensor/master)](https://github.com/lab-cosmo/metatensor/actions?query=branch%3Amaster)
 [![documentation](https://img.shields.io/badge/documentation-latest-sucess)](https://lab-cosmo.github.io/metatensor/latest/)
+[![coverage](https://codecov.io/gh/lab-cosmo/metatensor/branch/master/graph/badge.svg)]( https://codecov.io/gh/lab-cosmo/metatensor)
 
 Metatensor is a self-describing sparse tensor data format for atomistic machine
 learning and beyond; storing values and gradients of these values together.

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,12 @@ min_version = 4.0
 # these are the default environments, i.e. the list of tests running when you
 # execute `tox` in the command-line without anything else
 envlist =
+    lint
     core-tests
     operations-notorch-tests
     operations-torch-tests
     torch-tests
     docs-tests
-    lint
 
 
 [testenv]
@@ -17,6 +17,7 @@ package = external
 package_env = build-metatensor-core
 lint_folders = "{toxinidir}/python" "{toxinidir}/setup.py"
 build_single_wheel = --no-deps --no-build-isolation --check-build-dependencies
+test_options = --cov={env_site_packages_dir}/metatensor --cov-append --import-mode=append
 
 commands =
     # error if the user gives a wrong testenv name in `tox -e`
@@ -28,10 +29,10 @@ commands =
 # all other environments requiring metatensor to be installed
 passenv = *
 deps =
+    cmake
     setuptools
     packaging
     wheel
-    cmake
 
 commands =
     pip wheel python/metatensor-core {[testenv]build_single_wheel} --wheel-dir {envtmpdir}/dist
@@ -40,21 +41,23 @@ commands =
 [testenv:core-tests]
 # this environement runs the tests of the metatensor-core Python package
 deps =
-    pytest
     numpy
+    pytest
+    pytest-cov
     torch
 
 changedir = python/metatensor-core
 commands =
-    pytest --import-mode=append {posargs}
+    pytest {[testenv]test_options} {posargs}
 
 [testenv:operations-notorch-tests]
 # this environement runs the tests of the metatensor-operations Python package
 # without torch functionalities
 deps =
     packaging
-    pytest
     numpy
+    pytest
+    pytest-cov
 
 changedir = python/metatensor-operations
 commands =
@@ -65,7 +68,7 @@ commands =
     pip install . {[testenv]build_single_wheel} --force-reinstall
 
     # run the unit tests
-    pytest --import-mode=append {posargs}
+    pytest {[testenv]test_options} {posargs}
 
 [testenv:operations-torch-tests]
 # this environement runs the tests of the metatensor-operations Python package
@@ -73,22 +76,21 @@ commands =
 deps =
     torch
     {[testenv:operations-notorch-tests]deps}
-
+changedir =
+    {[testenv:operations-notorch-tests]changedir}
 commands =
     {[testenv:operations-notorch-tests]commands}
 
-changedir =
-    {[testenv:operations-notorch-tests]changedir}
 
 [testenv:torch-tests]
 # this environement runs the tests of the metatensor-torch Python package
 deps =
+    cmake
+    numpy
     packaging
     pytest
-    numpy
+    pytest-cov
     torch
-
-    cmake
 
 changedir = python/metatensor-torch
 commands =
@@ -98,7 +100,7 @@ commands =
     pip install ../metatensor-operations {[testenv]build_single_wheel} --force-reinstall
 
     # run the unit tests
-    pytest --import-mode=append {posargs}
+    pytest {[testenv]test_options} {posargs}
 
 
 [testenv:docs-tests]
@@ -210,3 +212,23 @@ commands =
 [flake8]
 max_line_length = 88
 extend-ignore = E203
+
+[coverage:report]
+skip_covered = True
+show_missing = True
+omit =
+    tests/.*
+    **/documentation.py
+
+[coverage:paths]
+core =
+    python/metatensor-core/metatensor
+    .tox/*/lib/python*/site-packages/metatensor
+
+operations =
+    python/metatensor-operations/metatensor/operations
+    .tox/*/lib/python*/site-packages/metatensor/operations
+
+torch =
+    python/metatensor-torch/metatensor/torch
+    .tox/*/lib/python*/site-packages/metatensor/torch


### PR DESCRIPTION
As a starting point this PR adds collecting the coverage for the Python code.

# TODO

- [x] Create page at codecov.io
- [x] add badge in README.rst 

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--381.org.readthedocs.build/en/381/

<!-- readthedocs-preview metatensor end -->