### PR TITLE
Return stress in Voigt notation for ASE calculator

### DIFF
--- a/python/metatensor-torch/tests/atomistic/ase_calculator.py
+++ b/python/metatensor-torch/tests/atomistic/ase_calculator.py
@@ -230,3 +230,13 @@ def test_exported_model(tmpdir, model, model_different_units, atoms):
 
     model_different_units.export(path)
     check_against_ase_lj(atoms, MetatensorCalculator(path))
+
+
+def test_get_properties(model, atoms):
+    atoms.calc = MetatensorCalculator(model)
+
+    properties = atoms.get_properties(["energy", "forces", "stress"])
+
+    assert np.all(properties["energy"] == atoms.get_potential_energy())
+    assert np.all(properties["forces"] == atoms.get_forces())
+    assert np.all(properties["stress"] == atoms.get_stress())


### PR DESCRIPTION
This fix calls to `atoms.get_properties["stress"]`, which would otherwise fail with `ValueError: stress has bad shape: (3, 3)`


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--463.org.readthedocs.build/en/463/

<!-- readthedocs-preview metatensor end -->