### PR TITLE
Updates for PyTorch 2.1

### DIFF
--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -24,18 +24,18 @@ jobs:
             do-valgrind: true
 
           - os: ubuntu-20.04
-            torch-version: 2.0.*
+            torch-version: 2.1.*
             python-version: "3.11"
             cargo-test-flags:
             cxx-flags: -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -g
 
           - os: macos-11
-            torch-version: 2.0.*
+            torch-version: 2.1.*
             python-version: "3.11"
             cargo-test-flags: --release
 
           - os: windows-2019
-            torch-version: 2.0.*
+            torch-version: 2.1.*
             python-version: "3.11"
             cargo-test-flags: --release
     steps:

--- a/metatensor-torch/CMakeLists.txt
+++ b/metatensor-torch/CMakeLists.txt
@@ -81,7 +81,7 @@ add_library(metatensor_torch SHARED
 )
 
 target_link_libraries(metatensor_torch PUBLIC torch metatensor::shared)
-target_compile_features(metatensor_torch PUBLIC cxx_std_14)
+target_compile_features(metatensor_torch PUBLIC cxx_std_17)
 target_include_directories(metatensor_torch PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>

--- a/metatensor-torch/tests/utils/mod.rs
+++ b/metatensor-torch/tests/utils/mod.rs
@@ -84,7 +84,7 @@ pub fn setup_pytorch(build_dir: PathBuf) -> PathBuf {
         .expect("failed to run python");
     assert!(status.success(), "failed to run `python -m pip install --upgrade pip`");
 
-    let torch_version = std::env::var("METATENSOR_TORCH_TEST_VERSION").unwrap_or("2.0.*".into());
+    let torch_version = std::env::var("METATENSOR_TORCH_TEST_VERSION").unwrap_or("2.1.*".into());
     let status = Command::new(&python)
         .arg("-m")
         .arg("pip")

--- a/python/metatensor-torch/tests/block.py
+++ b/python/metatensor-torch/tests/block.py
@@ -2,6 +2,7 @@ from typing import List, Tuple
 
 import pytest
 import torch
+from packaging import version
 from torch import Tensor
 
 from metatensor.torch import Labels, TensorBlock
@@ -95,6 +96,10 @@ def test_repr():
 """
     assert str(block) == expected
 
+    if version.parse(torch.__version__) >= version.parse("2.1"):
+        # custom __repr__ definitions are only available since torch 2.1
+        assert repr(block) == expected
+
     expected = """Gradient TensorBlock ('g')
     samples (3): ['sample', 'g']
     components (3, 1, 2): ['c_1', 'c_2', 'c_3']
@@ -102,6 +107,10 @@ def test_repr():
     gradients: None
 """
     assert str(block.gradient("g")) == expected
+
+    if version.parse(torch.__version__) >= version.parse("2.1"):
+        # custom __repr__ definitions are only available since torch 2.1
+        assert repr(block.gradient("g")) == expected
 
 
 def test_copy():

--- a/python/metatensor-torch/tests/labels.py
+++ b/python/metatensor-torch/tests/labels.py
@@ -2,6 +2,7 @@ from typing import Any, List, Optional, Tuple, Union
 
 import pytest
 import torch
+from packaging import version
 from torch import Tensor
 
 from metatensor.torch import Labels, LabelsEntry
@@ -136,9 +137,10 @@ def test_repr():
 
     expected = "Labels(\n    aaa  bbb\n     1    2\n     3    4\n)"
     assert str(labels) == expected
-    # custom __repr__ definitions are not passed to Python, we need to wait for
-    # https://github.com/pytorch/pytorch/pull/100724 to be merged and available
-    # assert repr(labels) == expected
+
+    if version.parse(torch.__version__) >= version.parse("2.1"):
+        # custom __repr__ definitions are only available since torch 2.1
+        assert repr(labels) == expected
 
     expected = "LabelsEntry(aaa=1, bbb=2)"
     assert str(labels[0]) == expected

--- a/python/metatensor-torch/tests/operations/split.py
+++ b/python/metatensor-torch/tests/operations/split.py
@@ -36,6 +36,7 @@ def check_operation(split):
     assert isinstance(split_tensors_samples[0], torch.ScriptObject)
     if version.parse(torch.__version__) >= version.parse("2.1"):
         assert split_tensors_samples[0]._type().name() == "TensorMap"
+
     assert isinstance(split_tensors_properties, list)
     assert isinstance(split_tensors_properties[0], torch.ScriptObject)
     if version.parse(torch.__version__) >= version.parse("2.1"):
@@ -81,11 +82,12 @@ def check_operation_block(split_block):
     assert isinstance(split_blocks_samples, list)
     assert isinstance(split_blocks_samples[0], torch.ScriptObject)
     if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert split_blocks_samples[0]._type().name() == "TensorMap"
+        assert split_blocks_samples[0]._type().name() == "TensorBlock"
+
     assert isinstance(split_blocks_properties, list)
     assert isinstance(split_blocks_properties[0], torch.ScriptObject)
     if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert split_blocks_properties[0]._type().name() == "TensorMap"
+        assert split_blocks_properties[0]._type().name() == "TensorBlock"
 
     # check values
     assert torch.equal(split_blocks_samples[0].values, torch.tensor([[0, 1, 2]]))

--- a/python/metatensor-torch/tests/tensor.py
+++ b/python/metatensor-torch/tests/tensor.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Tuple, Union
 
 import pytest
 import torch
+from packaging import version
 
 from metatensor.torch import Labels, LabelsEntry, TensorBlock, TensorMap
 
@@ -37,6 +38,10 @@ keys: key_1  key_2
     assert expected == str(tensor)
     assert expected == tensor.print(6)
 
+    if version.parse(torch.__version__) >= version.parse("2.1"):
+        # custom __repr__ definitions are only available since torch 2.1
+        assert repr(tensor) == expected
+
 
 def test_print_large(large_tensor):
     expected = """TensorMap with 12 blocks
@@ -58,6 +63,25 @@ keys: key_1  key_2
         2      5
         3      5"""
     assert expected == large_tensor.print(6)
+
+    expected = """TensorMap with 12 blocks
+keys: key_1  key_2
+        0      0
+        1      0
+        2      2
+        2      3
+        0      4
+        1      4
+        2      4
+        3      4
+        0      5
+        1      5
+        2      5
+        3      5"""
+
+    if version.parse(torch.__version__) >= version.parse("2.1"):
+        # custom __repr__ definitions are only available since torch 2.1
+        assert repr(large_tensor) == expected
 
 
 def test_labels_names(tensor):


### PR DESCRIPTION
PyTorch 2.1 has just been released, we need some changes to fully support it!

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--395.org.readthedocs.build/en/395/

<!-- readthedocs-preview metatensor end -->