### PR TITLE
Correct issues with automatic artefacts upload from CI

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -11,6 +11,8 @@ concurrency:
   group: python-wheels-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
+env:
+  METATENSOR_NO_LOCAL_DEPS: "1"
 
 jobs:
   build-core-wheels:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -124,13 +124,50 @@ jobs:
             dist/cxx/*.tar.gz
             dist/*.whl
 
-      - name: upload to GitHub release
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: upload to GitHub release (metatensor-core)
+        if: startsWith(github.ref, 'refs/tags/metatensor-core-v')
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            dist/*.tar.gz
-            dist/cxx/*.tar.gz
-            dist/*.whl
+            dist/metatensor-core-*.tar.gz
+            dist/cxx/metatensor-core-cxx-*.tar.gz
+            dist/metatensor_core-*.whl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: upload to GitHub release (metatensor-torch)
+        if: startsWith(github.ref, 'refs/tags/metatensor-torch-v')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/metatensor-torch-*.tar.gz
+            dist/cxx/metatensor-torch-cxx-*.tar.gz
+            dist/metatensor_torch-*.whl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: upload to GitHub release (metatensor-operations)
+        if: startsWith(github.ref, 'refs/tags/metatensor-operations-v')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/metatensor-operations-*.tar.gz
+            dist/metatensor_operations-*.whl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: remove all sdist except metatensor
+        run: |
+          rm dist/metatensor-core-*.tar.gz
+          rm dist/metatensor-torch-*.tar.gz
+          rm dist/metatensor-operations-*.tar.gz
+
+      - name: upload to GitHub release (metatensor-python)
+        if: startsWith(github.ref, 'refs/tags/metatensor-python-v')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/metatensor-*.tar.gz
+            dist/metatensor-*.whl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/python/metatensor-operations/setup.py
+++ b/python/metatensor-operations/setup.py
@@ -114,7 +114,10 @@ if __name__ == "__main__":
             authors = fd.read().splitlines()
 
     install_requires = []
-    if os.path.exists(METATENSOR_CORE):
+
+    # when packaging a release, we should never use local dependencies
+    METATENSOR_NO_LOCAL_DEPS = os.environ.get("METATENSOR_NO_LOCAL_DEPS", "0") == "1"
+    if not METATENSOR_NO_LOCAL_DEPS and os.path.exists(METATENSOR_CORE):
         # we are building from a git checkout or full repo archive
 
         # add a random uuid to the file url to prevent pip from using a cached

--- a/python/metatensor-torch/setup.py
+++ b/python/metatensor-torch/setup.py
@@ -233,7 +233,10 @@ if __name__ == "__main__":
             authors = fd.read().splitlines()
 
     install_requires = ["torch >= 1.11"]
-    if os.path.exists(METATENSOR_CORE):
+
+    # when packaging a release, we should never use local dependencies
+    METATENSOR_NO_LOCAL_DEPS = os.environ.get("METATENSOR_NO_LOCAL_DEPS", "0") == "1"
+    if not METATENSOR_NO_LOCAL_DEPS and os.path.exists(METATENSOR_CORE):
         # we are building from a git checkout
 
         # add a random uuid to the file url to prevent pip from using a cached

--- a/scripts/package-core.sh
+++ b/scripts/package-core.sh
@@ -38,8 +38,12 @@ cd "$TMP_DIR"
 tar cf "$ARCHIVE_NAME.tar" "$ARCHIVE_NAME"
 gzip -9 "$ARCHIVE_NAME.tar"
 
+rm -f "$ROOT_DIR"/metatensor/metatensor-core-cxx-*.tar.gz
 cp "$TMP_DIR/$ARCHIVE_NAME.tar.gz" "$ROOT_DIR/metatensor/"
+
+rm -f "$ROOT_DIR"/python/metatensor-core/metatensor-core-cxx-*.tar.gz
 cp "$TMP_DIR/$ARCHIVE_NAME.tar.gz" "$ROOT_DIR/python/metatensor-core/"
 
 mkdir -p "$ROOT_DIR/dist/cxx"
+rm -f "$ROOT_DIR"/dist/cxx/metatensor-core-cxx-*.tar.gz
 cp "$TMP_DIR/$ARCHIVE_NAME.tar.gz" "$ROOT_DIR/dist/cxx/"

--- a/scripts/package-torch.sh
+++ b/scripts/package-torch.sh
@@ -26,7 +26,10 @@ cd "$TMP_DIR"
 tar cf "$ARCHIVE_NAME".tar "$ARCHIVE_NAME"
 
 gzip -9 "$ARCHIVE_NAME".tar
+
+rm -f "$ROOT_DIR"/python/metatensor-torch/metatensor-torch-cxx-*.tar.gz
 cp "$ARCHIVE_NAME".tar.gz "$ROOT_DIR/python/metatensor-torch/"
 
 mkdir -p "$ROOT_DIR/dist/cxx"
+rm -f "$ROOT_DIR"/dist/cxx/metatensor-torch-cxx-*.tar.gz
 cp "$ARCHIVE_NAME".tar.gz "$ROOT_DIR/dist/cxx/"

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,10 @@ def create_version_number(version):
 if __name__ == "__main__":
     install_requires = []
     extras_require = {}
-    if os.path.exists(METATENSOR_CORE):
+
+    # when creating a sdist, we should never use local dependencies
+    METATENSOR_NO_LOCAL_DEPS = os.environ.get("METATENSOR_NO_LOCAL_DEPS", "0") == "1"
+    if not METATENSOR_NO_LOCAL_DEPS and os.path.exists(METATENSOR_CORE):
         # we are building from a git checkout
         assert os.path.exists(METATENSOR_OPERATIONS)
         assert os.path.exists(METATENSOR_TORCH)

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ def n_commits_since_last_tag():
     if not os.path.exists(script):
         return 0
 
-    TAG_PREFIX = "metatensor-v"
+    TAG_PREFIX = "metatensor-python-v"
     output = subprocess.run(
         [sys.executable, script, TAG_PREFIX],
         stderr=subprocess.PIPE,


### PR DESCRIPTION
The metatensor Python package had the wrong metatadata, and all artefacts where uploaded to all tags.

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--391.org.readthedocs.build/en/391/

<!-- readthedocs-preview metatensor end -->