### PR TITLE
Release -core and -rust v0.1.1

### DIFF
--- a/metatensor-core/CHANGELOG.md
+++ b/metatensor-core/CHANGELOG.md
@@ -46,12 +46,14 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 - the Julia bindings to metatensor-core in the Metatensor.jl package
 
-#### Fixed
 
-#### Changed
+## [Version 0.1.1](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-core-v0.1.1) - 2024-01-05
 
-#### Removed
+### Fixed
 
+- Fixed the build with Cargo 1.75 (#438)
+- Allowed saving and loading empty TensorMap; i.e. TensorMap where one of the
+  dimensions of the array has 0 elements (#419)
 
 ## [Version 0.1.0](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-core-v0.1.0) - 2023-10-11
 

--- a/metatensor-core/Cargo.toml
+++ b/metatensor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metatensor-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 rust-version = "1.65"

--- a/metatensor/CHANGELOG.md
+++ b/metatensor/CHANGELOG.md
@@ -15,6 +15,12 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
+## [Version 0.1.1](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-rust-v0.1.1) - 2024-01-05
+
+### Fixed
+
+- Fixed the build with Cargo 1.75
+
 ## [Version 0.1.0](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-rust-v0.1.0) - 2023-10-11
 
 ### Added

--- a/metatensor/Cargo.toml
+++ b/metatensor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metatensor"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.65"
 include = [


### PR DESCRIPTION
Incorporating mainly #438 and #419.

<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--440.org.readthedocs.build/en/440/

<!-- readthedocs-preview metatensor end -->