### PR TITLE
Fix the version of sccache we pull from github

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.3
+        with:
+          version: "v0.5.4"
 
       - name: Setup sccache environnement variables
         run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.3
+        with:
+          version: "v0.5.4"
 
       - name: setup MSVC command prompt
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -82,6 +82,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.3
+        with:
+          version: "v0.5.4"
 
       - name: Setup sccache environnement variables
         run: |

--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -62,6 +62,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.3
+        with:
+          version: "v0.5.4"
 
       - name: Setup sccache environnement variables
         run: |


### PR DESCRIPTION
Otherwise CI fails trying to pull a version from which there are no artifacts yet.

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--408.org.readthedocs.build/en/408/

<!-- readthedocs-preview metatensor end -->