### PR TITLE
Use consistently samples_names in both rs and py

### DIFF
--- a/docs/src/get-started/concepts.rst
+++ b/docs/src/get-started/concepts.rst
@@ -47,14 +47,14 @@ dimensions you'll encounter when working with atomistic data are the following:
 - **symmetry markers**: Another use case for metatensor is to store and
   manipulate equivariant data, i.e. data that transforms in a known, specific
   way when the corresponding atomic structure is transformed. This is typically
-  used to represent the symmetry property of some data with respect to
-  rotations, by decomposing the properties of interest on a basis of spherical
-  harmonics. When handling this kind of data, it is convenient to store and
-  manipulate the data corresponding to different spherical harmonics (or
-  generally different irreducible representations of the symmetry group)
-  separately. This is the case of the ``spherical_harmonics_l`` key dimension
-  produced by `rascaline`_: different blocks will contain the :math:`\ell = 1`
-  and :math:`\ell = 2` parts of an equivariant representation.
+  used to represent the symmetry of some data with respect to rotations, by
+  decomposing the properties of interest on a basis of spherical harmonics. When
+  handling this kind of data, it is convenient to store and manipulate the data
+  corresponding to different spherical harmonics (or generally different
+  irreducible representations of the symmetry group) separately. This is the
+  case of the ``spherical_harmonics_l`` key dimension produced by `rascaline`_:
+  different blocks will contain the :math:`\ell = 1` and :math:`\ell = 2` parts
+  of an equivariant representation.
 
 .. _rascaline: https://github.com/Luthaf/rascaline/
 
@@ -177,7 +177,7 @@ In addition to storing data and metadata together, a :py:class:`TensorBlock` can
 also store values and gradients together. The gradients are stored in another
 :py:class:`TensorBlock`, associated with a **parameter** name, describing with
 respect to **what** the gradients are taken. Regarding metadata, the gradient
-properties always match the values properties; while the gradient sample are
+properties always match the values properties; while the gradient samples are
 different from the value samples. The gradient samples contains both what a
 given row in the data is the gradient **of**, and **with respect to** what the
 gradient is taken. As illustrated below, multiple gradient rows can be gradients
@@ -191,7 +191,7 @@ of different particles in the system).
     Illustration of gradients stored inside a :py:class:`TensorBlock`.
 
 
-.. TODO: explain how the gradient sample works in a separate tutorial
+.. TODO: explain how the gradient samples works in a separate tutorial
 
 Components
 ----------

--- a/docs/src/reference/c/tensor.rst
+++ b/docs/src/reference/c/tensor.rst
@@ -11,7 +11,7 @@ The following functions operate on :c:type:`mts_tensormap_t`:
 - :c:func:`mts_tensormap_keys`: get the keys defined in a tensor map as :c:struct:`mts_labels_t`
 - :c:func:`mts_tensormap_block_by_id`: get a :c:struct:`mts_block_t` in a tensor map from its index
 - :c:func:`mts_tensormap_blocks_matching`: get a list of block indexes matching a selection
-- :c:func:`mts_tensormap_keys_to_samples`: move entries from keys to sample labels
+- :c:func:`mts_tensormap_keys_to_samples`: move entries from keys to samples labels
 - :c:func:`mts_tensormap_keys_to_properties`: move entries from keys to properties labels
 - :c:func:`mts_tensormap_components_to_properties`: move entries from component labels to properties labels
 

