### PR TITLE
Bump min Python version 3.7

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            python-version: "3.7"
+            python-version: "3.8"
           - os: ubuntu-20.04
             python-version: "3.11"
           - os: macos-11

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ on metatensor:
   use a version provided by your operating system. We need at least Rust version
   1.65 to build metatensor.
 - **Python**: you can install ``Python`` and ``pip`` from your operating system.
-  We require a Python version of at least 3.7.
+  We require a Python version of at least 3.8.
 - **tox**: a Python test runner, cf https://tox.readthedocs.io/en/latest/. You
   can install tox with ``pip install tox``.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "metatensor"
 dynamic = ["version", "authors", "dependencies", "optional-dependencies"]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 readme = "README.md"
 license = {text = "BSD-3-Clause"}

--- a/python/metatensor-core/metatensor/__init__.py
+++ b/python/metatensor-core/metatensor/__init__.py
@@ -14,7 +14,6 @@
 # only declares dependencies on `metatensor-core` and `metatensor-operation`; as well
 # an an optional dependency on `metatensor-torch`.
 
-
 from .version import __version__  # noqa
 from . import utils  # noqa
 from .block import TensorBlock  # noqa

--- a/python/metatensor-core/metatensor/tensor.py
+++ b/python/metatensor-core/metatensor/tensor.py
@@ -1,11 +1,7 @@
 import copy
 import ctypes
-import sys
+from pickle import PickleBuffer
 from typing import Dict, List, Sequence, Union
-
-
-if (sys.version_info.major >= 3) and (sys.version_info.minor >= 8):
-    from pickle import PickleBuffer
 
 import numpy as np
 

--- a/python/metatensor-core/metatensor/version.py
+++ b/python/metatensor-core/metatensor/version.py
@@ -1,12 +1,4 @@
-import sys
+import importlib.metadata
 
 
-if (sys.version_info.major >= 3) and (sys.version_info.minor >= 8):
-    import importlib.metadata
-
-    __version__ = importlib.metadata.version("metatensor-core")
-
-else:
-    from pkg_resources import get_distribution
-
-    __version__ = get_distribution("metatensor-core").version
+__version__ = importlib.metadata.version("metatensor-core")

--- a/python/metatensor-core/pyproject.toml
+++ b/python/metatensor-core/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "metatensor-core"
 dynamic = ["version", "authors"]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 readme = "README.rst"
 license = {text = "BSD-3-Clause"}

--- a/python/metatensor-core/tests/serialization.py
+++ b/python/metatensor-core/tests/serialization.py
@@ -1,7 +1,6 @@
 import io
 import os
 import pickle
-import sys
 
 import numpy as np
 import pytest
@@ -149,10 +148,7 @@ def test_save_warning_errors(tmpdir, tensor):
             metatensor.save(tmpfile, tensor.block(0))
 
 
-if (sys.version_info.major >= 3) and (sys.version_info.minor >= 8):
-    protocols = (4, 5)
-else:
-    protocols = (4,)
+protocols = (4, 5)
 
 
 @pytest.mark.parametrize("protocol", protocols)

--- a/python/metatensor-operations/metatensor/operations/__init__.py
+++ b/python/metatensor-operations/metatensor/operations/__init__.py
@@ -1,14 +1,6 @@
-import sys
+import importlib.metadata
 
-if (sys.version_info.major >= 3) and (sys.version_info.minor >= 8):
-    import importlib.metadata
-
-    __version__ = importlib.metadata.version("metatensor-operations")
-
-else:
-    from pkg_resources import get_distribution
-
-    __version__ = get_distribution("metatensor-operations").version
+__version__ = importlib.metadata.version("metatensor-operations")
 
 
 from ._utils import NotEqualError  # noqa

--- a/python/metatensor-operations/pyproject.toml
+++ b/python/metatensor-operations/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "metatensor-operations"
 dynamic = ["version", "authors", "dependencies"]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 readme = "README.rst"
 license = {text = "BSD-3-Clause"}

--- a/python/metatensor-operations/tests/slice.py
+++ b/python/metatensor-operations/tests/slice.py
@@ -530,7 +530,7 @@ def test_slice_errors(tensor):
         "not <class 'metatensor.block.TensorBlock'>"
     )
     with pytest.raises(TypeError, match=message):
