### PR TITLE
Improve formulation of master branch description

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,7 +1,7 @@
 Contribution via pull requests are always welcome. Source code is available from
 `Github`_. Before submitting a pull request, please open an issue to discuss
-your changes. Use the only `master` as reference branch for submitting your
-requests.
+your changes. Use only `master` as target branch when submitting a
+pull requests.
 
 .. _`Github` : https://github.com/lab-cosmo/metatensor
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,6 +1,6 @@
 Contribution via pull requests are always welcome. Source code is available from
 `Github`_. Before submitting a pull request, please open an issue to discuss
-your changes. Use only the `master` branch as target branch when submitting a pull request (PR).
+your changes. Use only the `master` branch as the target branch when submitting a pull request (PR).
 
 .. _`Github` : https://github.com/lab-cosmo/metatensor
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,7 +1,6 @@
 Contribution via pull requests are always welcome. Source code is available from
 `Github`_. Before submitting a pull request, please open an issue to discuss
-your changes. Use only `master` as target branch when submitting a
-pull requests.
+your changes. Use only the `master` branch as target branch when submitting a pull request (PR).
 
 .. _`Github` : https://github.com/lab-cosmo/metatensor
 


### PR DESCRIPTION
In the `CONTRIBUTING.rst` the description of the master branch as required target branch is not very clear and has a typo. I tried to improve the sentence.

<!-- What does this implement/fix? Explain your changes here. -->



# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--462.org.readthedocs.build/en/462/

<!-- readthedocs-preview metatensor end -->