--- a/metatensor-core/src/blocks.rs
+++ b/metatensor-core/src/blocks.rs
@@ -47,7 +47,7 @@ fn check_data_and_labels(
 
     if shape[0] != samples.count() {
         return Err(Error::InvalidParameter(format!(
-            "{}: the array shape along axis 0 is {} but we have {} sample labels",
+            "{}: the array shape along axis 0 is {} but we have {} samples labels",
             context, shape[0], samples.count()
         )));
     }
@@ -192,7 +192,7 @@ impl TensorBlock {
     /// Add a gradient with respect to `parameter` to this block.
     ///
     /// The gradient `data` is given as an array, and the samples and components
-    /// labels must be provided. The property labels are assumed to match the
+    /// labels must be provided. The properties labels are assumed to match the
     /// ones of the values in the current block.
     ///
     /// The components labels must contain at least the same entries as the
@@ -298,19 +298,19 @@ impl TensorBlock {
 
         let moved_component = self.components.0.remove(component_axis);
 
-        // construct the new property with old properties and the components
+        // construct the new properties with old properties and the components
         let old_properties = &self.properties;
-        let new_property_names = moved_component.names().iter()
+        let new_properties_names = moved_component.names().iter()
             .chain(old_properties.names().iter())
             .copied()
             .collect();
 
-        let mut new_properties_builder = LabelsBuilder::new(new_property_names)?;
-        for new_property in &*moved_component {
-            for old_property in old_properties.iter() {
-                let mut property = new_property.to_vec();
-                property.extend_from_slice(old_property);
-                new_properties_builder.add(&property)?;
+        let mut new_properties_builder = LabelsBuilder::new(new_properties_names)?;
+        for new_properties in &*moved_component {
+            for old_properties in old_properties.iter() {
+                let mut properties = new_properties.to_vec();
+                properties.extend_from_slice(old_properties);
+                new_properties_builder.add(&properties)?;
             }
         }
         let new_properties = new_properties_builder.finish();
@@ -362,7 +362,7 @@ mod tests {
         assert_eq!(
             result.unwrap_err().to_string(),
             "invalid parameter: data and labels don't match: the array shape \
-            along axis 0 is 3 but we have 4 sample labels"
+            along axis 0 is 3 but we have 4 samples labels"
         );
 
         let values = TestArray::new(vec![4, 9]);

--- a/metatensor-core/src/c_api/blocks.rs
+++ b/metatensor-core/src/c_api/blocks.rs
@@ -12,8 +12,8 @@ use super::{catch_unwind, mts_status_t};
 /// `mts_array_t`, and n sets of `mts_labels_t` (one for each dimension).
 ///
 /// A block can also contain gradients of the values with respect to a variety
-/// of parameters. In this case, each gradient has a separate set of sample
-/// and component labels but share the property labels with the values.
+/// of parameters. In this case, each gradient has a separate set of samples
+/// and components labels but share the properties labels with the values.
 #[allow(non_camel_case_types)]
 pub struct mts_block_t(TensorBlock);
 
@@ -46,11 +46,10 @@ impl mts_block_t {
 /// @param data array handle containing the data for this block. The block takes
 ///             ownership of the array, and will release it with
 ///             `array.destroy(array.ptr)` when it no longer needs it.
-/// @param samples sample labels corresponding to the first dimension of the data
-/// @param components array of component labels corresponding to intermediary
-///                   dimensions of the data
+/// @param samples labels corresponding to the first dimension of the data
+/// @param components labels corresponding to intermediary dimensions of the data
 /// @param components_count number of entries in the `components` array
-/// @param properties property labels corresponding to the last dimension of the data
+/// @param properties labels corresponding to the last dimension of the data
 ///
 /// @returns A pointer to the newly allocated block, or a `NULL` pointer in
 ///          case of error. In case of error, you can use `mts_last_error()`
@@ -192,7 +191,7 @@ pub unsafe extern fn mts_block_labels(
             // component labels
             &block.components[axis - 1]
         } else if axis == n_components + 1 {
-            // property labels
+            // properties labels
             &block.properties
         } else {
             return Err(Error::InvalidParameter(format!(

--- a/metatensor-core/src/c_api/tensor.rs
+++ b/metatensor-core/src/c_api/tensor.rs
@@ -292,33 +292,32 @@ pub unsafe extern fn mts_tensormap_blocks_matching(
 
 
 /// Merge blocks with the same value for selected keys dimensions along the
-/// property axis.
+/// properties axis.
 ///
-/// The dimensions (names) of `keys_to_move` will be moved from the keys to
-/// the property labels, and blocks with the same remaining keys dimensions
-/// will be merged together along the property axis.
+/// The dimensions (names) of `keys_to_move` will be moved from the keys to the
+/// properties labels, and blocks with the same remaining keys dimensions will
+/// be merged together along the properties axis.
 ///
-/// If `keys_to_move` does not contains any entries (`keys_to_move.count
-/// == 0`), then the new property labels will contain entries corresponding
-/// to the merged blocks only. For example, merging a block with key `a=0`
-/// and properties `p=1, 2` with a block with key `a=2` and properties `p=1,
-/// 3` will produce a block with properties `a, p = (0, 1), (0, 2), (2, 1),
-/// (2, 3)`.
+/// If `keys_to_move` does not contains any entries (`keys_to_move.count == 0`),
+/// then the new properties labels will contain entries corresponding to the
+/// merged blocks only. For example, merging a block with key `a=0` and
+/// properties `p=1, 2` with a block with key `a=2` and properties `p=1, 3` will
+/// produce a block with properties `a, p = (0, 1), (0, 2), (2, 1), (2, 3)`.
 ///
-/// If `keys_to_move` contains entries, then the property labels must be the
-/// same for all the merged blocks. In that case, the merged property labels
+/// If `keys_to_move` contains entries, then the properties labels must be the
+/// same for all the merged blocks. In that case, the merged properties labels
 /// will contains each of the entries of `keys_to_move` and then the current
-/// property labels. For example, using `a=2, 3` in `keys_to_move`, and
-/// blocks with properties `p=1, 2` will result in `a, p = (2, 1), (2, 2),
-/// (3, 1), (3, 2)`.
+/// properties labels. For example, using `a=2, 3` in `keys_to_move`, and blocks
+/// with properties `p=1, 2` will result in `a, p = (2, 1), (2, 2), (3, 1), (3,
+/// 2)`.
 ///
-/// The new sample labels will contains all of the merged blocks sample
-/// labels. The order of the samples is controlled by `sort_samples`. If
-/// `sort_samples` is true, samples are re-ordered to keep them
-/// lexicographically sorted. Otherwise they are kept in the order in which
-/// they appear in the blocks.
+/// The new samples labels will contains all of the merged blocks samples labels.
+/// The order of the samples is controlled by `sort_samples`. If `sort_samples`
+/// is true, samples are re-ordered to keep them lexicographically sorted.
+/// Otherwise they are kept in the order in which they appear in the blocks.
 ///
-/// The result is a new tensor map, which should be freed with `mts_tensormap_free`.
+/// The result is a new tensor map, which should be freed with
+/// `mts_tensormap_free`.
 ///
 /// @param tensor pointer to an existing tensor map
 /// @param keys_to_move description of the keys to move
@@ -358,7 +357,7 @@ pub unsafe extern fn mts_tensormap_keys_to_properties(
 }
 
 
-/// Move the given dimensions from the component labels to the property labels
+/// Move the given dimensions from the component labels to the properties labels
 /// for each block in this tensor map.
 ///
 /// `dimensions` must be an array of `dimensions_count` NULL-terminated strings,
@@ -412,21 +411,21 @@ pub unsafe extern fn mts_tensormap_components_to_properties(
 /// samples axis.
 ///
 /// The dimensions (names) of `keys_to_move` will be moved from the keys to
-/// the sample labels, and blocks with the same remaining keys dimensions
-/// will be merged together along the sample axis.
+/// the samples labels, and blocks with the same remaining keys dimensions
+/// will be merged together along the samples axis.
 ///
 /// `keys_to_move` must be empty (`keys_to_move.count == 0`), and the new
-/// sample labels will contain entries corresponding to the merged blocks'
+/// samples labels will contain entries corresponding to the merged blocks'
 /// keys.
 ///
-/// The new sample labels will contains all of the merged blocks sample
+/// The new samples labels will contains all of the merged blocks samples
 /// labels. The order of the samples is controlled by `sort_samples`. If
 /// `sort_samples` is true, samples are re-ordered to keep them
 /// lexicographically sorted. Otherwise they are kept in the order in which
 /// they appear in the blocks.
 ///
 /// This function is only implemented if all merged block have the same
-/// property labels.
+/// properties labels.
 ///
 /// @param tensor pointer to an existing tensor map
 /// @param keys_to_move description of the keys to move

--- a/metatensor-core/src/data.rs
+++ b/metatensor-core/src/data.rs
@@ -153,15 +153,15 @@ pub struct mts_array_t {
     /// should be moved from `input` to `output`.
     ///
     /// This function should copy data from `input[samples[i].input, ..., :]` to
-    /// `array[samples[i].output, ..., property_start:property_end]` for `i` up
+    /// `array[samples[i].output, ..., properties_start:properties_end]` for `i` up
     /// to `samples_count`. All indexes are 0-based.
     move_samples_from: Option<unsafe extern fn(
         output: *mut c_void,
         input: *const c_void,
         samples: *const mts_sample_mapping_t,
         samples_count: usize,
-        property_start: usize,
-        property_end: usize,
+        properties_start: usize,
+        properties_end: usize,
     ) -> mts_status_t>,
 }
 

--- a/metatensor-core/src/tensor/keys_to_samples.rs
+++ b/metatensor-core/src/tensor/keys_to_samples.rs
@@ -13,21 +13,21 @@ impl TensorMap {
     /// samples axis.
     ///
     /// The dimensions (names) of `keys_to_move` will be moved from the keys to
-    /// the sample labels, and blocks with the same remaining keys dimensions
-    /// will be merged together along the sample axis.
+    /// the samples labels, and blocks with the same remaining keys dimensions
+    /// will be merged together along the samples axis.
     ///
     /// `keys_to_move` must be empty (`keys_to_move.count() == 0`), and the new
-    /// sample labels will contain entries corresponding to the merged blocks'
+    /// samples labels will contain entries corresponding to the merged blocks'
     /// keys.
     ///
-    /// The new sample labels will contains all of the merged blocks sample
+    /// The new samples labels will contains all of the merged blocks samples
     /// labels. The order of the samples is controlled by `sort_samples`. If
     /// `sort_samples` is true, samples are re-ordered to keep them
     /// lexicographically sorted. Otherwise they are kept in the order in which
     /// they appear in the blocks.
     ///
     /// This function is only implemented if all merged block have the same
-    /// property labels.
+    /// properties labels.
     pub fn keys_to_samples(&self, keys_to_move: &Labels, sort_samples: bool) -> Result<TensorMap, Error> {
         if self.keys.is_empty() {
             return Err(Error::InvalidParameter(
@@ -103,7 +103,7 @@ impl TensorMap {
     }
 }
 
-/// Merge the given `blocks` along the sample axis.
+/// Merge the given `blocks` along the samples axis.
 fn merge_blocks_along_samples(
     blocks_to_merge: &[KeyAndBlock],
     extracted_names: &[&str],
@@ -134,7 +134,7 @@ fn merge_blocks_along_samples(
         if &block.properties != first_properties_label {
             return Err(Error::InvalidParameter(
                 "can not move keys to samples if the blocks have \
-                different property labels".into() // TODO: this might be possible
+                different properties labels".into() // TODO: this might be possible
             ))
         }
     }
@@ -157,14 +157,14 @@ fn merge_blocks_along_samples(
     new_shape[0] = merged_samples.count();
     let mut new_data = first_block.values.create(&new_shape)?;
 
-    let property_range = 0..new_properties.count();
+    let properties_range = 0..new_properties.count();
 
     debug_assert_eq!(blocks_to_merge.len(), samples_mappings.len());
     for (KeyAndBlock{block, ..}, samples_mapping) in blocks_to_merge.iter().zip(&samples_mappings) {
         new_data.move_samples_from(
             &block.values,
             samples_mapping,
-            property_range.clone(),
+            properties_range.clone(),
         )?;
     }
 
@@ -209,7 +209,7 @@ fn merge_blocks_along_samples(
             new_gradient.move_samples_from(
                 &gradient.values,
                 &samples_to_move,
-                property_range.clone(),
+                properties_range.clone(),
             )?;
         }
 

--- a/metatensor-core/src/tensor/mod.rs
+++ b/metatensor-core/src/tensor/mod.rs
@@ -29,15 +29,15 @@ pub struct TensorMap {
 
 fn check_labels_names(
     block: &TensorBlock,
-    sample_names: &[&str],
+    samples_names: &[&str],
     components_names: &[Vec<&str>],
     context: &str,
 ) -> Result<(), Error> {
-    if block.samples.names() != sample_names {
+    if block.samples.names() != samples_names {
         return Err(Error::InvalidParameter(format!(
             "all blocks must have the same sample label names, got [{}] and [{}]{}",
             block.samples.names().join(", "),
-            sample_names.join(", "),
+            samples_names.join(", "),
             context,
         )));
     }
@@ -88,7 +88,7 @@ fn check_origin(blocks: &Vec<TensorBlock>) -> Result<(), Error> {
 
 #[derive(Debug, Clone, PartialEq)]
 struct GradientMetadata<'a> {
-    sample_names: Vec<&'a str>,
+    samples_names: Vec<&'a str>,
     components_names: Vec<Vec<&'a str>>,
 }
 
@@ -105,7 +105,7 @@ impl GradientMap<'_> {
         let mut gradients = HashMap::new();
         for (gradient_name, sub_gradient) in block.gradients() {
             let metadata = GradientMetadata {
-                sample_names: sub_gradient.samples.names(),
+                samples_names: sub_gradient.samples.names(),
                 components_names: sub_gradient.components.iter()
                     .map(|c| c.names())
                     .collect::<Vec<_>>(),
@@ -136,7 +136,7 @@ impl TensorMap {
 
         if !blocks.is_empty() {
             // extract metadata from the first block
-            let sample_names = blocks[0].samples.names();
+            let samples_names = blocks[0].samples.names();
             let components_names = blocks[0].components.iter()
                 .map(|c| c.names())
                 .collect::<Vec<_>>();
@@ -145,7 +145,7 @@ impl TensorMap {
 
             for block in &blocks {
                 // check samples and components are the same as those of the first block
-                check_labels_names(block, &sample_names, &components_names, "")?;
+                check_labels_names(block, &samples_names, &components_names, "")?;
 
                 // check properties are the same as those of the first block
                 if block.properties.names() != properties_names {

--- a/metatensor-core/src/tensor/mod.rs
+++ b/metatensor-core/src/tensor/mod.rs
@@ -35,7 +35,7 @@ fn check_labels_names(
 ) -> Result<(), Error> {
     if block.samples.names() != samples_names {
         return Err(Error::InvalidParameter(format!(
-            "all blocks must have the same sample label names, got [{}] and [{}]{}",
+            "all blocks must have the same samples names, got [{}] and [{}]{}",
             block.samples.names().join(", "),
             samples_names.join(", "),
             context,
@@ -150,7 +150,7 @@ impl TensorMap {
                 // check properties are the same as those of the first block
                 if block.properties.names() != properties_names {
                     return Err(Error::InvalidParameter(format!(
-                        "all blocks must have the same property label names, got [{}] and [{}]",
+                        "all blocks must have the same properties names, got [{}] and [{}]",
                         block.properties.names().join(", "),
                         properties_names.join(", "),
                     )));
@@ -255,7 +255,7 @@ impl TensorMap {
         return Ok(matching);
     }
 
-    /// Move the given dimensions from the component labels to the property labels
+    /// Move the given dimensions from the component labels to the properties labels
     /// for each block in this `TensorMap`.
     pub fn components_to_properties(&self, dimensions: &[&str]) -> Result<TensorMap, Error> {
         let mut clone = self.try_clone()?;
@@ -325,7 +325,7 @@ mod tests {
         );
         assert_eq!(
             result.unwrap_err().to_string(),
-            "invalid parameter: all blocks must have the same sample label \
+            "invalid parameter: all blocks must have the same samples \
             names, got [something_else] and [samples]"
         );
 
@@ -401,7 +401,7 @@ mod tests {
         );
         assert_eq!(
             result.unwrap_err().to_string(),
-            "invalid parameter: all blocks must have the same property label \
+            "invalid parameter: all blocks must have the same properties \
             names, got [something_else] and [properties]"
         );
 

--- a/metatensor-core/src/tensor/utils.rs
+++ b/metatensor-core/src/tensor/utils.rs
@@ -120,10 +120,10 @@ pub fn merge_gradient_samples(
 
 pub fn merge_samples(
     blocks: &[KeyAndBlock],
-    new_sample_names: Vec<&str>,
+    new_samples_names: Vec<&str>,
     sort: bool
 ) -> (Arc<Labels>, Vec<Vec<mts_sample_mapping_t>>) {
-    let add_key_to_samples = blocks[0].block.samples.size() < new_sample_names.len();
+    let add_key_to_samples = blocks[0].block.samples.size() < new_samples_names.len();
 
     // Collect samples in an IndexSet to keep them in the same order as they
     // were in the blocks, and then optionally sort them later below
@@ -143,7 +143,7 @@ pub fn merge_samples(
         merged_samples.sort_unstable();
     }
 
-    let mut merged_samples_builder = LabelsBuilder::new(new_sample_names).expect("invalid new samples names");
+    let mut merged_samples_builder = LabelsBuilder::new(new_samples_names).expect("invalid new samples names");
     for sample in merged_samples {
         merged_samples_builder.add(&sample).expect("got duplicated samples");
     }

--- a/metatensor-core/tests/cmake-project/README.md
+++ b/metatensor-core/tests/cmake-project/README.md
@@ -1,3 +1,3 @@
-# Sample CMake project using metatensor
+# Example CMake project using metatensor
 
 This is a basic cmake project linking to metatensor from C and C++ code.

--- a/metatensor-core/tests/cpp/labels.cpp
+++ b/metatensor-core/tests/cpp/labels.cpp
@@ -133,7 +133,7 @@ TEST_CASE("User data") {
             delete static_cast<UserData*>(ptr);
         });
 
-        auto labels = Labels({"sample"}, {{0}, {1}, {2}});
+        auto labels = Labels({"s"}, {{0}, {1}, {2}});
         labels.set_user_data(std::move(user_data));
 
         auto* data_ptr = static_cast<UserData*>(labels.user_data());
@@ -147,7 +147,7 @@ TEST_CASE("User data") {
             std::unique_ptr<SimpleDataArray>(new SimpleDataArray({3, 2})),
             labels,
             {},
-            Labels({"properties"}, {{5}, {3}})
+            Labels({"p"}, {{5}, {3}})
         );
 
         auto samples = block.samples();
@@ -169,7 +169,7 @@ TEST_CASE("User data") {
         CHECK(data_ptr->values == std::vector<double>{1.0, 2.0, 3.0, 42.1, 12356});
 
         // check that we can register user data after the construction of the block
-        data = new UserData{"properties", 0, {}};
+        data = new UserData{"name of data", 0, {}};
         user_data = metatensor::LabelsUserData(data, [](void* ptr){
             DELETE_CALL_MARKER += 10000000;
             delete static_cast<UserData*>(ptr);
@@ -181,7 +181,7 @@ TEST_CASE("User data") {
         properties = block.properties();
         data_ptr = static_cast<UserData*>(properties.user_data());
         REQUIRE(data_ptr != nullptr);
-        CHECK(data_ptr->name == "properties");
+        CHECK(data_ptr->name == "name of data");
         CHECK(data_ptr->count == 0);
         CHECK(data_ptr->values.empty());
     }

--- a/metatensor-torch/include/metatensor/torch/array.hpp
+++ b/metatensor-torch/include/metatensor/torch/array.hpp
@@ -63,8 +63,8 @@ public:
     void move_samples_from(
         const metatensor::DataArrayBase& input,
         std::vector<mts_sample_mapping_t> samples,
-        uintptr_t property_start,
-        uintptr_t property_end
+        uintptr_t properties_start,
+        uintptr_t properties_end
     ) override;
 
 private:

--- a/metatensor-torch/include/metatensor/torch/block.hpp
+++ b/metatensor-torch/include/metatensor/torch/block.hpp
@@ -51,7 +51,7 @@ public:
     /// the given `axis`.
     TorchLabels labels(uintptr_t axis) const;
 
-    /// Access the sample `Labels` for this block.
+    /// Access the samples `Labels` for this block.
     ///
     /// The entries in these labels describe the first dimension of the
     /// `values()` array.
@@ -74,7 +74,7 @@ public:
         return result;
     }
 
-    /// Access the property `Labels` for this block.
+    /// Access the properties `Labels` for this block.
     ///
     /// The entries in these labels describe the last dimension of the
     /// `values()` array. The properties are guaranteed to be the same for

--- a/metatensor-torch/include/metatensor/torch/tensor.hpp
+++ b/metatensor-torch/include/metatensor/torch/tensor.hpp
@@ -89,7 +89,7 @@ public:
     static std::vector<TorchTensorBlock> blocks_torch(TorchTensorMap self, torch::IValue index);
 
     /// Merge blocks with the same value for selected keys dimensions along the
-    /// property axis.
+    /// properties axis.
     ///
     /// See `metatensor::TensorMap::keys_to_properties` for more information on
     /// this function.
@@ -99,7 +99,7 @@ public:
     TorchTensorMap keys_to_properties(torch::IValue keys_to_move, bool sort_samples) const;
 
     /// Merge blocks with the same value for selected keys dimensions along the
-    /// sample axis.
+    /// samples axis.
     ///
     /// See `metatensor::TensorMap::keys_to_samples` for more information on
     /// this function.
@@ -108,7 +108,7 @@ public:
     /// strings, or a `TorchLabels` instance.
     TorchTensorMap keys_to_samples(torch::IValue keys_to_move, bool sort_samples) const;
 
-    /// Move the given `dimensions` from the component labels to the property
+    /// Move the given `dimensions` from the component labels to the properties
     /// labels for each block.
     ///
     /// See `metatensor::TensorMap::components_to_properties` for more

--- a/metatensor-torch/src/array.cpp
+++ b/metatensor-torch/src/array.cpp
@@ -102,8 +102,8 @@ void TorchDataArray::swap_axes(uintptr_t axis_1, uintptr_t axis_2) {
 void TorchDataArray::move_samples_from(
     const metatensor::DataArrayBase& raw_input,
     std::vector<mts_sample_mapping_t> samples,
-    uintptr_t property_start,
-    uintptr_t property_end
+    uintptr_t properties_start,
+    uintptr_t properties_end
 ) {
     const auto& input = dynamic_cast<const TorchDataArray&>(raw_input);
     auto input_tensor = input.tensor();
@@ -126,7 +126,7 @@ void TorchDataArray::move_samples_from(
 
     // output[output_samples, ..., properties] = input[input_samples, ..., :]
     output_tensor.index_put_(
-        {output_samples, Ellipsis, Slice(property_start, property_end)},
+        {output_samples, Ellipsis, Slice(properties_start, properties_end)},
         input_tensor.index({input_samples, Ellipsis, Slice()})
     );
 }

--- a/metatensor-torch/tests/block.cpp
+++ b/metatensor-torch/tests/block.cpp
@@ -68,10 +68,10 @@ TEST_CASE("Blocks") {
         auto gradient = TensorBlockHolder::gradient(block, "g");
         CHECK((gradient->values().sizes() == std::vector<int64_t>{1, 3, 2}));
 
-        auto sample_names = gradient->samples()->names();
-        CHECK(sample_names.size() == 2);
-        CHECK(sample_names[0] == "sample");
-        CHECK(sample_names[1] == "g");
+        auto samples_names = gradient->samples()->names();
+        CHECK(samples_names.size() == 2);
+        CHECK(samples_names[0] == "sample");
+        CHECK(samples_names[1] == "g");
 
         for (const auto& entry: TensorBlockHolder::gradients(block)) {
             CHECK(std::get<0>(entry) == "g");

--- a/metatensor-torch/tests/cmake-project/README.md
+++ b/metatensor-torch/tests/cmake-project/README.md
@@ -1,3 +1,3 @@
-# Sample CMake project using metatensor-torch
+# Example CMake project using metatensor-torch
 
 This is a basic cmake project linking to metatensor-torch from C++ code.

--- a/metatensor/src/block/owned.rs
+++ b/metatensor/src/block/owned.rs
@@ -126,7 +126,7 @@ impl TensorBlock {
 
     /// Add a gradient with respect to `parameter` to this block.
     ///
-    /// The property of the gradient should match the ones of this block. The
+    /// The properties of the gradient should match the ones of this block. The
     /// components of the gradients must contain at least the same entries as
     /// the value components, and can prepend other components.
     #[allow(clippy::needless_pass_by_value)]

--- a/metatensor/src/c_api.rs
+++ b/metatensor/src/c_api.rs
@@ -200,8 +200,8 @@ pub struct mts_array_t {
             input: *const ::std::os::raw::c_void,
             samples: *const mts_sample_mapping_t,
             samples_count: usize,
-            property_start: usize,
-            property_end: usize,
+            properties_start: usize,
+            properties_end: usize,
         ) -> mts_status_t,
     >,
 }

--- a/metatensor/src/data/array.rs
+++ b/metatensor/src/data/array.rs
@@ -227,8 +227,8 @@ unsafe extern fn rust_array_move_samples_from(
     input: *const c_void,
     samples: *const mts_sample_mapping_t,
     samples_count: usize,
-    property_start: usize,
-    property_end: usize,
+    properties_start: usize,
+    properties_end: usize,
 ) -> mts_status_t {
     crate::errors::catch_unwind(|| {
         check_pointers!(output, input);
@@ -242,7 +242,7 @@ unsafe extern fn rust_array_move_samples_from(
             std::slice::from_raw_parts(samples, samples_count)
         };
 
-        (*output).move_samples_from(&**input, samples, property_start..property_end);
+        (*output).move_samples_from(&**input, samples, properties_start..properties_end);
     })
 }
 
@@ -287,12 +287,12 @@ impl Array for ndarray::ArrayD<f64> {
         &mut self,
         input: &dyn Array,
         samples: &[mts_sample_mapping_t],
-        property: Range<usize>,
+        properties: Range<usize>,
     ) {
         use ndarray::{Axis, Slice};
 
         // -2 since we also remove one axis with `index_axis_mut` below
-        let property_axis = self.shape().len() - 2;
+        let properties_axis = self.shape().len() - 2;
 
         let input = input.as_any().downcast_ref::<ndarray::ArrayD<f64>>().expect("input must be a ndarray");
         for sample in samples {
@@ -300,7 +300,7 @@ impl Array for ndarray::ArrayD<f64> {
 
             let mut output_location = self.index_axis_mut(Axis(0), sample.output);
             let mut output_location = output_location.slice_axis_mut(
-                Axis(property_axis), Slice::from(property.clone())
+                Axis(properties_axis), Slice::from(properties.clone())
             );
 
             output_location.assign(&value);

--- a/metatensor/src/tensor.rs
+++ b/metatensor/src/tensor.rs
@@ -283,21 +283,21 @@ impl TensorMap {
     /// samples axis.
     ///
     /// The dimensions (names) of `keys_to_move` will be moved from the keys to
-    /// the sample labels, and blocks with the same remaining keys dimensions
-    /// will be merged together along the sample axis.
+    /// the samples labels, and blocks with the same remaining keys dimensions
+    /// will be merged together along the samples axis.
     ///
     /// `keys_to_move` must be empty (`keys_to_move.count() == 0`), and the new
-    /// sample labels will contain entries corresponding to the merged blocks'
+    /// samples labels will contain entries corresponding to the merged blocks'
     /// keys.
     ///
-    /// The new sample labels will contains all of the merged blocks sample
+    /// The new samples labels will contains all of the merged blocks samples
     /// labels. The order of the samples is controlled by `sort_samples`. If
     /// `sort_samples` is true, samples are re-ordered to keep them
     /// lexicographically sorted. Otherwise they are kept in the order in which
     /// they appear in the blocks.
     ///
     /// This function is only implemented if all merged block have the same
-    /// property labels.
+    /// properties labels.
     #[inline]
     pub fn keys_to_samples(&self, keys_to_move: &Labels, sort_samples: bool) -> Result<TensorMap, Error> {
         let ptr = unsafe {
@@ -313,27 +313,27 @@ impl TensorMap {
     }
 
     /// Merge blocks with the same value for selected keys dimensions along the
-    /// property axis.
+    /// properties axis.
     ///
     /// The dimensions (names) of `keys_to_move` will be moved from the keys to
-    /// the property labels, and blocks with the same remaining keys dimensions
-    /// will be merged together along the property axis.
+    /// the properties labels, and blocks with the same remaining keys
+    /// dimensions will be merged together along the properties axis.
     ///
     /// If `keys_to_move` does not contains any entries (`keys_to_move.count()
-    /// == 0`), then the new property labels will contain entries corresponding
-    /// to the merged blocks only. For example, merging a block with key `a=0`
-    /// and properties `p=1, 2` with a block with key `a=2` and properties `p=1,
-    /// 3` will produce a block with properties `a, p = (0, 1), (0, 2), (2, 1),
-    /// (2, 3)`.
+    /// == 0`), then the new properties labels will contain entries
+    /// corresponding to the merged blocks only. For example, merging a block
+    /// with key `a=0` and properties `p=1, 2` with a block with key `a=2` and
+    /// properties `p=1, 3` will produce a block with properties `a, p = (0, 1),
+    /// (0, 2), (2, 1), (2, 3)`.
     ///
-    /// If `keys_to_move` contains entries, then the property labels must be the
-    /// same for all the merged blocks. In that case, the merged property labels
-    /// will contains each of the entries of `keys_to_move` and then the current
-    /// property labels. For example, using `a=2, 3` in `keys_to_move`, and
-    /// blocks with properties `p=1, 2` will result in `a, p = (2, 1), (2, 2),
-    /// (3, 1), (3, 2)`.
+    /// If `keys_to_move` contains entries, then the properties labels must be
+    /// the same for all the merged blocks. In that case, the merged properties
+    /// labels will contains each of the entries of `keys_to_move` and then the
+    /// current properties labels. For example, using `a=2, 3` in
+    /// `keys_to_move`, and blocks with properties `p=1, 2` will result in `a, p
+    /// = (2, 1), (2, 2), (3, 1), (3, 2)`.
     ///
-    /// The new sample labels will contains all of the merged blocks sample
+    /// The new samples labels will contains all of the merged blocks samples
     /// labels. The order of the samples is controlled by `sort_samples`. If
     /// `sort_samples` is true, samples are re-ordered to keep them
     /// lexicographically sorted. Otherwise they are kept in the order in which
@@ -352,7 +352,7 @@ impl TensorMap {
         return Ok(unsafe { TensorMap::from_raw(ptr) });
     }
 
-    /// Move the given dimensions from the component labels to the property
+    /// Move the given dimensions from the components labels to the properties
     /// labels for each block in this `TensorMap`.
     #[inline]
     pub fn components_to_properties(&self, dimensions: &[&str]) -> Result<TensorMap, Error> {

--- a/metatensor/tests/components-to-properties.rs
+++ b/metatensor/tests/components-to-properties.rs
@@ -9,24 +9,24 @@ use utils::example_labels;
 fn one_component() {
     let mut block = TensorBlock::new(
         ArrayD::from_elem(vec![3, 2, 3], 1.0),
-        &example_labels(vec!["samples"], vec![[0], [1], [2]]),
-        &[example_labels(vec!["components"], vec![[0], [1]])],
-        &example_labels(vec!["properties"], vec![[0], [1], [2]]),
+        &example_labels(vec!["s"], vec![[0], [1], [2]]),
+        &[example_labels(vec!["c"], vec![[0], [1]])],
+        &example_labels(vec!["p"], vec![[0], [1], [2]]),
     ).unwrap();
 
     let gradient = TensorBlock::new(
         ArrayD::from_elem(vec![2, 2, 3], 11.0),
         &example_labels(vec!["sample", "parameter"], vec![[0, 2], [1, 2]]),
-        &[example_labels(vec!["components"], vec![[0], [1]])],
-        &example_labels(vec!["properties"], vec![[0], [1], [2]]),
+        &[example_labels(vec!["c"], vec![[0], [1]])],
+        &example_labels(vec!["p"], vec![[0], [1], [2]]),
     ).unwrap();
     block.add_gradient("parameter", gradient).unwrap();
 
     let tensor = TensorMap::new(Labels::single(), vec![block]).unwrap();
-    let tensor = tensor.components_to_properties(&["components"]).unwrap();
+    let tensor = tensor.components_to_properties(&["c"]).unwrap();
 
     let block = tensor.block_by_id(0);
-    assert_eq!(block.samples().names(), ["samples"]);
+    assert_eq!(block.samples().names(), ["s"]);
     assert_eq!(block.samples().count(), 3);
     assert_eq!(block.samples()[0], [0]);
     assert_eq!(block.samples()[1], [1]);
@@ -34,7 +34,7 @@ fn one_component() {
 
     assert_eq!(block.components().len(), 0);
 
-    assert_eq!(block.properties().names(), ["components", "properties"]);
+    assert_eq!(block.properties().names(), ["c", "p"]);
     assert_eq!(block.properties().count(), 6);
     assert_eq!(block.properties()[0], [0, 0]);
     assert_eq!(block.properties()[1], [0, 1]);
@@ -62,14 +62,14 @@ fn multiple_components() {
     ]).unwrap();
 
     let components = [
-        example_labels(vec!["component_1"], vec![[0], [1]]),
-        example_labels(vec!["component_2"], vec![[0], [1], [2]]),
+        example_labels(vec!["c1"], vec![[0], [1]]),
+        example_labels(vec!["c2"], vec![[0], [1], [2]]),
     ];
-    let properties = example_labels(vec!["properties"], vec![[0], [1]]);
+    let properties = example_labels(vec!["p"], vec![[0], [1]]);
 
     let mut block = TensorBlock::new(
         data,
-        &example_labels(vec!["samples"], vec![[0], [1]]),
+        &example_labels(vec!["s"], vec![[0], [1]]),
         &components,
         &properties,
     ).unwrap();
@@ -84,22 +84,22 @@ fn multiple_components() {
     block.add_gradient("parameter", gradient).unwrap();
 
     let tensor = TensorMap::new(Labels::single(), vec![block]).unwrap();
-    let tensor = tensor.components_to_properties(&["component_1"]).unwrap();
+    let tensor = tensor.components_to_properties(&["c1"]).unwrap();
 
     let block = tensor.block_by_id(0);
-    assert_eq!(block.samples().names(), ["samples"]);
+    assert_eq!(block.samples().names(), ["s"]);
     assert_eq!(block.samples().count(), 2);
     assert_eq!(block.samples()[0], [0]);
     assert_eq!(block.samples()[1], [1]);
 
     assert_eq!(block.components().len(), 1);
-    assert_eq!(block.components()[0].names(), ["component_2"]);
+    assert_eq!(block.components()[0].names(), ["c2"]);
     assert_eq!(block.components()[0].count(), 3);
     assert_eq!(block.components()[0][0], [0]);
     assert_eq!(block.components()[0][1], [1]);
     assert_eq!(block.components()[0][2], [2]);
 
-    assert_eq!(block.properties().names(), ["component_1", "properties"]);
+    assert_eq!(block.properties().names(), ["c1", "p"]);
     assert_eq!(block.properties().count(), 4);
     assert_eq!(block.properties()[0], [0, 0]);
     assert_eq!(block.properties()[1], [0, 1]);

--- a/metatensor/tests/keys-to-properties.rs
+++ b/metatensor/tests/keys-to-properties.rs
@@ -95,7 +95,7 @@ fn user_provided_entries_different_properties() {
     assert_eq!(
         result.unwrap_err().message,
         "invalid parameter: can not provide values for the keys to move to \
-        properties if the blocks have different property labels"
+        properties if the blocks have different properties labels"
     );
 }
 
@@ -263,7 +263,7 @@ fn user_provided_entries() {
     ]).unwrap();
     assert_eq!(block.values().as_array(), expected);
 
-    // second block also contains the new property chanel even if it was not
+    // second block also contains the new properties channel even if it was not
     // merged with another block
     let block = tensor.block_by_id(1);
     let expected = ArrayD::from_shape_vec(vec![3, 1, 8], vec![

--- a/metatensor/tests/utils/mod.rs
+++ b/metatensor/tests/utils/mod.rs
@@ -57,7 +57,7 @@ pub fn example_tensor() -> TensorMap {
         /* gradient_values  */ 11.0,
     );
 
-    // different property size
+    // different properties size
     let block_2 = example_block(
         /* samples          */ vec![[0], [1], [3]],
         /* components       */ vec![[0]],

--- a/python/metatensor-core/metatensor/block.py
+++ b/python/metatensor-core/metatensor/block.py
@@ -26,7 +26,7 @@ class TensorBlock:
     A block can also contain gradients of the values with respect to a variety
     of parameters. In this case, each gradient is a :py:class:`TensorBlock` with
     a separate set of samples and possibly components, but which shares the same
-    property labels as the original :py:class:`TensorBlock`.
+    properties labels as the original :py:class:`TensorBlock`.
     """
 
     def __init__(
@@ -192,7 +192,7 @@ class TensorBlock:
     @property
     def samples(self) -> Labels:
         """
-        Get the sample :py:class:`Labels` for this block.
+        Get the samples :py:class:`Labels` for this block.
 
         The entries in these labels describe the first dimension of the
         ``values`` array.
@@ -218,14 +218,14 @@ class TensorBlock:
     @property
     def properties(self) -> Labels:
         """
-        Get the property :py:class:`Labels` for this block.
+        Get the properties :py:class:`Labels` for this block.
 
         The entries in these labels describe the last dimension of the
         ``values`` array. The properties are guaranteed to be the same for
         values and gradients in the same block.
         """
-        property_axis = len(self.values.shape) - 1
-        return self._labels(property_axis)
+        properties_axis = len(self.values.shape) - 1
+        return self._labels(properties_axis)
 
     def _labels(self, axis) -> Labels:
         result = mts_labels_t()
@@ -244,18 +244,18 @@ class TensorBlock:
         >>> from metatensor import Labels, TensorBlock
         >>> block = TensorBlock(
         ...     values=np.full((3, 1, 5), 1.0),
-        ...     samples=Labels(["structure"], np.array([[0], [2], [4]])),
-        ...     components=[Labels.range("component", 1)],
-        ...     properties=Labels.range("property", 5),
+        ...     samples=Labels(["s"], np.array([[0], [2], [4]])),
+        ...     components=[Labels.range("c", 1)],
+        ...     properties=Labels.range("p", 5),
         ... )
         >>> positions_gradient = TensorBlock(
         ...     values=np.full((2, 3, 1, 5), 11.0),
         ...     samples=Labels(["sample", "atom"], np.array([[0, 2], [2, 3]])),
         ...     components=[
         ...         Labels.range("direction", 3),
-        ...         Labels.range("component", 1),
+        ...         Labels.range("c", 1),
         ...     ],
-        ...     properties=Labels.range("property", 5),
+        ...     properties=Labels.range("p", 5),
         ... )
 
         >>> block.add_gradient("positions", positions_gradient)
@@ -265,9 +265,9 @@ class TensorBlock:
         ...     components=[
         ...         Labels.range("direction_1", 3),
         ...         Labels.range("direction_2", 3),
-        ...         Labels.range("component", 1),
+        ...         Labels.range("c", 1),
         ...     ],
-        ...     properties=Labels.range("property", 5),
+        ...     properties=Labels.range("p", 5),
         ... )
         >>> block.add_gradient("cell", cell_gradient)
 
@@ -275,16 +275,16 @@ class TensorBlock:
         >>> print(positions_gradient)
         Gradient TensorBlock ('positions')
             samples (2): ['sample', 'atom']
-            components (3, 1): ['direction', 'component']
-            properties (5): ['property']
+            components (3, 1): ['direction', 'c']
+            properties (5): ['p']
             gradients: None
 
         >>> cell_gradient = block.gradient("cell")
         >>> print(cell_gradient)
         Gradient TensorBlock ('cell')
             samples (2): ['sample']
-            components (3, 3, 1): ['direction_1', 'direction_2', 'component']
-            properties (5): ['property']
+            components (3, 3, 1): ['direction_1', 'direction_2', 'c']
+            properties (5): ['p']
             gradients: None
         """
         gradient_block = ctypes.POINTER(mts_block_t)()
@@ -324,22 +324,22 @@ class TensorBlock:
         >>> from metatensor import Labels, TensorBlock
         >>> block = TensorBlock(
         ...     values=np.full((3, 1, 1), 1.0),
-        ...     samples=Labels(["structure"], np.array([[0], [2], [4]])),
-        ...     components=[Labels.range("component", 1)],
-        ...     properties=Labels.range("property", 1),
+        ...     samples=Labels(["s"], np.array([[0], [2], [4]])),
+        ...     components=[Labels.range("c", 1)],
+        ...     properties=Labels.range("p", 1),
         ... )
         >>> gradient = TensorBlock(
         ...     values=np.full((2, 1, 1), 11.0),
         ...     samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
-        ...     components=[Labels.range("component", 1)],
-        ...     properties=Labels.range("property", 1),
+        ...     components=[Labels.range("c", 1)],
+        ...     properties=Labels.range("p", 1),
         ... )
         >>> block.add_gradient("parameter", gradient)
         >>> print(block)
         TensorBlock
-            samples (3): ['structure']
-            components (1): ['component']
-            properties (1): ['property']
+            samples (3): ['s']
+            components (1): ['c']
+            properties (1): ['p']
             gradients: ['parameter']
         """
         if self._parent is not None:

--- a/python/metatensor-core/metatensor/data/array.py
+++ b/python/metatensor-core/metatensor/data/array.py
@@ -219,8 +219,8 @@ def _mts_array_move_samples_from(
     input,
     samples_ptr,
     samples_count,
-    property_start,
-    property_end,
+    properties_start,
+    properties_end,
 ):
     output = _object_from_ptr(this).array
     input = _object_from_ptr(input).array
@@ -231,5 +231,5 @@ def _mts_array_move_samples_from(
         input_samples.append(samples_ptr[i].input)
         output_samples.append(samples_ptr[i].output)
 
-    properties = slice(property_start, property_end)
+    properties = slice(properties_start, properties_end)
     output[output_samples, ..., properties] = input[input_samples, ..., :]

--- a/python/metatensor-core/metatensor/tensor.py
+++ b/python/metatensor-core/metatensor/tensor.py
@@ -291,24 +291,24 @@ class TensorMap:
         >>> keys = Labels(["key_1", "key_2"], np.array([[0, 0], [6, 8]]))
         >>> block_1 = TensorBlock(
         ...     values=np.full((3, 5), 1.0),
-        ...     samples=Labels.range("sample", 3),
+        ...     samples=Labels.range("s", 3),
         ...     components=[],
-        ...     properties=Labels.range("property", 5),
+        ...     properties=Labels.range("p", 5),
         ... )
         >>> block_2 = TensorBlock(
         ...     values=np.full((5, 3), 2.0),
-        ...     samples=Labels.range("sample", 5),
+        ...     samples=Labels.range("s", 5),
         ...     components=[],
-        ...     properties=Labels.range("property", 3),
+        ...     properties=Labels.range("p", 3),
         ... )
         >>> tensor = TensorMap(keys, [block_1, block_2])
         >>> # numeric index selection, this gives a block by its position
         >>> block = tensor.block(0)
         >>> block
         TensorBlock
-            samples (3): ['sample']
+            samples (3): ['s']
             components (): []
-            properties (5): ['property']
+            properties (5): ['p']
             gradients: None
         >>> # This is the first block
         >>> block.values.mean()
@@ -456,7 +456,7 @@ class TensorMap:
         self, dimensions: Union[str, Sequence[str]]
     ) -> "TensorMap":
         """
-        Move the given ``dimensions`` from the component labels to the property labels
+        Move the given ``dimensions`` from the component labels to the properties labels
         for each block.
 
         :param dimensions: name of the component dimensions to move to the properties
@@ -482,7 +482,7 @@ class TensorMap:
         with the same remaining keys values. Then it will merge these blocks along the
         properties direction (i.e. do an *horizontal* concatenation).
 
-        If ``keys_to_move`` is given as strings, then the new property labels will
+        If ``keys_to_move`` is given as strings, then the new properties labels will
         **only** contain entries from the existing blocks. For example, merging a block
         with key ``a=0`` and properties ``p=1, 2`` with a block with key ``a=2`` and
         properties ``p=1, 3`` will produce a block with properties ``a, p = (0, 1), (0,

--- a/python/metatensor-operations/metatensor/operations/_utils.py
+++ b/python/metatensor-operations/metatensor/operations/_utils.py
@@ -167,7 +167,7 @@ def _check_blocks_impl(
                     )
         else:
             raise ValueError(
-                f"{metadata} is not a valid property to check, "
+                f"{metadata} is not a valid set of labels to check, "
                 "choose from 'samples', 'properties' and 'components'"
             )
     return ""
@@ -305,7 +305,7 @@ def _check_same_gradients_impl(
                         return err_msg + err_msg_1
             else:
                 raise ValueError(
-                    f"{metadata} is not a valid property to check, "
+                    f"{metadata} is not a valid set of labels to check, "
                     "choose from 'samples', 'properties' and 'components'"
                 )
     return ""

--- a/python/metatensor-operations/metatensor/operations/allclose.py
+++ b/python/metatensor-operations/metatensor/operations/allclose.py
@@ -372,17 +372,9 @@ def allclose_block(
     ...             [3, 5, 6],
     ...         ]
     ...     ),
-    ...     samples=Labels(
-    ...         ["structure", "center"],
-    ...         np.array(
-    ...             [
-    ...                 [0, 0],
-    ...                 [0, 1],
-    ...             ]
-    ...         ),
-    ...     ),
+    ...     samples=Labels.range("s", 2),
     ...     components=[],
-    ...     properties=Labels(["property_1"], np.array([[0], [1], [2]])),
+    ...     properties=Labels.range("p", 3),
     ... )
 
     Recreate ``block_1``, but change first value in the block from ``1`` to ``1.00001``.
@@ -394,17 +386,9 @@ def allclose_block(
     ...             [3, 5, 6],
     ...         ]
     ...     ),
-    ...     samples=Labels(
-    ...         ["structure", "center"],
-    ...         np.array(
-    ...             [
-    ...                 [0, 0],
-    ...                 [0, 1],
-    ...             ]
-    ...         ),
-    ...     ),
+    ...     samples=Labels.range("s", 2),
     ...     components=[],
-    ...     properties=Labels(["property_1"], np.array([[0], [1], [2]])),
+    ...     properties=Labels.range("p", 3),
     ... )
 
     Call :py:func:`metatensor.allclose_block()`, which should return :py:obj:`False`
@@ -466,17 +450,9 @@ def allclose_block_raise(
     ...             [3, 5, 6],
     ...         ]
     ...     ),
-    ...     samples=Labels(
-    ...         ["structure", "center"],
-    ...         np.array(
-    ...             [
-    ...                 [0, 0],
-    ...                 [0, 1],
-    ...             ]
-    ...         ),
-    ...     ),
+    ...     samples=Labels.range("s", 2),
     ...     components=[],
-    ...     properties=Labels(["property_1"], np.array([[0], [1], [2]])),
+    ...     properties=Labels.range("property_1", 3),
     ... )
 
     Recreate ``block_1``, but rename properties label ``'property_1'`` to
@@ -489,17 +465,9 @@ def allclose_block_raise(
     ...             [3, 5, 6],
     ...         ]
     ...     ),
-    ...     samples=Labels(
-    ...         ["structure", "center"],
-    ...         np.array(
-    ...             [
-    ...                 [0, 0],
-    ...                 [0, 1],
-    ...             ]
-    ...         ),
-    ...     ),
+    ...     samples=Labels.range("s", 2),
     ...     components=[],
-    ...     properties=Labels(["property_2"], np.array([[0], [1], [2]])),
+    ...     properties=Labels.range("property_2", 3),
     ... )
 
     Call :py:func:`metatensor.allclose_block_raise()`, which should raise

--- a/python/metatensor-operations/metatensor/operations/empty_like.py
+++ b/python/metatensor-operations/metatensor/operations/empty_like.py
@@ -36,16 +36,16 @@ def empty_like(
 
     >>> block = TensorBlock(
     ...     values=np.random.rand(4, 3),
-    ...     samples=Labels.range("sample", 4),
+    ...     samples=Labels.range("s", 4),
     ...     components=[],
-    ...     properties=Labels.range("property", 3),
+    ...     properties=Labels.range("p", 3),
     ... )
     >>> block.add_gradient(
     ...     parameter="alpha",
     ...     gradient=TensorBlock(
     ...         values=np.random.rand(2, 3, 3),
-    ...         samples=Labels(["sample", "atom"], np.array([[0, 0], [0, 2]])),
-    ...         components=[Labels.range("component", 3)],
+    ...         samples=Labels(["sample", "alpha"], np.array([[0, 0], [0, 2]])),
+    ...         components=[Labels.range("c", 3)],
     ...         properties=block.properties,
     ...     ),
     ... )
@@ -62,9 +62,9 @@ def empty_like(
     >>> tensor = TensorMap(keys, [block])
     >>> print(tensor.block(0))
     TensorBlock
-        samples (4): ['sample']
+        samples (4): ['s']
         components (): []
-        properties (3): ['property']
+        properties (3): ['p']
         gradients: ['alpha', 'beta']
 
     Then we use ``empty_like`` to create a :py:class:`TensorMap` with the same
@@ -73,9 +73,9 @@ def empty_like(
     >>> tensor_empty = metatensor.empty_like(tensor)
     >>> print(tensor_empty.block(0))
     TensorBlock
-        samples (4): ['sample']
+        samples (4): ['s']
         components (): []
-        properties (3): ['property']
+        properties (3): ['p']
         gradients: ['alpha', 'beta']
 
     Note that if we copy just the gradient ``alpha``, ``beta`` is no longer

--- a/python/metatensor-operations/metatensor/operations/join.py
+++ b/python/metatensor-operations/metatensor/operations/join.py
@@ -243,7 +243,7 @@ def join(
             "either 'error', 'intersection' or 'union'."
         )
 
-    # Deduce if sample/property names are the same in all tensors.
+    # Deduce if samples/properties names are the same in all tensors.
     # If this is not the case we have to change unify the corresponding labels later.
     if axis == "samples":
         names_list = [tensor.samples_names for tensor in tensors]
@@ -263,11 +263,11 @@ def join(
     length_equal = [len(unique_names) == len(names) for names in names_list]
     names_are_same = sum(length_equal) == len(length_equal)
 
-    # It's fine to lose metadata on the property axis, less so on the sample axis!
+    # It's fine to lose metadata on the property axis, less so on the samples axis!
     if axis == "samples" and not names_are_same:
         raise ValueError(
-            "Sample names are not the same! Joining along samples with different "
-            "sample names will loose information and is not supported."
+            "Samples names are not the same! Joining along samples with different "
+            "samples names will loose information and is not supported."
         )
 
     keys = tensors[0].keys

--- a/python/metatensor-operations/metatensor/operations/ones_like.py
+++ b/python/metatensor-operations/metatensor/operations/ones_like.py
@@ -36,16 +36,16 @@ def ones_like(
 
     >>> block = TensorBlock(
     ...     values=np.random.rand(4, 3),
-    ...     samples=Labels.range("sample", 4),
+    ...     samples=Labels.range("s", 4),
     ...     components=[],
-    ...     properties=Labels.range("property", 3),
+    ...     properties=Labels.range("p", 3),
     ... )
     >>> block.add_gradient(
     ...     parameter="alpha",
     ...     gradient=TensorBlock(
     ...         values=np.random.rand(2, 3, 3),
-    ...         samples=Labels(["sample", "atom"], np.array([[0, 0], [0, 2]])),
-    ...         components=[Labels.range("component", 3)],
+    ...         samples=Labels(["sample", "alpha"], np.array([[0, 0], [0, 2]])),
+    ...         components=[Labels.range("c", 3)],
     ...         properties=block.properties,
     ...     ),
     ... )
@@ -53,7 +53,7 @@ def ones_like(
     ...     parameter="beta",
     ...     gradient=TensorBlock(
     ...         values=np.random.rand(1, 3),
-    ...         samples=Labels(["sample"], np.array([[0]])),
+    ...         samples=Labels.range("sample", 1),
     ...         components=[],
     ...         properties=block.properties,
     ...     ),
@@ -62,9 +62,9 @@ def ones_like(
     >>> tensor = TensorMap(keys, [block])
     >>> print(tensor.block(0))
     TensorBlock
-        samples (4): ['sample']
+        samples (4): ['s']
         components (): []
-        properties (3): ['property']
+        properties (3): ['p']
         gradients: ['alpha', 'beta']
 
     Then we use ``ones_like`` to create a :py:class:`TensorMap` with the same
@@ -73,9 +73,9 @@ def ones_like(
     >>> tensor_ones = metatensor.ones_like(tensor)
     >>> print(tensor_ones.block(0))
     TensorBlock
-        samples (4): ['sample']
+        samples (4): ['s']
         components (): []
-        properties (3): ['property']
+        properties (3): ['p']
         gradients: ['alpha', 'beta']
     >>> print(tensor_ones.block(0).values)
     [[1. 1. 1.]

--- a/python/metatensor-operations/metatensor/operations/random_like.py
+++ b/python/metatensor-operations/metatensor/operations/random_like.py
@@ -37,16 +37,16 @@ def random_uniform_like(
 
     >>> block = TensorBlock(
     ...     values=np.random.rand(4, 3),
-    ...     samples=Labels.range("sample", 4),
+    ...     samples=Labels.range("s", 4),
     ...     components=[],
-    ...     properties=Labels.range("property", 3),
+    ...     properties=Labels.range("p", 3),
     ... )
     >>> block.add_gradient(
     ...     parameter="alpha",
     ...     gradient=TensorBlock(
     ...         values=np.random.rand(2, 3, 3),
-    ...         samples=Labels(["sample", "atom"], np.array([[0, 0], [0, 2]])),
-    ...         components=[Labels.range("component", 3)],
+    ...         samples=Labels(["sample", "alpha"], np.array([[0, 0], [0, 2]])),
+    ...         components=[Labels.range("c", 3)],
     ...         properties=block.properties,
     ...     ),
     ... )
@@ -63,9 +63,9 @@ def random_uniform_like(
     >>> tensor = TensorMap(keys, [block])
     >>> print(tensor.block(0))
     TensorBlock
-        samples (4): ['sample']
+        samples (4): ['s']
         components (): []
-        properties (3): ['property']
+        properties (3): ['p']
         gradients: ['alpha', 'beta']
 
     Then we use ``random_uniform_like`` to create a :py:class:`TensorMap` with
@@ -75,9 +75,9 @@ def random_uniform_like(
     >>> tensor_random = metatensor.random_uniform_like(tensor)
     >>> print(tensor_random.block(0))
     TensorBlock
-        samples (4): ['sample']
+        samples (4): ['s']
         components (): []
-        properties (3): ['property']
+        properties (3): ['p']
         gradients: ['alpha', 'beta']
     >>> print(tensor_random.block(0).values)
     [[0.53316528 0.69187711 0.31551563]

--- a/python/metatensor-operations/metatensor/operations/reduce_over_samples.py
+++ b/python/metatensor-operations/metatensor/operations/reduce_over_samples.py
@@ -2,14 +2,14 @@
 Reduction over samples
 ======================
 
-These functions allow to reduce over the sample indices of a :py:class:`TensorMap` or
+These functions allow to reduce over the samples indices of a :py:class:`TensorMap` or
 :py:class:`TensorBlock` objects, generating a new :py:class:`TensorMap` or
 :py:class:`TensorBlock` in which the values sharing the same indices for the indicated
 ``samples_names`` have been combined in a single entry. The functions differ by the type
 of reduction operation, but otherwise operate in the same way. The reduction operation
 loops over the samples in each block/map, and combines all those that only differ by the
 values of the indices associated with the names listed in the ``samples_names``
-argument. One way to see these operations is that the sample indices describe the
+argument. One way to see these operations is that the samples indices describe the
 non-zero entries in a *sparse* array, and the reduction acts much like
 :func:`numpy.sum`, where ``samples_names`` plays the same role as the ``axis`` argument.
 Whenever gradients are present, the reduction is performed also on the gradients.
@@ -104,12 +104,10 @@ def _reduce_over_samples_block(
         assert sample in block_samples.names
 
     assert reduction in ["sum", "mean", "var", "std"]
-    # get the indices of the selected sample
-    sample_selected = [
-        block_samples.names.index(sample) for sample in remaining_samples_names
-    ]
+    # get the indices of the selected samples
+    samples_selected = [block_samples.names.index(s) for s in remaining_samples_names]
 
-    # checks if it is a zero sample TensorBlock
+    # checks if it is a zero samples TensorBlock
     if len(block.samples) == 0:
         # Here is different from the general case where we use Labels.single() if
         # if len(remaining_samples_names) == 0
@@ -152,7 +150,7 @@ def _reduce_over_samples_block(
 
     # get which samples will still be there after reduction
     new_samples, index = _dispatch.unique_with_inverse(
-        block_samples.values[:, sample_selected], axis=0
+        block_samples.values[:, samples_selected], axis=0
     )
 
     block_values = block.values
@@ -308,7 +306,7 @@ def _reduce_over_samples_block(
                             gradient_values_result[i], nan=0.0, posinf=0.0, neginf=0.0
                         )
 
-        # no check for the len of the gradient sample is needed because there
+        # no check for the len of the gradient samples is needed because there
         # always will be at least one sample in the gradient
         result_block.add_gradient(
             parameter=parameter,
@@ -347,7 +345,7 @@ def _reduce_over_samples(
     for sample in samples_names_list:
         if sample not in tensor.samples_names:
             raise ValueError(
-                f"one of the requested sample name ({sample}) is not part of "
+                f"one of the requested samples name ({sample}) is not part of "
                 "this TensorMap"
             )
 
@@ -381,7 +379,7 @@ def sum_over_samples_block(
 
     ``samples_names`` indicates over which dimensions in the samples the sum is
     performed. It accept either a single string or a list of the string with the
-    sample names corresponding to the directions along which the sum is
+    samples names corresponding to the directions along which the sum is
     performed. A single string is equivalent to a list with a single element:
     ``samples_names = "center"`` is the same as ``samples_names = ["center"]``.
 
@@ -391,7 +389,7 @@ def sum_over_samples_block(
         names of samples to sum over
 
     :returns:
-        a :py:class:`TensorBlock` containing the reduced values and sample labels
+        a :py:class:`TensorBlock` containing the reduced values and samples labels
 
     >>> from metatensor import Labels, TensorBlock, TensorMap
     >>> block = TensorBlock(
@@ -448,7 +446,7 @@ def sum_over_samples(
 
     ``samples_names`` indicates over which dimensions in the samples the sum is
     performed. It accept either a single string or a list of the string with the
-    sample names corresponding to the directions along which the sum is
+    samples names corresponding to the directions along which the sum is
     performed. A single string is equivalent to a list with a single element:
     ``samples_names = "center"`` is the same as ``samples_names = ["center"]``.
 
@@ -458,7 +456,7 @@ def sum_over_samples(
         names of samples to sum over
 
     :returns:
-        a :py:class:`TensorMap` containing the reduced values and sample labels
+        a :py:class:`TensorMap` containing the reduced values and samples labels
 
     >>> from metatensor import Labels, TensorBlock, TensorMap
     >>> block = TensorBlock(
@@ -487,7 +485,7 @@ def sum_over_samples(
     >>> keys = Labels(names=["key"], values=np.array([[0]]))
     >>> tensor = TensorMap(keys, [block])
     >>> tensor_sum = sum_over_samples(tensor, samples_names="center")
-    >>> # only 'structure' is left as a sample
+    >>> # only 'structure' is left in the samples dimensions
     >>> print(tensor_sum.block(0))
     TensorBlock
         samples (2): ['structure']
@@ -524,7 +522,7 @@ def mean_over_samples_block(
         names of samples to average over
 
     :returns:
-        a :py:class:`TensorBlock` containing the reduced values and sample labels
+        a :py:class:`TensorBlock` containing the reduced values and samples labels
     """
 
     return _reduce_over_samples_block(
@@ -545,7 +543,7 @@ def mean_over_samples(
 
     ``samples_names`` indicates over which dimensions in the samples the mean is
     performed. It accept either a single string or a list of the string with the
-    sample names corresponding to the directions along which the mean is performed.
+    samples names corresponding to the directions along which the mean is performed.
     A single string is equivalent to a list with a single element:
     ``samples_names = "center"`` is the same as ``samples_names = ["center"]``.
 
@@ -574,7 +572,7 @@ def std_over_samples_block(
         names of samples to compute the standard deviation for
 
     :returns:
-        a :py:class:`TensorBlock` containing the reduced values and sample labels
+        a :py:class:`TensorBlock` containing the reduced values and samples labels
     """
 
     return _reduce_over_samples_block(
@@ -595,7 +593,7 @@ def std_over_samples(
 
     ``samples_names`` indicates over which dimensions in the samples the mean is
     performed. It accept either a single string or a list of the string with the
-    sample names corresponding to the directions along which the mean is performed.
+    samples names corresponding to the directions along which the mean is performed.
     A single string is equivalent to a list with a single element:
     ``samples_names = "center"`` is the same as ``samples_names = ["center"]``.
 
@@ -631,7 +629,7 @@ def var_over_samples_block(
         names of samples to compute the variance for
 
     :returns:
-        a :py:class:`TensorBlock` containing the reduced values and sample labels
+        a :py:class:`TensorBlock` containing the reduced values and samples labels
     """
 
     return _reduce_over_samples_block(
@@ -652,7 +650,7 @@ def var_over_samples(
 
     ``samples_names`` indicates over which dimensions in the samples the mean is
     performed. It accept either a single string or a list of the string with the
-    sample names corresponding to the directions along which the mean is performed.
+    samples names corresponding to the directions along which the mean is performed.
     A single string is equivalent to a list with a single element:
     ``samples_names = "center"`` is the same as ``samples_names = ["center"]``.
 

--- a/python/metatensor-operations/metatensor/operations/slice.py
+++ b/python/metatensor-operations/metatensor/operations/slice.py
@@ -205,19 +205,19 @@ def _slice_block(block: TensorBlock, axis: str, labels: Labels) -> TensorBlock:
             properties=block.properties,
         )
 
-        # Create a map from the previous samples indexes to the new sample indexes
-        # to update the gradient samples
+        # Create a map from the previous samples indexes to the
+        # new samples indexes to update the gradient samples
 
-        # sample_map contains at position old_sample the index of the
+        # samples_map contains at position old_sample the index of the
         # corresponding new sample
-        sample_map = _dispatch.int_array_like(
+        samples_map = _dispatch.int_array_like(
             int_list=[-1] * len(samples_mask),
             like=samples_mask,
         )
         last = 0
         for i, picked in enumerate(samples_mask):
             if picked:
-                sample_map[i] = last
+                samples_map[i] = last
                 last += 1
 
         for parameter, gradient in block.gradients():
@@ -233,7 +233,7 @@ def _slice_block(block: TensorBlock, axis: str, labels: Labels) -> TensorBlock:
             if new_grad_samples_values.shape[0] != 0:
                 # update the "sample" column of the gradient samples
                 # to refer to the new samples
-                new_grad_samples_values[:, 0] = sample_map[
+                new_grad_samples_values[:, 0] = samples_map[
                     new_grad_samples_values[:, 0]
                 ]
 
@@ -334,7 +334,7 @@ def _check_args(
         for name in labels.names:
             if name not in s_names:
                 raise ValueError(
-                    f"invalid sample name '{name}' which is not part of the input"
+                    f"invalid samples name '{name}' which is not part of the input"
                 )
     else:
         assert axis == "properties"
@@ -342,5 +342,5 @@ def _check_args(
         for name in labels.names:
             if name not in p_names:
                 raise ValueError(
-                    f"invalid property name '{name}' which is not part of the input"
+                    f"invalid properties name '{name}' which is not part of the input"
                 )

--- a/python/metatensor-operations/metatensor/operations/solve.py
+++ b/python/metatensor-operations/metatensor/operations/solve.py
@@ -8,19 +8,16 @@ from ._utils import _check_same_gradients_raise, _check_same_keys_raise
 def solve(X: TensorMap, Y: TensorMap) -> TensorMap:
     """Solve a linear system among two :py:class:`TensorMap`.
 
-    Solve the linear equation set
-    ``Y = X * w`` for the unknown ``w``.
-    Where ``Y``, ``X`` and ``w`` are all :py:class:`TensorMap`.
-    ``Y`` and ``X`` must have the same ``keys`` and
-    all their :py:class:`TensorBlock` must be 2D-square array.
+    Solve the linear equation set ``Y = X * w`` for the unknown ``w``. Where ``Y``,
+    ``X`` and ``w`` are all :py:class:`TensorMap`. ``Y`` and ``X`` must have the same
+    ``keys`` and all their :py:class:`TensorBlock` must be 2D-square array.
 
     :param X: a :py:class:`TensorMap` containing the "coefficient" matrices.
     :param Y: a :py:class:`TensorMap` containing the "dependent variable" values.
 
-    :return: a :py:class:`TensorMap` with the same keys of ``Y`` and ``X``,
-            and where each :py:class:`TensorBlock` has: the ``sample``
-            equal to the ``properties`` of ``Y``;
-            and the ``properties`` equal to the ``properties`` of ``X``.
+    :return: a :py:class:`TensorMap` with the same keys of ``Y`` and ``X``, and where
+        each :py:class:`TensorBlock` has its ``samples`` equal to the ``properties`` of
+        ``Y``; and its ``properties`` equal to the ``properties`` of ``X``.
 
 
     >>> import numpy as np
@@ -39,9 +36,9 @@ def solve(X: TensorMap, Y: TensorMap) -> TensorMap:
     ...     keys=Labels(names=["dummy"], values=np.array([[0]])),
     ...     blocks=[
     ...         TensorBlock(
-    ...             samples=Labels.range("sample", 2),
+    ...             samples=Labels.range("s", 2),
     ...             components=[],
-    ...             properties=Labels.range("properties_for_regression", 2),
+    ...             properties=Labels.range("features", 2),
     ...             values=covariance,
     ...         )
     ...     ],
@@ -50,9 +47,9 @@ def solve(X: TensorMap, Y: TensorMap) -> TensorMap:
     ...     keys=Labels(names=["dummy"], values=np.array([[0]])),
     ...     blocks=[
     ...         TensorBlock(
-    ...             samples=Labels.range("sample", 2),
+    ...             samples=Labels.range("s", 2),
     ...             components=[],
-    ...             properties=Labels.range("property_to_regress", 1),
+    ...             properties=Labels.range("target", 1),
     ...             values=y_regression,
     ...         )
     ...     ],
@@ -60,9 +57,9 @@ def solve(X: TensorMap, Y: TensorMap) -> TensorMap:
     >>> c = metatensor.solve(X, y)
     >>> print(c.block())
     TensorBlock
-        samples (1): ['property_to_regress']
+        samples (1): ['target']
         components (): []
-        properties (2): ['properties_for_regression']
+        properties (2): ['features']
         gradients: None
     >>> # c should now be close to true_c
     >>> print(c.block().values)

--- a/python/metatensor-operations/metatensor/operations/zeros_like.py
+++ b/python/metatensor-operations/metatensor/operations/zeros_like.py
@@ -36,16 +36,16 @@ def zeros_like(
 
     >>> block = TensorBlock(
     ...     values=np.random.rand(4, 3),
-    ...     samples=Labels.range("sample", 4),
+    ...     samples=Labels.range("s", 4),
     ...     components=[],
-    ...     properties=Labels.range("property", 3),
+    ...     properties=Labels.range("p", 3),
     ... )
     >>> block.add_gradient(
     ...     parameter="alpha",
     ...     gradient=TensorBlock(
     ...         values=np.random.rand(2, 3, 3),
-    ...         samples=Labels(["sample", "atom"], np.array([[0, 0], [0, 2]])),
-    ...         components=[Labels.range("component", 3)],
+    ...         samples=Labels(["sample", "alpha"], np.array([[0, 0], [0, 2]])),
+    ...         components=[Labels.range("c", 3)],
     ...         properties=block.properties,
     ...     ),
     ... )
@@ -62,9 +62,9 @@ def zeros_like(
     >>> tensor = TensorMap(keys, [block])
     >>> print(tensor.block(0))
     TensorBlock
-        samples (4): ['sample']
+        samples (4): ['s']
         components (): []
-        properties (3): ['property']
+        properties (3): ['p']
         gradients: ['alpha', 'beta']
 
     Then we use ``zeros_like`` to create a :py:class:`TensorMap` with
@@ -73,9 +73,9 @@ def zeros_like(
     >>> tensor_zeros = metatensor.zeros_like(tensor)
     >>> print(tensor_zeros.block(0))
     TensorBlock
-        samples (4): ['sample']
+        samples (4): ['s']
         components (): []
-        properties (3): ['property']
+        properties (3): ['p']
         gradients: ['alpha', 'beta']
     >>> print(tensor_zeros.block(0).values)
     [[0. 0. 0.]

--- a/python/metatensor-operations/tests/equal_metadata.py
+++ b/python/metatensor-operations/tests/equal_metadata.py
@@ -198,7 +198,7 @@ def test_single_nonexisting_meta(test_tensor_map_1):
     # wrong metadata key alone
     wrong_meta = "species"
     error_message = (
-        "species is not a valid property to check, choose from "
+        "species is not a valid set of labels to check, choose from "
         "'samples', 'properties' and 'components'"
     )
 
@@ -224,7 +224,7 @@ def test_single_nonexisting_meta_block(test_tensor_block_1):
     # wrong metadata key alone
     wrong_meta = "species"
     error_message = (
-        "species is not a valid property to check, choose from "
+        "species is not a valid set of labels to check, choose from "
         "'samples', 'properties' and 'components'"
     )
     with pytest.raises(ValueError, match=error_message):

--- a/python/metatensor-operations/tests/join.py
+++ b/python/metatensor-operations/tests/join.py
@@ -85,11 +85,11 @@ def test_join_properties_metadata(tensor):
 
     joined_tensor = metatensor.join([tensor, tensor, tensor], axis="properties")
 
-    # test property names
+    # test properties names
     names = tensor.block(0).properties.names
     assert joined_tensor.block(0).properties.names == ["tensor"] + names
 
-    # test property values
+    # test properties values
     tensor_prop = np.unique(joined_tensor.block(0).properties["tensor"])
     assert set(tensor_prop) == set((0, 1, 2))
 
@@ -101,11 +101,11 @@ def test_join_properties_metadata(tensor):
 
 def test_join_properties_values(tensor):
     """Test values for joining along `properties`"""
-    first_property = Labels(
+    first_properties = Labels(
         tensor[0].properties.names,
         tensor[0].properties.values[:1],
     )
-    slice_1 = metatensor.slice(tensor, axis="properties", labels=first_property)
+    slice_1 = metatensor.slice(tensor, axis="properties", labels=first_properties)
 
     other_properties = Labels(
         tensor[0].properties.names,
@@ -132,11 +132,11 @@ def test_join_properties_with_same_properties_names(tensor):
 
     joined_tensor = metatensor.join([tensor, tensor, tensor], axis="properties")
 
-    # test property names
+    # test properties names
     names = tensor.block(0).properties.names
     assert joined_tensor.block(0).properties.names == ["tensor"] + names
 
-    # test property values
+    # test properties values
     tensor_prop = np.unique(joined_tensor.block(0).properties["tensor"])
     assert set(tensor_prop) == set((0, 1, 2))
 
@@ -259,7 +259,7 @@ def test_join_samples_with_different_samples_names():
         ],
     )
 
-    with pytest.raises(ValueError, match="Sample names are not the same!"):
+    with pytest.raises(ValueError, match="Samples names are not the same!"):
         metatensor.join([tensor_map_a, tensor_map_b], axis="samples")
 
 

--- a/python/metatensor-operations/tests/slice.py
+++ b/python/metatensor-operations/tests/slice.py
@@ -79,10 +79,10 @@ def _check_sliced_block_samples(block, sliced_block, structures_to_keep):
         assert np.all(sliced_c == c)
 
     # we have the right values
-    samples_filter = np.array(
+    samples_mask = np.array(
         [sample["structure"] in structures_to_keep for sample in block.samples]
     )
-    assert np.all(sliced_block.values == block.values[samples_filter, ...])
+    assert np.all(sliced_block.values == block.values[samples_mask, ...])
 
     for parameter, gradient in block.gradients():
         sliced_gradient = sliced_block.gradient(parameter)
@@ -93,9 +93,9 @@ def _check_sliced_block_samples(block, sliced_block, structures_to_keep):
         assert np.max(sliced_gradient.samples["sample"]) < sliced_block.values.shape[0]
 
         # other columns in the gradient samples have been sliced correctly
-        gradient_sample_filter = samples_filter[gradient.samples["sample"]]
+        gradient_sample_mask = samples_mask[gradient.samples["sample"]]
         if len(gradient.samples.names) > 1:
-            expected = gradient.samples.values[gradient_sample_filter, 1:]
+            expected = gradient.samples.values[gradient_sample_mask, 1:]
             sliced_gradient_samples = sliced_gradient.samples.values[:, 1:]
             assert np.all(sliced_gradient_samples == expected)
 
@@ -104,7 +104,7 @@ def _check_sliced_block_samples(block, sliced_block, structures_to_keep):
         for sliced_c, c in zip(sliced_gradient.components, gradient.components):
             assert np.all(sliced_c == c)
 
-        expected = gradient.values[gradient_sample_filter]
+        expected = gradient.values[gradient_sample_mask]
         assert np.all(sliced_gradient.values == expected)
 
 
@@ -126,8 +126,8 @@ def _check_sliced_block_properties(block, sliced_block, radial_to_keep):
         assert np.all(sliced_c == c)
 
     # we have the right values
-    property_filter = [property["n"] in radial_to_keep for property in block.properties]
-    assert np.all(sliced_block.values == block.values[..., property_filter])
+    properties_mask = [p["n"] in radial_to_keep for p in block.properties]
+    assert np.all(sliced_block.values == block.values[..., properties_mask])
 
     for parameter, gradient in block.gradients():
         sliced_gradient = sliced_block.gradient(parameter)
@@ -148,7 +148,7 @@ def _check_sliced_block_properties(block, sliced_block, radial_to_keep):
             assert np.all(sliced_c == c)
 
         # we have the right values
-        assert np.all(sliced_gradient.values == gradient.values[..., property_filter])
+        assert np.all(sliced_gradient.values == gradient.values[..., properties_mask])
 
 
 def _check_empty_block(block, sliced_block, axis):
@@ -370,11 +370,9 @@ def test_slice_block_samples_and_properties(tensor):
     )
 
     # we have the right values
-    samples_filter = [sample["center"] in centers_to_keep for sample in block.samples]
-    properties_filter = [
-        property["n"] in channels_to_keep for property in block.properties
-    ]
-    expected = block.values[samples_filter][..., properties_filter]
+    samples_mask = [sample["center"] in centers_to_keep for sample in block.samples]
+    properties_mask = [p["n"] in channels_to_keep for p in block.properties]
+    expected = block.values[samples_mask][..., properties_mask]
     assert np.all(sliced_block.values == expected)
 
     # Second, slice on properties and then on samples
@@ -406,11 +404,9 @@ def test_slice_block_samples_and_properties(tensor):
     )
 
     # we have the right values
-    samples_filter = [sample["center"] in centers_to_keep for sample in block.samples]
-    properties_filter = [
-        property["n"] in channels_to_keep for property in block.properties
-    ]
-    expected = block.values[samples_filter][..., properties_filter]
+    samples_mask = [sample["center"] in centers_to_keep for sample in block.samples]
+    properties_mask = [p["n"] in channels_to_keep for p in block.properties]
+    expected = block.values[samples_mask][..., properties_mask]
     assert np.all(sliced_block.values == expected)
 
 

--- a/python/metatensor-operations/tests/split.py
+++ b/python/metatensor-operations/tests/split.py
@@ -50,8 +50,8 @@ def test_split_block_samples():
         for parameter, gradient in block.gradients():
             split_gradient = split_block.gradient(parameter)
 
-            # only check the non-"sample" dimension, since the "sample" dimension should
-            # have been updated.
+            # only check the non-"sample" dimension, since the "sample"
+            # dimension should have been updated.
             gradient_mask = mask[gradient.samples["sample"]]
             assert np.all(
                 gradient.samples.values[gradient_mask, 1:]

--- a/python/metatensor-operations/tests/to.py
+++ b/python/metatensor-operations/tests/to.py
@@ -13,7 +13,7 @@ except ImportError:
 
 
 import metatensor
-from metatensor import Labels, TensorBlock, TensorMap
+from metatensor import Labels, TensorMap
 
 
 @pytest.fixture
@@ -313,11 +313,8 @@ def test_change_dtype_branched():
     """Test a `to` change of dtype with multiple gradient branches"""
 
     def get_dummy_block():
-        return TensorBlock(
-            values=np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]),
-            samples=Labels.range("sample", 2),
-            components=[],
-            properties=Labels.range("property", 3),
+        return metatensor.block_from_array(
+            np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]),
         )
 
     grad_00 = get_dummy_block()
@@ -348,9 +345,7 @@ def test_change_dtype_branched():
     grad_2.add_gradient("gradient_21", grad_21)
     grad_2.add_gradient("gradient_22", grad_22)
 
-    block = metatensor.block_from_array(
-        np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]),
-    )
+    block = get_dummy_block()
     block.add_gradient("gradient_0", grad_0)
     block.add_gradient("gradient_1", grad_1)
     block.add_gradient("gradient_2", grad_2)

--- a/python/metatensor-operations/tests/unique_metadata.py
+++ b/python/metatensor-operations/tests/unique_metadata.py
@@ -29,7 +29,7 @@ def real_tensor():
 
 
 def test_unique_metadata_block(large_tensor):
-    # unique metadata along sample axis
+    # unique metadata along samples axis
     target_samples = Labels(names=["s"], values=np.array([0, 1, 3]).reshape(-1, 1))
     actual_samples = metatensor.unique_metadata_block(
         large_tensor.block(1),
@@ -38,7 +38,7 @@ def test_unique_metadata_block(large_tensor):
     )
     assert target_samples == actual_samples
 
-    # unique metadata of gradient along sample axis
+    # unique metadata of gradient along samples axis
     names = ["sample", "g"]
     target_samples = Labels(names=names, values=np.array([[0, -2], [0, 3], [2, -2]]))
     actual_samples = metatensor.unique_metadata_block(

--- a/python/metatensor-torch/metatensor/torch/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/documentation.py
@@ -953,7 +953,7 @@ class TensorMap:
         """
 
     @property
-    def sample_names(self) -> List[str]:
+    def samples_names(self) -> List[str]:
         """names of the sample labels for all blocks in this tensor map"""
 
     @property

--- a/python/metatensor-torch/metatensor/torch/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/documentation.py
@@ -579,7 +579,7 @@ class TensorBlock:
     @property
     def samples(self) -> Labels:
         """
-        Get the sample :py:class:`Labels` for this block.
+        Get the samples :py:class:`Labels` for this block.
 
         The entries in these labels describe the first dimension of the
         ``values`` array.
@@ -632,9 +632,9 @@ class TensorBlock:
         >>> from metatensor.torch import TensorBlock, Labels
         >>> block = TensorBlock(
         ...     values=torch.full((3, 1, 1), 1.0),
-        ...     samples=Labels(["structure"], torch.IntTensor([[0], [2], [4]])),
-        ...     components=[Labels.range("component", 1)],
-        ...     properties=Labels.range("property", 1),
+        ...     samples=Labels(["s"], torch.IntTensor([[0], [2], [4]])),
+        ...     components=[Labels.range("c", 1)],
+        ...     properties=Labels.range("p", 1),
         ... )
         >>> gradient = TensorBlock(
         ...     values=torch.full((2, 1, 1), 11.0),
@@ -642,15 +642,15 @@ class TensorBlock:
         ...         names=["sample", "parameter"],
         ...         values=torch.IntTensor([[0, -2], [2, 3]]),
         ...     ),
-        ...     components=[Labels.range("component", 1)],
-        ...     properties=Labels.range("property", 1),
+        ...     components=[Labels.range("c", 1)],
+        ...     properties=Labels.range("p", 1),
         ... )
         >>> block.add_gradient("parameter", gradient)
         >>> print(block)
         TensorBlock
-            samples (3): ['structure']
-            components (1): ['component']
-            properties (1): ['property']
+            samples (3): ['s']
+            components (1): ['c']
+            properties (1): ['p']
             gradients: ['parameter']
         <BLANKLINE>
         """
@@ -666,9 +666,9 @@ class TensorBlock:
         >>> from metatensor.torch import TensorBlock, Labels
         >>> block = TensorBlock(
         ...     values=torch.full((3, 1, 5), 1.0),
-        ...     samples=Labels(["structure"], torch.tensor([[0], [2], [4]])),
-        ...     components=[Labels.range("component", 1)],
-        ...     properties=Labels.range("property", 5),
+        ...     samples=Labels(["s"], torch.tensor([[0], [2], [4]])),
+        ...     components=[Labels.range("c", 1)],
+        ...     properties=Labels.range("p", 5),
         ... )
 
         >>> positions_gradient = TensorBlock(
@@ -676,9 +676,9 @@ class TensorBlock:
         ...     samples=Labels(["sample", "atom"], torch.tensor([[0, 2], [2, 3]])),
         ...     components=[
         ...         Labels.range("direction", 3),
-        ...         Labels.range("component", 1),
+        ...         Labels.range("c", 1),
         ...     ],
-        ...     properties=Labels.range("property", 5),
+        ...     properties=Labels.range("p", 5),
         ... )
         >>> block.add_gradient("positions", positions_gradient)
 
@@ -688,9 +688,9 @@ class TensorBlock:
         ...     components=[
         ...         Labels.range("direction_1", 3),
         ...         Labels.range("direction_2", 3),
-        ...         Labels.range("component", 1),
+        ...         Labels.range("c", 1),
         ...     ],
-        ...     properties=Labels.range("property", 5),
+        ...     properties=Labels.range("p", 5),
         ... )
         >>> block.add_gradient("cell", cell_gradient)
 
@@ -698,16 +698,16 @@ class TensorBlock:
         >>> print(positions_gradient)
         Gradient TensorBlock ('positions')
             samples (2): ['sample', 'atom']
-            components (3, 1): ['direction', 'component']
-            properties (5): ['property']
+            components (3, 1): ['direction', 'c']
+            properties (5): ['p']
             gradients: None
         <BLANKLINE>
         >>> cell_gradient = block.gradient("cell")
         >>> print(cell_gradient)
         Gradient TensorBlock ('cell')
             samples (2): ['sample']
-            components (3, 3, 1): ['direction_1', 'direction_2', 'component']
-            properties (5): ['property']
+            components (3, 3, 1): ['direction_1', 'direction_2', 'c']
+            properties (5): ['p']
             gradients: None
         <BLANKLINE>
         """
@@ -827,7 +827,7 @@ class TensorMap:
         blocks along the properties direction (i.e. do an *horizontal*
         concatenation).
 
-        If ``keys_to_move`` is given as strings, then the new property labels
+        If ``keys_to_move`` is given as strings, then the new properties labels
         will **only** contain entries from the existing blocks. For example,
         merging a block with key ``a=0`` and properties ``p=1, 2`` with a block
         with key ``a=2`` and properties ``p=1, 3`` will produce a block with
@@ -863,7 +863,7 @@ class TensorMap:
 
     def components_to_properties(self, dimensions: StrSequence) -> "TensorMap":
         """
-        Move the given ``dimensions`` from the component labels to the property
+        Move the given ``dimensions`` from the component labels to the properties
         labels for each block.
 
         :param dimensions: name of the component dimensions to move to the
@@ -954,15 +954,15 @@ class TensorMap:
 
     @property
     def samples_names(self) -> List[str]:
-        """names of the sample labels for all blocks in this tensor map"""
+        """names of the samples labels for all blocks in this tensor map"""
 
     @property
-    def components_names(self) -> List[List[str]]:
-        """names of the component labels for all blocks in this tensor map"""
+    def components_names(self) -> List[str]:
+        """names of the components labels for all blocks in this tensor map"""
 
     @property
     def property_names(self) -> List[str]:
-        """names of the property labels for all blocks in this tensor map"""
+        """names of the properties labels for all blocks in this tensor map"""
 
     def print(self, max_keys: int) -> str:
         """

--- a/python/metatensor-torch/tests/operations/join.py
+++ b/python/metatensor-torch/tests/operations/join.py
@@ -17,7 +17,7 @@ def check_operation(join):
     # test keys
     assert joined_tensor.keys == tensor.keys
 
-    # test property names
+    # test properties names
     names = tensor.block(0).properties.names
     assert joined_tensor.block(0).properties.names == ["tensor"] + names
 


### PR DESCRIPTION
Addresses #388 - possibly also needs syncing up the rascaline version of mt.

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--389.org.readthedocs.build/en/389/

<!-- readthedocs-preview metatensor end -->