### PR TITLE
Fix documentation for `metatensor.torch.Labels.to`

### DIFF
--- a/python/metatensor-torch/metatensor/torch/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/documentation.py
@@ -427,12 +427,7 @@ class Labels:
         )
         """
 
-    @overload
-    def to(self, str) -> "Labels":
-        """move the values for these Labels to the given ``device``"""
-
-    @overload
-    def to(self, device) -> "Labels":
+    def to(self, device: Union[str, torch.device]) -> "Labels":
         """move the values for these Labels to the given ``device``"""
 
     def position(


### PR DESCRIPTION
Fixes #434 


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--435.org.readthedocs.build/en/435/

<!-- readthedocs-preview metatensor end -->