### PR TITLE
Fix build with MinGW on windows

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -51,7 +51,13 @@ jobs:
             rust-version: stable
             rust-target: x86_64-pc-windows-msvc
             cargo-build-flags: --features=rayon
-            extra-name: ""
+            extra-name: " / MSVC"
+
+          - os: windows-2019
+            rust-version: stable
+            rust-target: x86_64-pc-windows-gnu
+            cargo-build-flags: --features=rayon
+            extra-name: " / MinGW"
     steps:
       - name: install dependencies in container
         if: matrix.container == 'ubuntu:20.04'

--- a/metatensor-core/CMakeLists.txt
+++ b/metatensor-core/CMakeLists.txt
@@ -238,6 +238,13 @@ add_library(metatensor::shared SHARED IMPORTED GLOBAL)
 set(METATENSOR_SHARED_LOCATION "${CARGO_OUTPUT_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}metatensor${CMAKE_SHARED_LIBRARY_SUFFIX}")
 set(METATENSOR_IMPLIB_LOCATION "${METATENSOR_SHARED_LOCATION}.lib")
 
+if (MINGW)
+    # `rustc` does not follow the usual naming scheme for DLL with mingw (it
+    # would typically be 'libmetatensor.dll')
+    set(METATENSOR_SHARED_LOCATION "${CARGO_OUTPUT_DIR}/metatensor.dll")
+    set(METATENSOR_IMPLIB_LOCATION "${CARGO_OUTPUT_DIR}/libmetatensor.dll.a")
+endif()
+
 add_library(metatensor::static STATIC IMPORTED GLOBAL)
 set(METATENSOR_STATIC_LOCATION "${CARGO_OUTPUT_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}metatensor${CMAKE_STATIC_LIBRARY_SUFFIX}")
 

--- a/python/metatensor-operations/tests/slice.py
+++ b/python/metatensor-operations/tests/slice.py
@@ -165,12 +165,11 @@ def _check_sliced_block_properties(block, sliced_block, radial_to_keep):
 
 
 def _check_empty_block(block, sliced_block, axis):
-    # Define the axis that should be sliced to zero (axis1)
-    # and the one that should not be sliced (axis2)
     if axis == "s":
         sliced_axis, unsliced_axis = 0, -1
     else:
         sliced_axis, unsliced_axis = -1, 0
+
     # sliced block has no values
     assert len(sliced_block.values.flatten()) == 0
     # sliced block has dimension zero for properties
@@ -257,9 +256,8 @@ def test_slice_samples(tensor):
         labels=samples,
     )
 
-    for block in sliced_tensor:
-        # all blocks are empty
-        _check_empty_block(block, sliced_tensor.block(key), "s")
+    for sliced_block in sliced_tensor:
+        _check_empty_block(tensor.block(key), sliced_block, "s")
 
 
 # ===== Tests for slicing along properties =====


### PR DESCRIPTION
MinGW is used as the Windows ABI for Julia.

`rustc` creates DLL files without a `lib` prefix, which does not match the expectations of most tools in the MinGW world.

This PR tries to enable CI for this target, and fix the CMake build to pass the right arguments.


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--441.org.readthedocs.build/en/441/

<!-- readthedocs-preview metatensor end -->