### PR TITLE
Two fixes for sample reduction with torch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,7 +46,7 @@ jobs:
       - name: collect Python coverage
         run: |
             tox -e core-tests
-            tox -e operations-notorch-tests
+            tox -e operations-numpy-tests
             tox -e operations-torch-tests
             tox -e torch-tests
         env:

--- a/python/metatensor-operations/metatensor/operations/_dispatch.py
+++ b/python/metatensor-operations/metatensor/operations/_dispatch.py
@@ -331,6 +331,9 @@ def index_add(output_array, input_array, index):
     """
     index = to_index_array(index)
     if isinstance(input_array, TorchTensor):
+        if not isinstance(index, TorchTensor):
+            index = torch.tensor(index).to(device=input_array.device)
+
         _check_all_torch_tensor([output_array, input_array, index])
         output_array.index_add_(0, index, input_array)
     elif isinstance(input_array, np.ndarray):
@@ -644,7 +647,6 @@ def argsort_labels_values(labels_values, reverse: bool = False):
     :param reverse: if true, order is descending
 
     :return: indices corresponding to the sorted values in ``labels_values``
-
     """
     if isinstance(labels_values, TorchTensor):
         # torchscript does not support sorted for List[List[int]]

--- a/python/metatensor-operations/metatensor/operations/reduce_over_samples.py
+++ b/python/metatensor-operations/metatensor/operations/reduce_over_samples.py
@@ -151,9 +151,15 @@ def _reduce_over_samples_block(
         return result_block
 
     # get which samples will still be there after reduction
-    new_samples, index = _dispatch.unique_with_inverse(
-        block_samples.values[:, sample_selected], axis=0
-    )
+    if len(remaining_sample_names) == 0:
+        new_samples = _dispatch.zeros_like(block_samples.values, shape=(1, 0))
+        index = _dispatch.zeros_like(
+            block_samples.values, shape=(block_samples.values.shape[0],)
+        )
+    else:
+        new_samples, index = _dispatch.unique_with_inverse(
+            block_samples.values[:, sample_selected], axis=0
+        )
 
     block_values = block.values
     other_shape = block_values.shape[1:]

--- a/python/metatensor-operations/tests/reduce_special_cases.py
+++ b/python/metatensor-operations/tests/reduce_special_cases.py
@@ -2,6 +2,14 @@ import os
 
 import numpy as np
 
+
+try:
+    import torch
+
+    HAS_TORCH = True
+except ImportError:
+    HAS_TORCH = False
+
 import metatensor
 from metatensor import Labels, TensorBlock, TensorMap
 
@@ -30,16 +38,37 @@ def test_reduction_all_samples():
     var_X = metatensor.var_over_samples(X, sample_names=["s"])
     std_X = metatensor.std_over_samples(X, sample_names=["s"])
 
+    assert sum_X[0].samples == Labels.single()
     assert metatensor.equal_metadata(sum_X, mean_X)
     assert metatensor.equal_metadata(sum_X, std_X)
     assert metatensor.equal_metadata(mean_X, var_X)
-    assert sum_X[0].samples == Labels.single()
-    assert std_X[0].samples == Labels.single()
 
     assert np.all(sum_X[0].values == np.sum(X[0].values, axis=0))
     assert np.all(mean_X[0].values == np.mean(X[0].values, axis=0))
     assert np.allclose(std_X[0].values, np.std(X[0].values, axis=0))
     assert np.allclose(var_X[0].values, np.var(X[0].values, axis=0))
+
+    if HAS_TORCH:
+        X = metatensor.to(X, backend="torch")
+
+        sum_X = metatensor.sum_over_samples(X, sample_names=["s"])
+        mean_X = metatensor.mean_over_samples(X, sample_names=["s"])
+        var_X = metatensor.var_over_samples(X, sample_names=["s"])
+        std_X = metatensor.std_over_samples(X, sample_names=["s"])
+
+        assert sum_X[0].samples == Labels.single()
+        assert metatensor.equal_metadata(sum_X, mean_X)
+        assert metatensor.equal_metadata(sum_X, std_X)
+        assert metatensor.equal_metadata(mean_X, var_X)
+
+        assert torch.all(sum_X[0].values == torch.sum(X[0].values, axis=0))
+        assert torch.all(mean_X[0].values == torch.mean(X[0].values, axis=0))
+        assert torch.allclose(
+            std_X[0].values, torch.std(X[0].values, correction=0, axis=0)
+        )
+        assert torch.allclose(
+            var_X[0].values, torch.var(X[0].values, correction=0, axis=0)
+        )
 
 
 def test_zeros_sample_block():

--- a/python/metatensor-torch/tests/operations/reduce_over_samples.py
+++ b/python/metatensor-torch/tests/operations/reduce_over_samples.py
@@ -1,6 +1,7 @@
 import torch
 
 import metatensor.torch
+from metatensor.torch import Labels, TensorBlock, TensorMap
 
 from .data import load_data
 
@@ -27,3 +28,35 @@ def test_operations_as_torch_script():
     check_operation(torch.jit.script(metatensor.torch.mean_over_samples))
     check_operation(torch.jit.script(metatensor.torch.std_over_samples))
     check_operation(torch.jit.script(metatensor.torch.var_over_samples))
+
+
+def test_reduction_all_samples():
+    block_1 = TensorBlock(
+        values=torch.tensor(
+            [
+                [1, 2, 4],
+                [3, 5, 6],
+                [-1.3, 26.7, 4.54],
+            ]
+        ),
+        samples=Labels.range("s", 3),
+        components=[],
+        properties=Labels(["p"], torch.IntTensor([[0], [1], [5]])),
+    )
+    keys = Labels(names=["key_1", "key_2"], values=torch.IntTensor([[0, 0]]))
+    X = TensorMap(keys, [block_1])
+
+    sum_X = metatensor.torch.sum_over_samples(X, sample_names=["s"])
+    mean_X = metatensor.torch.mean_over_samples(X, sample_names=["s"])
+    var_X = metatensor.torch.var_over_samples(X, sample_names=["s"])
+    std_X = metatensor.torch.std_over_samples(X, sample_names=["s"])
+
+    assert sum_X[0].samples == Labels.single()
+    assert metatensor.torch.equal_metadata(sum_X, mean_X)
+    assert metatensor.torch.equal_metadata(sum_X, std_X)
+    assert metatensor.torch.equal_metadata(mean_X, var_X)
+
+    assert torch.all(sum_X[0].values == torch.sum(X[0].values, axis=0))
+    assert torch.all(mean_X[0].values == torch.mean(X[0].values, axis=0))
+    assert torch.allclose(std_X[0].values, torch.std(X[0].values, correction=0, axis=0))
+    assert torch.allclose(var_X[0].values, torch.var(X[0].values, correction=0, axis=0))

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ package = external
 package_env = build-metatensor-core
 lint_folders = "{toxinidir}/python" "{toxinidir}/setup.py"
 build_single_wheel = --no-deps --no-build-isolation --check-build-dependencies
-test_options = --cov={env_site_packages_dir}/metatensor --cov-append --import-mode=append
+test_options = --cov={env_site_packages_dir}/metatensor --cov-append --cov-report= --import-mode=append
 
 commands =
     # error if the user gives a wrong testenv name in `tox -e`

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ min_version = 4.0
 envlist =
     lint
     core-tests
-    operations-notorch-tests
+    operations-numpy-tests
     operations-torch-tests
     torch-tests
     docs-tests
@@ -50,9 +50,9 @@ changedir = python/metatensor-core
 commands =
     pytest {[testenv]test_options} {posargs}
 
-[testenv:operations-notorch-tests]
+[testenv:operations-numpy-tests]
 # this environement runs the tests of the metatensor-operations Python package
-# without torch functionalities
+# using numpy arrays
 deps =
     packaging
     numpy
@@ -72,14 +72,14 @@ commands =
 
 [testenv:operations-torch-tests]
 # this environement runs the tests of the metatensor-operations Python package
-# with torch functionalities
+# using torch arrays
 deps =
     torch
-    {[testenv:operations-notorch-tests]deps}
+    {[testenv:operations-numpy-tests]deps}
 changedir =
-    {[testenv:operations-notorch-tests]changedir}
+    {[testenv:operations-numpy-tests]changedir}
 commands =
-    {[testenv:operations-notorch-tests]commands}
+    {[testenv:operations-numpy-tests]commands}
 
 
 [testenv:torch-tests]


### PR DESCRIPTION
In the metatensor-core version, the `index` must be converted to a torch tensor before passing it to `index_add`. Since it comes from the Labels, it is a numpy array by default.

In the metatensor-torch version, `unique_with_inverse` does not work when reducing to a single sample

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--404.org.readthedocs.build/en/404/

<!-- readthedocs-preview metatensor end -->