### PR TITLE
Add a test building metatensor-torch from sdist

### DIFF
--- a/python/metatensor-core/setup.py
+++ b/python/metatensor-core/setup.py
@@ -215,16 +215,16 @@ if __name__ == "__main__":
     if not os.path.exists(METATENSOR_CORE):
         # we are building from a sdist, which should include metatensor-core Rust
         # sources as a tarball
-        crate_file = glob.glob(os.path.join(ROOT, "metatensor-core-*.tar.gz"))
+        tarballs = glob.glob(os.path.join(ROOT, "metatensor-core-*.tar.gz"))
 
-        if not len(crate_file) == 1:
+        if not len(tarballs) == 1:
             raise RuntimeError(
                 "expected a single 'metatensor-core-*.tar.gz' file containing "
                 "metatensor-core Rust sources. remove all files and re-run "
                 "scripts/package-core.sh"
             )
 
-        METATENSOR_CORE = os.path.realpath(crate_file[0])
+        METATENSOR_CORE = os.path.realpath(tarballs[0])
         subprocess.run(
             ["cmake", "-E", "tar", "xf", METATENSOR_CORE],
             cwd=ROOT,

--- a/python/metatensor-torch/setup.py
+++ b/python/metatensor-torch/setup.py
@@ -203,16 +203,16 @@ if __name__ == "__main__":
     if not os.path.exists(METATENSOR_TORCH):
         # we are building from a sdist, which should include metatensor-core Rust
         # sources as a tarball
-        crate_file = glob.glob(os.path.join(ROOT, "metatensor-core-*.tar.gz"))
+        tarballs = glob.glob(os.path.join(ROOT, "metatensor-torch-*.tar.gz"))
 
-        if not len(crate_file) == 1:
+        if not len(tarballs) == 1:
             raise RuntimeError(
-                "expected a single 'metatensor-core-*.tar.gz' file containing "
-                "metatensor-core Rust sources. remove all files and re-run "
-                "scripts/package-core.sh"
+                "expected a single 'metatensor-torch-*.tar.gz' file containing "
+                "metatensor-torch Rust sources. remove all files and re-run "
+                "scripts/package-torch.sh"
             )
 
-        METATENSOR_TORCH = os.path.realpath(crate_file[0])
+        METATENSOR_TORCH = os.path.realpath(tarballs[0])
         subprocess.run(
             ["cmake", "-E", "tar", "xf", METATENSOR_TORCH],
             cwd=ROOT,

--- a/scripts/build-python.sh
+++ b/scripts/build-python.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)
+cd "$ROOT_DIR"
+
+TMP_DIR="$1"
+rm -rf "$TMP_DIR"/dist
+
+./scripts/package-core.sh
+./scripts/package-torch.sh
+
+# check building sdist from a checkout, and wheel from the sdist
+python -m build python/metatensor-core --outdir "$TMP_DIR"/dist
+python -m build python/metatensor-operations --outdir "$TMP_DIR"/dist
+python -m build . --outdir "$TMP_DIR"/dist
+
+# for metatensor-torch, we need a pre-built version of metatensor-core, so
+# we use the one we just generated and make it available to pip
+dir2pi --no-symlink "$TMP_DIR"/dist
+
+PORT=8912
+if nc -z localhost $PORT; then
+    printf "\033[91m ERROR: an application is listening to port %d. Please free up the port first. \033[0m\n" $PORT >&2
+    exit 1
+fi
+
+PYPI_SERVER_PID=""
+function cleanup() {
+    kill $PYPI_SERVER_PID
+}
+# Make sure to stop the Python server on script exit/cancellation
+trap cleanup INT TERM EXIT
+
+python -m http.server --directory "$TMP_DIR"/dist $PORT &
+PYPI_SERVER_PID=$!
+
+# add the python server to the set of extra pip index URL
+export PIP_EXTRA_INDEX_URL="http://localhost:$PORT/simple/ ${PIP_EXTRA_INDEX_URL=}"
+
+# build metatensor-torch, using metatensor-core from `PIP_EXTRA_INDEX_URL`
+# for the sdist => wheel build.
+python -m build python/metatensor-torch --outdir "$TMP_DIR/dist"

--- a/tox.ini
+++ b/tox.ini
@@ -189,25 +189,13 @@ package = skip
 deps =
     build
     twine  # a tool to check sdist and wheels metadata
+    pip2pi # tool to create PyPI-like package indexes
 
 allowlist_externals = bash
 commands =
     python --version  # print the version of python used in this test
 
-    bash ./scripts/package-core.sh
-    bash ./scripts/package-torch.sh
-
-    bash -c "rm -rf {envtmpdir}/dist"
-
-    # check building sdist from a checkout, and wheel from the sdist
-    python -m build python/metatensor-core --outdir {envtmpdir}/dist
-    python -m build python/metatensor-operations --outdir {envtmpdir}/dist
-    python -m build . --outdir {envtmpdir}/dist
-
-    # for metatensor-torch, we can not build from a sdist until metatensor-core
-    # is available on PyPI, so we build both sdist and wheel from a checkout
-    python -m build python/metatensor-torch --sdist --outdir {envtmpdir}/dist
-    python -m build python/metatensor-torch --wheel --outdir {envtmpdir}/dist
+    bash ./scripts/build-python.sh {envtmpdir}
 
     twine check {envtmpdir}/dist/*.tar.gz
     twine check {envtmpdir}/dist/*.whl
@@ -215,6 +203,7 @@ commands =
     # check building wheels directly from the a checkout
     python -m build python/metatensor-core --wheel --outdir {envtmpdir}/dist
     python -m build python/metatensor-operations --wheel --outdir {envtmpdir}/dist
+    python -m build python/metatensor-torch --wheel --outdir {envtmpdir}/dist
     python -m build .  --wheel --outdir {envtmpdir}/dist
 
 


### PR DESCRIPTION
Since building metatensor-torch wheel requires a version of metatensor-torch available through pip, we use `dir2pi` from https://pypi.org/project/pip2pi/ to generate a pip-compatible server serving freshly built wheels. The tests also moved to a bash script since we need to start an HTTP server in the background, and cleanup once we exit.

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--387.org.readthedocs.build/en/387/

<!-- readthedocs-preview metatensor end -->