### PR TITLE
Fix collate fn `group_and_join` for `ScriptObject`s that aren't TensorMaps

### DIFF
--- a/python/examples/learn/2-indexed-dataset.py
+++ b/python/examples/learn/2-indexed-dataset.py
@@ -71,7 +71,7 @@ print(dataset[3])
 #
 # Suppose the unique indexes for our 5 samples are:
 
-sample_ids = [
+sample_id = [
     "cat",
     4,
     ("small", "cow"),
@@ -79,11 +79,11 @@ sample_ids = [
     0,
 ]
 
-# Build an IndexedDataset, specifying the unique sample indexes with ``sample_ids``
+# Build an IndexedDataset, specifying the unique sample indexes with ``sample_id``
 dataset = IndexedDataset(
     x=x_data,
     y=y_data,
-    sample_ids=sample_ids,
+    sample_id=sample_id,
 )
 
 # %%
@@ -124,8 +124,7 @@ print(dataset.get_sample("cat"))
 # A :py:class:`DataLoader` can be constructed on top of an :py:class:`IndexedDataset`
 # in the same way as a :py:class:`Dataset`. Batches are accessed by iterating over the
 # :py:class:`DataLoader`, though this time the ``Batch`` named tuple returned by the
-# data loader will contain the unique sample indexes ``sample_ids`` (note: plural for
-# the batch, singular for the sample) as the first field.
+# data loader will contain the unique sample indexes ``sample_id`` as the first field.
 
 dataloader = DataLoader(dataset, batch_size=2)
 
@@ -145,7 +144,7 @@ for ids, x, y in dataloader:
 # -----------------------------------------------------------------
 #
 # When defining an :py:class:`IndexedDataset` with data fields on-disk, i.e. to be
-# loaded lazily, the sample indexes passed as the ``sample_ids`` kwarg to the
+# loaded lazily, the sample indexes passed as the ``sample_id`` kwarg to the
 # constructor are used as the arguments to the load function.
 #
 # To demonstrate this, as we did in the previous tutorial, let's save the ``x`` data to
@@ -157,7 +156,7 @@ for ids, x, y in dataloader:
 # Create a directory to save the dummy x data to disk
 os.makedirs("data", exist_ok=True)
 
-for i, x in zip(sample_ids, x_data):
+for i, x in zip(sample_id, x_data):
     torch.save(x, f"data/x_{i}.pt")
 
 # %%
@@ -180,7 +179,7 @@ def load_x(sample_id):
 # Now when we define an IndexedDataset, the 'x' data field can be passed as a
 # callable.
 
-mixed_dataset = IndexedDataset(x=load_x, y=y_data, sample_ids=sample_ids)
+mixed_dataset = IndexedDataset(x=load_x, y=y_data, sample_id=sample_id)
 print(mixed_dataset.get_sample("dog"))
 print(mixed_dataset.get_sample(("small", "cow")))
 
@@ -196,11 +195,11 @@ print(mixed_dataset.get_sample(("small", "cow")))
 #
 # For instance, imagine we have a global Dataset of 1000 samples, with indices [0, ...,
 # 999], but only want to build a dataset for samples with indices [4, 7, 200, 5, 999],
-# in that order. We can pass these indices kwarg ``sample_ids``.
+# in that order. We can pass these indices kwarg ``sample_id``.
 
 # Build an IndexedDataset, specifying the subset sample indexes in a specific order
-sample_ids = [4, 7, 200, 5, 999]
-dataset = IndexedDataset(x=x_data, y=y_data, sample_ids=sample_ids)
+sample_id = [4, 7, 200, 5, 999]
+dataset = IndexedDataset(x=x_data, y=y_data, sample_id=sample_id)
 
 # %%
 #

--- a/python/metatensor-learn/CHANGELOG.md
+++ b/python/metatensor-learn/CHANGELOG.md
@@ -17,6 +17,12 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 #### Removed
 -->
 
+### Changed
+
+- Pluralization removed for special kwarg `sample_ids` of `IndexedDataset` ->
+  `sample_id`, and provided collate functions `group` and `group_and_join`
+  updated accordingly.
+
 ## [Version 0.1.0](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-learn-v0.1.0) - 2024-01-26
 
 ### Added

--- a/python/metatensor-learn/metatensor/learn/data/collate.py
+++ b/python/metatensor-learn/metatensor/learn/data/collate.py
@@ -30,8 +30,7 @@ def group(batch: List[NamedTuple]) -> NamedTuple:
     :return: a named tuple, with the named fields the same as in the original
         samples in the batch, but with the samples grouped by data field.
     """
-    names = [name if name != "sample_id" else "sample_ids" for name in batch[0]._fields]
-    return namedtuple("Batch", names)(*list(zip(*batch)))
+    return namedtuple("Batch", batch[0]._fields)(*list(zip(*batch)))
 
 
 def group_and_join(
@@ -82,13 +81,13 @@ def group_and_join(
         :py:class:`TensorMap` objects, they are joined along the samples axis.
     """
     data: List[Union[TensorMap, torch.Tensor]] = []
-    names = [name if name != "sample_id" else "sample_ids" for name in batch[0]._fields]
+    names = batch[0]._fields
     if fields_to_join is None:
         fields_to_join = names
     if join_kwargs is None:
         join_kwargs = {}
     for name, field in zip(names, list(zip(*batch))):
-        if name == "sample_ids":  # special case, keep as is
+        if name == "sample_id":  # special case, keep as is
             data.append(field)
             continue
         # Join tensors or TensorMaps if requested

--- a/python/metatensor-learn/tests/dataloader.py
+++ b/python/metatensor-learn/tests/dataloader.py
@@ -100,7 +100,7 @@ def test_indexed_dataloader_indices_shuffle(create_dataset, tmpdir):
 
         matching = []
         for batch_i, batch in enumerate(dloader):
-            matching.append(np.all(batch.sample_ids == batched_indices[batch_i]))
+            matching.append(np.all(batch.sample_id == batched_indices[batch_i]))
 
         assert np.all(matching)
 
@@ -124,7 +124,7 @@ def test_dataloader_collate_fn_group_and_join(tmpdir):
                         in metatensor.unique_metadata(
                             field, "samples", "sample_index"
                         ).values
-                        for A in batch.sample_ids
+                        for A in batch.sample_id
                     ]
                 )
 
