### PR TITLE
`metatensor-learn` remove usage of Labels.range

### DIFF
--- a/python/metatensor-learn/CHANGELOG.md
+++ b/python/metatensor-learn/CHANGELOG.md
@@ -23,6 +23,10 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `sample_id`, and provided collate functions `group` and `group_and_join`
   updated accordingly.
 
+#### Fixed
+
+- Removal of usage of Labels.range in nn modules to support torch.jit.save see metatensor issue #410
+
 ## [Version 0.1.0](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-learn-v0.1.0) - 2024-01-26
 
 ### Added

--- a/python/metatensor-learn/metatensor/learn/nn/module_map.py
+++ b/python/metatensor-learn/metatensor/learn/nn/module_map.py
@@ -4,6 +4,8 @@ from typing import List, Optional, Union
 import torch
 from torch.nn import Module, ModuleList
 
+from metatensor.operations import _dispatch
+
 from .._classes import Labels, LabelsEntry, TensorBlock, TensorMap
 
 
@@ -280,7 +282,13 @@ class ModuleMap(ModuleList):
 
         out_values = module.forward(block.values)
         if self._out_properties is None:
-            properties = Labels.range("_", out_values.shape[-1])
+            # we do not use range because of metatensor/issues/410
+            properties = Labels(
+                "_",
+                _dispatch.int_array_like(
+                    list(range(out_values.shape[-1])), block.samples.values
+                ).reshape(-1, 1),
+            )
         else:
             properties = self._out_properties[module_idx]
         return TensorBlock(

--- a/python/metatensor-torch/tests/learn/linear.py
+++ b/python/metatensor-torch/tests/learn/linear.py
@@ -1,3 +1,5 @@
+import io
+
 import numpy as np
 import pytest
 import torch
@@ -117,3 +119,11 @@ def test_torchscript_linear(single_block_tensor):  # noqa F811
 
     # tests if member functions work that do not appear in forward
     tensor_module_script.get_module(single_block_tensor.keys[0])
+
+    # test save load
+    scripted = torch.jit.script(tensor_module_script)
+    buffer = io.BytesIO()
+    torch.jit.save(scripted, buffer)
+    buffer.seek(0)
+    torch.jit.load(buffer)
+    buffer.close()

--- a/python/metatensor-torch/tests/learn/module_map.py
+++ b/python/metatensor-torch/tests/learn/module_map.py
@@ -1,3 +1,5 @@
+import io
+
 import pytest
 import torch
 from torch.nn import Module, Sigmoid
@@ -100,3 +102,11 @@ def test_torchscript_module_map(single_block_tensor):  # noqa F811
 
     # tests if member functions work that do not appear in forward
     tensor_module_script.get_module(single_block_tensor.keys[0])
+
+    # test save load
+    scripted = torch.jit.script(tensor_module_script)
+    buffer = io.BytesIO()
+    torch.jit.save(scripted, buffer)
+    buffer.seek(0)
+    torch.jit.load(buffer)
+    buffer.close()


### PR DESCRIPTION
This needs to be done for to support torch.jit.save see issue #410

<!-- What does this implement/fix? Explain your changes here. -->



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--489.org.readthedocs.build/en/489/

<!-- readthedocs-preview metatensor end -->