### PR TITLE
Fix build with cargo 1.75

### DIFF
--- a/metatensor-core/CMakeLists.txt
+++ b/metatensor-core/CMakeLists.txt
@@ -172,28 +172,32 @@ endif()
 # Get the list of libraries linked by default by cargo/rustc to add when linking
 # to metatensor::static
 if (CARGO_VERSION_CHANGED)
+    include(cmake/tempdir.cmake)
+    get_tempdir(TMPDIR)
+
     # Adapted from https://github.com/corrosion-rs/corrosion/blob/dc1e4e5/cmake/FindRust.cmake
-    file(REMOVE_RECURSE "${CMAKE_CURRENT_BINARY_DIR}/_cargo_required_libs")
     execute_process(
         COMMAND "${CARGO_EXE}" new --lib _cargo_required_libs
-        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+        WORKING_DIRECTORY "${TMPDIR}"
         RESULT_VARIABLE cargo_new_result
         ERROR_QUIET
     )
 
     if (cargo_new_result)
-        message(FATAL_ERRPR "could not create empty project to find default static libs: ${cargo_new_result}")
+        message(FATAL_ERROR "could not create empty project to find default static libs: ${cargo_new_result}")
     endif()
 
-    file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/_cargo_required_libs/Cargo.toml"
-        "[workspace]\nmembers=[]\n[lib]\ncrate-type=[\"staticlib\"]")
+    file(APPEND "${TMPDIR}/_cargo_required_libs/Cargo.toml" "[lib]\ncrate-type=[\"staticlib\"]")
 
     execute_process(
         COMMAND ${CARGO_EXE} rustc --verbose --color never --target=${RUST_BUILD_TARGET} -- --print=native-static-libs
-        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/_cargo_required_libs"
+        WORKING_DIRECTORY "${TMPDIR}/_cargo_required_libs"
         RESULT_VARIABLE cargo_build_result
         ERROR_VARIABLE cargo_build_error_message
     )
+
+    # clean up the files
+    file(REMOVE_RECURSE "${TMPDIR}")
 
     if(cargo_build_result)
         message(FATAL_ERROR "could extract default static libs: ${cargo_build_result}")

--- a/metatensor-core/cmake/tempdir.cmake
+++ b/metatensor-core/cmake/tempdir.cmake
@@ -1,0 +1,50 @@
+# Create a temporary directory using mktemp on *nix and powershell on windows
+function(get_tempdir _outvar_)
+    # special case for github actions, where $TEMP might
+    # exist but point to nowhere/a non writable location
+    # https://docs.github.com/en/actions/learn-github-actions/variables
+    if (DEFINED ENV{RUNNER_TEMP})
+        string(RANDOM LENGTH 12 _dirname_)
+        set(_output_ $ENV{RUNNER_TEMP}/${_dirname_})
+        file(TO_NATIVE_PATH "${_output_}" _output_)
+        file(MAKE_DIRECTORY ${_output_})
+        set(${_outvar_} ${_output_} PARENT_SCOPE)
+        return()
+    endif()
+
+    find_program(MKTEMP_EXE NAMES mktemp)
+    if(MKTEMP_EXE)
+        execute_process(
+            COMMAND ${MKTEMP_EXE} -d
+            OUTPUT_VARIABLE _output_
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            RESULT_VARIABLE _status_
+        )
+
+        if(_status_ EQUAL 0)
+            set(${_outvar_} ${_output_} PARENT_SCOPE)
+            return()
+        endif()
+    endif()
+
+
+    find_program(POWERSHELL_EXE NAMES pwsh)
+    if(POWERSHELL_EXE)
+        execute_process(
+            COMMAND ${POWERSHELL_EXE} -c "[System.IO.Path]::GetTempPath()"
+            OUTPUT_VARIABLE _output_
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            RESULT_VARIABLE _status_
+        )
+
+        if(_status_ EQUAL 0)
+            string(RANDOM LENGTH 12 _dirname_)
+            set(_output_ ${_output_}${_dirname_})
+            file(MAKE_DIRECTORY ${_output_})
+            set(${_outvar_} ${_output_} PARENT_SCOPE)
+            return()
+        endif()
+    endif()
+
+    message(FATAL_ERROR "Could not find mktemp or powsershell to make temporary directory")
+endfunction()

--- a/metatensor-core/src/c_api/mod.rs
+++ b/metatensor-core/src/c_api/mod.rs
@@ -6,23 +6,16 @@ use once_cell::sync::Lazy;
 
 #[macro_use]
 mod status;
-
 pub use self::status::{catch_unwind, mts_status_t};
-pub use self::status::{MTS_SUCCESS, MTS_INVALID_PARAMETER_ERROR};
-pub use self::status::{MTS_BUFFER_SIZE_ERROR, MTS_INTERNAL_ERROR};
 
-pub mod labels;
-pub use self::labels::mts_labels_t;
+#[cfg(test)]
+pub use self::status::MTS_SUCCESS;
 
-pub mod data;
-
-pub mod blocks;
-pub use self::blocks::mts_block_t;
-
-pub mod tensor;
-pub use self::tensor::mts_tensormap_t;
-
-pub mod io;
+mod labels;
+mod data;
+mod blocks;
+mod tensor;
+mod io;
 
 mod utils;
 

--- a/metatensor/src/lib.rs
+++ b/metatensor/src/lib.rs
@@ -47,6 +47,7 @@ pub use self::labels::LabelsParIter;
 
 mod block;
 pub use self::block::{TensorBlock, TensorBlockRef, TensorBlockRefMut};
+pub use self::block::{TensorBlockData, TensorBlockDataMut};
 pub use self::block::{GradientsIter, GradientsMutIter};
 pub use self::block::LazyMetadata;
 

--- a/scripts/clean-python.sh
+++ b/scripts/clean-python.sh
@@ -25,5 +25,9 @@ rm -rf python/metatensor-torch/metatensor-torch-cxx-*.tar.gz
 rm -rf python/metatensor-torch/dist
 rm -rf python/metatensor-torch/build
 
+rm -rf python/metatensor-learn/dist
+rm -rf python/metatensor-learn/build
+
 find . -name "*.egg-info" -exec rm -rf "{}" +
 find . -name "__pycache__" -exec rm -rf "{}" +
+find . -name ".coverage" -exec rm -rf "{}" +


### PR DESCRIPTION
There where some changes in determining workspaces members, which broke the code we use to get the list of static libraries to link with.

We now list these libraries from a temporary directory instead of a subdirectory in `target`.

It might make sense to release this as 0.1.1 for metatensor-core and metatensor rust, to be able to use these inside rascaline.

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--438.org.readthedocs.build/en/438/

<!-- readthedocs-preview metatensor end -->