-        metatensor.slice(tensor.block(0), axis="samples", labels=samples),
+        metatensor.slice(tensor.block(0), axis="samples", labels=samples)
 
     message = "`labels` must be metatensor Labels, not <class 'numpy.ndarray'>"
     with pytest.raises(TypeError, match=message):
@@ -553,7 +553,7 @@ def test_slice_block_errors(tensor):
         "not <class 'metatensor.tensor.TensorMap'>"
     )
     with pytest.raises(TypeError, match=message):
-        metatensor.slice_block(tensor, axis="samples", labels=samples),
+        metatensor.slice_block(tensor, axis="samples", labels=samples)
 
     block = tensor.block(0)
     message = "`labels` must be metatensor Labels, not <class 'numpy.ndarray'>"

--- a/python/metatensor-operations/tests/split.py
+++ b/python/metatensor-operations/tests/split.py
@@ -235,11 +235,11 @@ def test_split_errors():
 
     message = "axis must be a string, not <class 'float'>"
     with pytest.raises(TypeError, match=message):
-        metatensor.split(tensor, axis=3.14, grouped_labels=grouped_labels),
+        metatensor.split(tensor, axis=3.14, grouped_labels=grouped_labels)
 
     message = "axis must be either 'samples' or 'properties'"
     with pytest.raises(ValueError, match=message):
-        metatensor.split(tensor, axis="buongiorno!", grouped_labels=grouped_labels),
+        metatensor.split(tensor, axis="buongiorno!", grouped_labels=grouped_labels)
 
     message = (
         "`grouped_labels` must be a list, " "not <class 'metatensor.labels.Labels'>"
@@ -289,4 +289,4 @@ def test_split_errors():
         "not <class 'metatensor.tensor.TensorMap'>"
     )
     with pytest.raises(TypeError, match=message):
-        metatensor.split_block(tensor, axis="samples", grouped_labels=[]),
+        metatensor.split_block(tensor, axis="samples", grouped_labels=[])

--- a/python/metatensor-torch/metatensor/torch/__init__.py
+++ b/python/metatensor-torch/metatensor/torch/__init__.py
@@ -1,9 +1,10 @@
 import os
 import torch
 
+from .version import __version__  # noqa
 from ._c_lib import _load_library
 from . import utils  # noqa
-from .version import __version__  # noqa
+
 
 if os.environ.get("METATENSOR_IMPORT_FOR_SPHINX") is not None:
     from .documentation import Labels, LabelsEntry, TensorBlock, TensorMap

--- a/python/metatensor-torch/metatensor/torch/version.py
+++ b/python/metatensor-torch/metatensor/torch/version.py
@@ -1,12 +1,4 @@
-import sys
+import importlib.metadata
 
 
-if (sys.version_info.major >= 3) and (sys.version_info.minor >= 8):
-    import importlib.metadata
-
-    __version__ = importlib.metadata.version("metatensor-torch")
-
-else:
-    from pkg_resources import get_distribution
-
-    __version__ = get_distribution("metatensor-torch").version
+__version__ = importlib.metadata.version("metatensor-torch")

--- a/python/metatensor-torch/pyproject.toml
+++ b/python/metatensor-torch/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "metatensor-torch"
 dynamic = ["version", "authors", "dependencies"]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 readme = "README.rst"
 license = {text = "BSD-3-Clause"}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-min_version = 4.0
+min_version = 4.9.0
 # these are the default environments, i.e. the list of tests running when you
 # execute `tox` in the command-line without anything else
 envlist =
@@ -18,10 +18,6 @@ package_env = build-metatensor-core
 lint_folders = "{toxinidir}/python" "{toxinidir}/setup.py"
 build_single_wheel = --no-deps --no-build-isolation --check-build-dependencies
 test_options = --cov={env_site_packages_dir}/metatensor --cov-append --cov-report= --import-mode=append
-
-commands =
-    # error if the user gives a wrong testenv name in `tox -e`
-    python -c "import sys; print('environement {env_name} does not exist'); sys.exit(1)"
 
 
 [testenv:build-metatensor-core]


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Removed support for Python 3.7 since it reaches its [end of life](https://www.python.org/downloads/release/python-3717/). 

@Luthaf you mentioned once there is some leftover code which is only there due to Python 3.7? I checked but haven't found anything.

Also should we update the changelog for this?

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--425.org.readthedocs.build/en/425/

<!-- readthedocs-preview metatensor end -->