### PR TITLE
Format with new black version 24.1

### DIFF
--- a/python/metatensor-learn/metatensor/learn/data/collate.py
+++ b/python/metatensor-learn/metatensor/learn/data/collate.py
@@ -1,6 +1,7 @@
 """
 Module containing a collate function for use in a Dataloader.
 """
+
 from collections import namedtuple
 from typing import List, NamedTuple, Optional, Union
 

--- a/python/metatensor-learn/metatensor/learn/data/dataloader.py
+++ b/python/metatensor-learn/metatensor/learn/data/dataloader.py
@@ -1,6 +1,7 @@
 """
 Module containing the DataLoader.
 """
+
 from typing import Callable
 
 import torch

--- a/python/metatensor-learn/metatensor/learn/data/dataset.py
+++ b/python/metatensor-learn/metatensor/learn/data/dataset.py
@@ -1,6 +1,7 @@
 """
 Module for defining a Dataset or IndexedDataset.
 """
+
 from collections import namedtuple
 from typing import List, NamedTuple, Optional
 

--- a/python/metatensor-learn/tests/collate.py
+++ b/python/metatensor-learn/tests/collate.py
@@ -1,6 +1,7 @@
 """
 Module for testing the custom collate functions in :py:module:`collate`.
 """
+
 import numpy as np
 import pytest
 

--- a/python/metatensor-learn/tests/dataset.py
+++ b/python/metatensor-learn/tests/dataset.py
@@ -1,6 +1,7 @@
 """
 Module for testing the Dataset class in :py:module:`dataset`.
 """
+
 import re
 
 import numpy as np

--- a/python/metatensor-learn/tests/utils.py
+++ b/python/metatensor-learn/tests/utils.py
@@ -1,6 +1,7 @@
 """
 Utilities for testing metatensor-learn.
 """
+
 import os
 from functools import partial
 

--- a/python/metatensor-operations/metatensor/operations/abs.py
+++ b/python/metatensor-operations/metatensor/operations/abs.py
@@ -2,6 +2,7 @@
 Module to find the absolute values of a :py:class:`TensorMap`, returning a new
 :py:class:`TensorMap`.
 """
+
 from typing import List
 
 from . import _dispatch

--- a/python/metatensor-operations/metatensor/operations/checks.py
+++ b/python/metatensor-operations/metatensor/operations/checks.py
@@ -26,6 +26,7 @@ Note that :py:class:`metatensor.unsafe_enable_checks()` or
 :py:class:`metatensor.unsafe_disable_checks()` overwrite the defintion of the enviroment
 variable.
 """
+
 import os
 
 

--- a/python/metatensor-operations/metatensor/operations/equal_metadata.py
+++ b/python/metatensor-operations/metatensor/operations/equal_metadata.py
@@ -1,6 +1,7 @@
 """
 Module for checking equivalence in metadata between 2 TensorMaps
 """
+
 from typing import List, Union
 
 from ._classes import TensorBlock, TensorMap, check_isinstance, torch_jit_is_scripting

--- a/python/metatensor-operations/metatensor/operations/manipulate_dimension.py
+++ b/python/metatensor-operations/metatensor/operations/manipulate_dimension.py
@@ -15,6 +15,7 @@ changing the columns of the :py:class:`metatensor.Labels` within).
 
 .. autofunction:: metatensor.rename_dimension
 """
+
 from typing import List
 
 from ._classes import TensorBlock, TensorMap

--- a/python/metatensor-operations/metatensor/operations/unique_metadata.py
+++ b/python/metatensor-operations/metatensor/operations/unique_metadata.py
@@ -1,6 +1,7 @@
 """
 Module for finding unique metadata for TensorMaps and TensorBlocks
 """
+
 from typing import List, Optional, Tuple, Union
 
 from . import _dispatch

--- a/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
@@ -44,8 +44,7 @@ class System:
             boundary conditions, non-periodic systems should set the cell to 0.
         """
 
-    def __len__(self) -> int:
-        ...
+    def __len__(self) -> int: ...
 
     @property
     def species(self) -> torch.Tensor:
@@ -199,17 +198,13 @@ class NeighborsListOptions:
         Add another ``requestor`` to the list of modules requesting this neighbors list
         """
 
-    def __repr__(self) -> str:
-        ...
+    def __repr__(self) -> str: ...
 
-    def __str__(self) -> str:
-        ...
+    def __str__(self) -> str: ...
 
-    def __eq__(self, other: "NeighborsListOptions") -> bool:
-        ...
+    def __eq__(self, other: "NeighborsListOptions") -> bool: ...
 
-    def __ne__(self, other: "NeighborsListOptions") -> bool:
-        ...
+    def __ne__(self, other: "NeighborsListOptions") -> bool: ...
 
 
 class ModelOutput:
@@ -221,8 +216,7 @@ class ModelOutput:
         unit: str = "",
         per_atom: bool = False,
         explicit_gradients: List[str] = [],  # noqa B006
-    ):
-        ...
+    ): ...
 
     quantity: str
     """
@@ -254,8 +248,7 @@ class ModelCapabilities:
         length_unit: str = "",
         species: List[int] = [],  # noqa B006
         outputs: Dict[str, ModelOutput] = {},  # noqa B006
-    ):
-        ...
+    ): ...
 
     length_unit: str
     """unit of lengths the model expects as input"""
@@ -283,8 +276,7 @@ class ModelEvaluationOptions:
         length_unit: str = "",
         outputs: Dict[str, ModelOutput] = {},  # noqa B006
         selected_atoms: Optional[Labels] = None,
-    ):
-        ...
+    ): ...
 
     length_unit: str
     """unit of lengths the engine uses for the model input"""

--- a/python/metatensor-torch/metatensor/torch/atomistic/model.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/model.py
@@ -60,8 +60,7 @@ class MetatensorAtomisticModel(torch.nn.Module):
     ...         systems: List[System],
     ...         outputs: Dict[str, ModelOutput],
     ...         selected_atoms: Optional[Labels] = None,
-    ...     ) -> Dict[str, TensorMap]:
-    ...         ...
+    ...     ) -> Dict[str, TensorMap]: ...
     ...
 
     The returned dictionary should have the same keys as ``outputs``, and the values


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->
Black has been updated for 23.12 to 24.1 and makes the linter fail in existing PRs.
I just run `tox -e format`


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--465.org.readthedocs.build/en/465/

<!-- readthedocs-preview metatensor end -->