@@ -140,7 +140,7 @@ def test_dataloader_collate_fn_group(tmpdir):
         for batch in dloader:
             for field in [batch.input, batch.output, batch.auxiliary]:
                 assert isinstance(field, tuple)
-                for i, A in enumerate(batch.sample_ids):
+                for i, A in enumerate(batch.sample_id):
                     assert isinstance(field[i], TensorMap)
                     assert (
                         A

--- a/python/metatensor-learn/tests/dataset.py
+++ b/python/metatensor-learn/tests/dataset.py
@@ -117,7 +117,7 @@ def test_indexed_dataset_fields():
     dset = IndexedDataset(
         a=[torch.zeros((1, 1)) for _ in range(10)],
         c=[torch.zeros((1, 1)) for _ in range(10)],
-        sample_ids=list(range(10)),
+        sample_id=list(range(10)),
         b=[torch.zeros((1, 1)) for _ in range(10)],
     )
     assert np.all(dset[5]._fields == ("sample_id", "a", "c", "b"))
@@ -147,7 +147,7 @@ def test_indexed_dataset_fields_arbitrary_types():
     dset = IndexedDataset(
         a=["hello" for _ in range(10)],
         c=[(3, 4, 7) for _ in range(10)],
-        sample_ids=list(range(10)),
+        sample_id=list(range(10)),
         b=[0 for _ in range(10)],
     )
     assert dset[5].a == "hello"
@@ -218,7 +218,7 @@ def test_indexed_dataset_invalid_callable():
     with pytest.raises(IOError) as excinfo:
         dset = IndexedDataset(
             c=lambda y: metatensor.load(f"path/to/{y}"),
-            sample_ids=["cat", "dog"],
+            sample_id=["cat", "dog"],
         )
         dset.get_sample("cat")
     assert message in str(excinfo.value)
@@ -252,7 +252,7 @@ def test_indexed_dataset_inconsistent_lengths():
     the appropriate error.
     """
     message = (
-        "Number of samples inconsistent between argument 'sample_ids' (9) "
+        "Number of samples inconsistent between argument 'sample_id' (9) "
         "and data fields in kwargs: ([10])"
     )
     with pytest.raises(ValueError, match=re.escape(message)):
@@ -260,11 +260,11 @@ def test_indexed_dataset_inconsistent_lengths():
             a=lambda x: f"path/to/{x}",
             c=lambda y: f"path/to/{y}",
             x=list(range(10)),
-            sample_ids=list(range(9)),
+            sample_id=list(range(9)),
         )
 
 
-def test_indexed_dataset_nonunique_sample_ids():
+def test_indexed_dataset_nonunique_sample_id():
     """
     Tests the appropriate error is raised when non-unique sample IDs are
     passed.
@@ -273,5 +273,5 @@ def test_indexed_dataset_nonunique_sample_ids():
     with pytest.raises(ValueError, match=message):
         IndexedDataset(
             a=[1, 2, 3],
-            sample_ids=["a", "b", "a"],
+            sample_id=["a", "b", "a"],
         )

--- a/python/metatensor-learn/tests/utils.py
+++ b/python/metatensor-learn/tests/utils.py
@@ -228,7 +228,7 @@ def indexed_dataset_in_mem(sample_indices):
     """Create an indexed dataset with everything in memory"""
     inputs, outputs, auxiliaries = generate_data(sample_indices)
     return IndexedDataset(
-        sample_ids=sample_indices,
+        sample_id=sample_indices,
         input=inputs,
         output=outputs,
         auxiliary=auxiliaries,
@@ -239,7 +239,7 @@ def indexed_dataset_on_disk(sample_indices):
     """Create an indexed dataset with everything on disk"""
     _ = generate_data(sample_indices)
     return IndexedDataset(
-        sample_ids=sample_indices,
+        sample_id=sample_indices,
         input=partial(transform, filename="input"),
         output=partial(transform, filename="output"),
         auxiliary=partial(transform, filename="auxiliary"),
@@ -253,7 +253,7 @@ def indexed_dataset_mixed_mem_disk(sample_indices):
     """
     inputs, outputs, _ = generate_data(sample_indices)
     return IndexedDataset(
-        sample_ids=sample_indices,
+        sample_id=sample_indices,
         input=inputs,
         output=outputs,
         auxiliary=partial(transform, filename="auxiliary"),


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Closes #485, and removes pluralization of the data field `sample_ids` -> `sample_id` in both `group` and `group_and_join` collate functions, and `IndexedDataset`

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--487.org.readthedocs.build/en/487/

<!-- readthedocs-preview metatensor end -->