### PR TITLE
Also include C++ tarballs in releases/Github CI artifacts

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           name: wheels
           path: ./wheelhouse/*.whl
+
       - name: upload wheel to GitHub release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
@@ -86,34 +87,50 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up Python
+
+    - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+
       - name: install dependencies
         run: python -m pip install wheel build
+
       - name: package vendored code
         run: ./scripts/package-core.sh
+
       - name: build metatensor-core sdist
         run: python -m build python/metatensor-core --sdist --outdir=dist/
+
       - name: build metatensor-operations sdist and wheel
         run: python -m build python/metatensor-operations --outdir=dist/
+
       - name: build metatensor-torch sdist
         run: python -m build python/metatensor-torch --sdist --outdir=dist/
+
       - name: build metatensor sdist and wheel
         run: python -m build . --outdir=dist/
+
+      - name: build C++ tarballs
+        run: |
+          ./scripts/package-core.sh
+          ./scripts/package-torch.sh
+
       - uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: |
             dist/*.tar.gz
+            dist/cxx/*.tar.gz
             dist/*.whl
+
       - name: upload to GitHub release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
           files: |
             dist/*.tar.gz
+            dist/cxx/*.tar.gz
             dist/*.whl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This mean making a release is just a matter of pushing a tag to the repo. Distribution of the C++ parts of metatensor (e.g. pre-built versions in conda-forge) will then be able to use the tarball attached to the release as the sources to build.

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--385.org.readthedocs.build/en/385/

<!-- readthedocs-preview metatensor end -->