### PR TITLE
Upgrade to codecov-action v4

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,7 +64,8 @@ jobs:
             coverage xml
 
       - name: upload to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
We where using v3, which is currently failing. Let's see if this one works better!

This is exactly the same as https://github.com/lab-cosmo/metatensor/pull/488, but as a PR from the same repo instead of a fork (since that's one of the big change in this new version). See https://github.com/lab-cosmo/metatensor/actions/runs/7787428418/job/21234557857?pr=488 for the corresponding CI log for the branch from a fork.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--491.org.readthedocs.build/en/491/

<!-- readthedocs-preview metatensor end -->