### PR TITLE
Fix #464 add comment in `metatensor-learn` linear that dtype is constant

### DIFF
--- a/python/metatensor-learn/metatensor/learn/nn/linear.py
+++ b/python/metatensor-learn/metatensor/learn/nn/linear.py
@@ -125,8 +125,7 @@ class Linear(ModuleMap):
             out_features=[len(weights[i].properties) for i in range(len(weights))],
             bias=False,
             device=weights.device,
-            dtype=weights[0].values.dtype,  # due to bug metatensor/issues/464
-            #  we use the dtype of the values
+            dtype=weights[0].values.dtype,  # dtype is consistent over blocks in map
             out_properties=[weights[i].properties for i in range(len(weights))],
         )
         for i in range(len(weights)):


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->
Fix #464 (not really a fix, but does give description why we can do use the first block's dtype)


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--481.org.readthedocs.build/en/481/

<!-- readthedocs-preview metatensor end -->