### PR TITLE
Move `tox.ini` environment comments to descriptions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,9 @@ test_options = --cov={env_site_packages_dir}/metatensor --cov-append --cov-repor
 
 
 [testenv:build-metatensor-core]
-# This environment is only used to build the wheels which are then re-used by
-# all other environments requiring metatensor to be installed
+description =
+    Used to only build the wheels which are then re-used by all other environments
+    requiring metatensor to be installed
 passenv = *
 deps =
     cmake
@@ -35,7 +36,7 @@ commands =
 
 
 [testenv:core-tests]
-# this environement runs the tests of the metatensor-core Python package
+description = Run the tests of the metatensor-core Python package
 deps =
     numpy
     pytest
@@ -47,8 +48,8 @@ commands =
     pytest {[testenv]test_options} {posargs}
 
 [testenv:operations-numpy-tests]
-# this environement runs the tests of the metatensor-operations Python package
-# using numpy arrays
+description =
+    Run the tests of the metatensor-operations Python package using numpy arrays
 deps =
     packaging
     numpy
@@ -67,8 +68,8 @@ commands =
     pytest {[testenv]test_options} {posargs}
 
 [testenv:operations-torch-tests]
-# this environement runs the tests of the metatensor-operations Python package
-# using torch arrays
+description =
+    Run the tests of the metatensor-operations Python package using torch arrays
 deps =
     torch
     {[testenv:operations-numpy-tests]deps}
@@ -79,7 +80,7 @@ commands =
 
 
 [testenv:torch-tests]
-# this environement runs the tests of the metatensor-torch Python package
+description = Run the tests of the metatensor-torch Python package
 deps =
     cmake
     numpy
@@ -100,7 +101,7 @@ commands =
 
 
 [testenv:docs-tests]
-# this environement runs the doctests defined in any metatensor package
+description = Run the doctests defined in any metatensor package
 deps =
     pytest
     numpy
@@ -127,8 +128,9 @@ commands =
 
 
 [testenv:lint]
-# this environement lints the Python code with flake8 (code linter), black (code
-# formatter), and isort (sorting of imports)
+description =
+    lint the Python code with flake8 (code linter), black (code formatter), and isort
+    (sorting of imports)
 package = skip
 deps =
     flake8
@@ -144,9 +146,7 @@ commands =
     isort --check-only --diff {[testenv]lint_folders}
 
 [testenv:format]
-# this environement abuses tox to do actual formatting
-#
-# Users can run `tox -e format` to run formatting on all files
+description = Abuse tox to do actual formatting on all files.
 package = skip
 deps =
     black
@@ -158,7 +158,7 @@ commands =
     isort {[testenv]lint_folders}
 
 [testenv:docs]
-# this environement builds the documentation with sphinx
+description = build the documentation with sphinx
 deps =
     -r docs/requirements.txt
     cmake
@@ -182,7 +182,7 @@ commands =
 
 
 [testenv:build-tests]
-# this environement makes sure one can build sdist and wheels for Python
+description = Asserts Pythons package build integrity so one can build sdist and wheels
 package = skip
 deps =
     build


### PR DESCRIPTION
This makes already existing descriptions available via `tox list`

```
default environments:
lint                   -> lint the Python code with flake8 (code linter), black (code formatter), and isort (sorting of imports)
core-tests             -> Run the tests of the metatensor-core Python package
operations-numpy-tests -> Run the tests of the metatensor-operations Python package using numpy arrays
operations-torch-tests -> Run the tests of the metatensor-operations Python package using torch arrays
torch-tests            -> Run the tests of the metatensor-torch Python package
docs-tests             -> Run the doctests defined in any metatensor package

additional environments:
format                 -> Abuse tox to do actual formatting on all files.
docs                   -> build the documentation with sphinx
build-tests            -> Asserts Pythons package build integrity so one can build sdist and wheels
```

<!-- readthedocs-preview metatensor start -->
----
:books: Documentation preview :books:: https://metatensor--429.org.readthedocs.build/en/429/

<!-- readthedocs-preview metatensor end -->