### PR TITLE
Check recorded version in models against metatensor-torch's version

### DIFF
--- a/metatensor-torch/src/atomistic.cpp
+++ b/metatensor-torch/src/atomistic.cpp
@@ -11,7 +11,10 @@
 #include <metatensor.hpp>
 
 #include "metatensor/torch/atomistic.hpp"
+#include "metatensor/torch/misc.hpp"
+
 #include "internal/scalar_type_name.hpp"
+
 
 using namespace metatensor_torch;
 
@@ -1098,7 +1101,7 @@ void metatensor_torch::check_atomistic_model(std::string path) {
     auto recorded_mts_version = Version(record_to_string(
         reader.getRecord("extra/metatensor-version")
     ));
-    auto current_mts_version = Version(mts_version());
+    auto current_mts_version = Version(metatensor_torch::version());
 
     if (!current_mts_version.is_compatible(recorded_mts_version)) {
         TORCH_WARN(


### PR DESCRIPTION
And not against metatensor-core version. Otherwise people just building and running a model get a warning they can't do anything with!

> [W atomistic.cpp:1108] Warning: Current metatensor version (0.2.0-dev8) is not compatible with the version (0.3.0.dev2) used to export the model at 'exported-model.pt'; proceed at your own risk. (function check_atomistic_model)


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--445.org.readthedocs.build/en/445/

<!-- readthedocs-preview metatensor end -->