### PR TITLE
Use default tox error for non existing environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-min_version = 4.0
+min_version = 4.9.0
 # these are the default environments, i.e. the list of tests running when you
 # execute `tox` in the command-line without anything else
 envlist =
@@ -18,10 +18,6 @@ package_env = build-metatensor-core
 lint_folders = "{toxinidir}/python" "{toxinidir}/setup.py"
 build_single_wheel = --no-deps --no-build-isolation --check-build-dependencies
 test_options = --cov={env_site_packages_dir}/metatensor --cov-append --cov-report= --import-mode=append
-
-commands =
-    # error if the user gives a wrong testenv name in `tox -e`
-    python -c "import sys; print('environement {env_name} does not exist'); sys.exit(1)"
 
 
 [testenv:build-metatensor-core]


### PR DESCRIPTION
Non existing tox environments will raise an error by default starting from [tox `4.9.0`](https://tox.wiki/en/latest/changelog.html#v4-9-0-2023-08-16).

```bash
philiploche@Philips-MacBook-Air:~/repos/lab-cosmo/metatensor$ tox -e fooo
ROOT: HandledError| provided environments not found in configuration file:
fooo
```

I think we can bump our min version and remove our custom code.

