### PR TITLE
Cleanup metatensor-learn tests

### DIFF
--- a/python/metatensor-learn/metatensor/learn/nn/linear.py
+++ b/python/metatensor-learn/metatensor/learn/nn/linear.py
@@ -112,7 +112,7 @@ class Linear(ModuleMap):
         Construct a linear module map from a tensor map for the weights and bias.
 
         :param weights:
-            The weight tensor map from which we create the linear modules.  The
+            The weight tensor map from which we create the linear modules. The
             properties of the tensor map describe the input dimension and the samples
             describe the output dimension.
 

--- a/python/metatensor-learn/tests/linear.py
+++ b/python/metatensor-learn/tests/linear.py
@@ -1,15 +1,26 @@
+import numpy as np
 import pytest
+
+import metatensor
+from metatensor import Labels
 
 
 torch = pytest.importorskip("torch")
 
-import numpy as np  # noqa: E402
-
-import metatensor  # noqa: E402
-from metatensor import Labels  # noqa: E402
 from metatensor.learn.nn import Linear  # noqa: E402
 
-from .utils import TORCH_KWARGS, single_block_tensor_torch  # noqa F401
+from .utils import (  # noqa F402
+    TORCH_KWARGS,
+    random_single_block_no_components_tensor_map,
+)
+
+
+@pytest.fixture()
+def single_block_tensor_torch():
+    """
+    random tensor map with no components using torch as array backend
+    """
+    return random_single_block_no_components_tensor_map(use_torch=True)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -23,7 +34,7 @@ def set_random_generator():
     torch.set_default_dtype(TORCH_KWARGS["dtype"])
 
 
-def test_linear_single_block_tensor(single_block_tensor_torch):  # noqa F811
+def test_linear_single_block_tensor(single_block_tensor_torch):
     # testing initialization by non sequence arguments
     tensor_module_init_nonseq = Linear(
         in_keys=single_block_tensor_torch.keys,
@@ -89,7 +100,7 @@ def test_linear_single_block_tensor(single_block_tensor_torch):  # noqa F811
             assert gradient.properties == out_gradient.properties
 
 
-def test_linear_from_weight(single_block_tensor_torch):  # noqa F811
+def test_linear_from_weight(single_block_tensor_torch):
     weights = metatensor.slice(
         single_block_tensor_torch,
         axis="samples",

--- a/python/metatensor-learn/tests/module_map.py
+++ b/python/metatensor-learn/tests/module_map.py
@@ -1,15 +1,26 @@
+import numpy as np
 import pytest
+
+from metatensor import Labels
 
 
 torch = pytest.importorskip("torch")
-
-import numpy as np  # noqa: E402
 from torch.nn import Module, Sigmoid  # noqa: E402
 
-from metatensor import Labels  # noqa: E402
 from metatensor.learn.nn import ModuleMap  # noqa: E402
 
-from .utils import TORCH_KWARGS, single_block_tensor_torch  # noqa F411 E402
+from .utils import (  # noqa E402
+    TORCH_KWARGS,
+    random_single_block_no_components_tensor_map,
+)
+
+
+@pytest.fixture
+def single_block_tensor_torch():
+    """
+    random tensor map with no components using torch as array backend
+    """
+    return random_single_block_no_components_tensor_map(use_torch=True)
 
 
 class MockModule(Module):
@@ -37,9 +48,7 @@ def set_random_generator():
 @pytest.mark.parametrize(
     "out_properties", [None, [Labels(["a", "b"], np.array([[1, 1]]))]]
 )
-def test_module_map_single_block_tensor(
-    single_block_tensor_torch, out_properties  # noqa F811
-):
+def test_module_map_single_block_tensor(single_block_tensor_torch, out_properties):
     modules = []
     for key in single_block_tensor_torch.keys:
         modules.append(

--- a/python/metatensor-learn/tests/utils.py
+++ b/python/metatensor-learn/tests/utils.py
@@ -1,6 +1,4 @@
-"""
-Utilities for testing metatensor-learn.
-"""
+"""Utilities for testing metatensor-learn."""
 
 import os
 from functools import partial
@@ -8,62 +6,40 @@ from functools import partial
 import numpy as np
 import pytest
 
+import metatensor
+from metatensor import Labels, TensorBlock, TensorMap
+
 
 torch = pytest.importorskip("torch")
 
-import metatensor  # noqa: E402
-from metatensor import Labels, TensorBlock, TensorMap  # noqa: E402
-from metatensor.learn.data import Dataset, IndexedDataset  # noqa: E402
+from metatensor.learn.data import Dataset, IndexedDataset  # noqa E402
 
 
 TORCH_KWARGS = {"device": "cpu", "dtype": torch.float32}
 
 
-def random_single_block_no_components_tensor_map(use_torch, use_metatensor_torch):
-    """
-    Create a dummy tensor map to be used in tests. This is the same one as the
-    tensor map used in `tensor.rs` tests.
-    """
-    if not use_torch and use_metatensor_torch:
-        raise ValueError(
-            "torch.TensorMap cannot be created without torch.Tensor block values."
-        )
-    if use_metatensor_torch:
-        import torch
-
-        from metatensor.torch import Labels, TensorBlock, TensorMap
-
-        create_int32_array = partial(torch.tensor, dtype=torch.int32)
-    else:
-        import numpy as np
-
-        from metatensor import Labels, TensorBlock, TensorMap
-
-        create_int32_array = partial(np.array, dtype=np.int32)
+def random_single_block_no_components_tensor_map(use_torch):
+    """Create a dummy tensor map to be used in tests."""
 
     if use_torch:
-        import torch
-
         create_random_array = partial(torch.rand, **TORCH_KWARGS)
     else:
-        import numpy as np
-
         create_random_array = np.random.rand
 
-    block_1 = TensorBlock(
+    block = TensorBlock(
         values=create_random_array(4, 2),
         samples=Labels(
             ["sample", "structure"],
-            create_int32_array([[0, 0], [1, 1], [2, 2], [3, 3]]),
+            np.array([[0, 0], [1, 1], [2, 2], [3, 3]], dtype=np.int32),
         ),
         components=[],
-        properties=Labels(["properties"], create_int32_array([[0], [1]])),
+        properties=Labels(["properties"], np.array([[0], [1]], dtype=np.int32)),
     )
     positions_gradient = TensorBlock(
         values=create_random_array(7, 3, 2),
         samples=Labels(
             ["sample", "structure", "center"],
-            create_int32_array(
+            np.array(
                 [
                     [0, 0, 1],
                     [0, 0, 2],
@@ -73,30 +49,31 @@ def random_single_block_no_components_tensor_map(use_torch, use_metatensor_torch
                     [2, 2, 0],
                     [3, 3, 0],
                 ],
+                dtype=np.int32,
             ),
         ),
-        components=[Labels(["direction"], create_int32_array([[0], [1], [2]]))],
-        properties=block_1.properties,
+        components=[Labels(["direction"], np.array([[0], [1], [2]], dtype=np.int32))],
+        properties=block.properties,
     )
-    block_1.add_gradient("positions", positions_gradient)
+    block.add_gradient("positions", positions_gradient)
 
     cell_gradient = TensorBlock(
         values=create_random_array(4, 6, 2),
         samples=Labels(
             ["sample", "structure"],
-            create_int32_array([[0, 0], [1, 1], [2, 2], [3, 3]]),
+            np.array([[0, 0], [1, 1], [2, 2], [3, 3]], dtype=np.int32),
         ),
         components=[
             Labels(
                 ["voigt_index"],
-                create_int32_array([[0], [1], [2], [3], [4], [5]]),
+                np.array([[0], [1], [2], [3], [4], [5]], dtype=np.int32),
             )
         ],
-        properties=block_1.properties,
+        properties=block.properties,
     )
-    block_1.add_gradient("cell", cell_gradient)
+    block.add_gradient("cell", cell_gradient)
 
-    return TensorMap(Labels.single(), [block_1])
+    return TensorMap(Labels.single(), [block])
 
 
 def tensor(sample_indices):
@@ -258,11 +235,3 @@ def indexed_dataset_mixed_mem_disk(sample_indices):
         output=outputs,
         auxiliary=partial(transform, filename="auxiliary"),
     )
-
-
-@pytest.fixture(scope="class")
-def single_block_tensor_torch():
-    """
-    random tensor map with no components using torch as array backend
-    """
-    return random_single_block_no_components_tensor_map(True, False)

--- a/python/metatensor-torch/tests/atomistic/ase_calculator.py
+++ b/python/metatensor-torch/tests/atomistic/ase_calculator.py
@@ -271,6 +271,7 @@ def test_serialize_ase(tmpdir, model, atoms):
             trajectory="file.traj",
         )
         dyn.run(10)
+        dyn.close()
 
         atoms = ase.io.read("file.traj", "-1")
         assert atoms.calc is not None

--- a/python/metatensor-torch/tests/learn/linear.py
+++ b/python/metatensor-torch/tests/learn/linear.py
@@ -1,21 +1,24 @@
 import io
 
-import numpy as np
 import pytest
 import torch
 
 import metatensor.torch
-from metatensor import Labels
-from metatensor.torch import allclose_raise
+from metatensor.torch import Labels, allclose_raise
 from metatensor.torch.learn.nn import Linear
 
-from .utils import TORCH_KWARGS, single_block_tensor  # noqa F401
+from .utils import TORCH_KWARGS, random_single_block_no_components_tensor_map
+
+
+@pytest.fixture
+def single_block_tensor():
+    return random_single_block_no_components_tensor_map()
 
 
 @pytest.fixture(scope="module", autouse=True)
 def set_random_generator():
     """Set the random generator to same seed before each test is run.
-    Otherwise test behaviour is dependend on the order of the tests
+    Otherwise test behaviour is dependent on the order of the tests
     in this file and the number of parameters of the test.
     """
     torch.random.manual_seed(122578741812)
@@ -23,7 +26,7 @@ def set_random_generator():
     torch.set_default_dtype(TORCH_KWARGS["dtype"])
 
 
-def test_linear_single_block_tensor(single_block_tensor):  # noqa F811
+def test_linear_single_block_tensor(single_block_tensor):
     # testing initialization by non sequence arguments
     tensor_module_init_nonseq = Linear(
         in_keys=single_block_tensor.keys,
@@ -89,22 +92,23 @@ def test_linear_single_block_tensor(single_block_tensor):  # noqa F811
             assert gradient.properties == out_gradient.properties
 
 
-def test_linear_from_weight(single_block_tensor):  # noqa F811
+def test_linear_from_weight(single_block_tensor):
+    print(type(single_block_tensor.block().values))
     weights = metatensor.torch.slice(
         single_block_tensor,
         axis="samples",
-        labels=Labels(["sample", "structure"], np.array([[0, 0], [1, 1]])),
+        labels=Labels(["sample", "structure"], torch.IntTensor([[0, 0], [1, 1]])),
     )
     bias = metatensor.torch.slice(
         single_block_tensor,
         axis="samples",
-        labels=Labels(["sample", "structure"], np.array([[3, 3]])),
+        labels=Labels(["sample", "structure"], torch.IntTensor([[3, 3]])),
     )
     module = Linear.from_weights(weights, bias)
     module(single_block_tensor)
 
 
-def test_torchscript_linear(single_block_tensor):  # noqa F811
+def test_torchscript_linear(single_block_tensor):
     tensor_module = Linear(
         single_block_tensor.keys,
         in_features=len(single_block_tensor[0].properties),

--- a/python/metatensor-torch/tests/learn/module_map.py
+++ b/python/metatensor-torch/tests/learn/module_map.py
@@ -7,7 +7,15 @@ from torch.nn import Module, Sigmoid
 from metatensor.torch import Labels, allclose_raise
 from metatensor.torch.learn.nn import ModuleMap
 
-from .utils import TORCH_KWARGS, single_block_tensor  # noqa F401
+from .utils import (  # noqa F402
+    TORCH_KWARGS,
+    random_single_block_no_components_tensor_map,
+)
+
+
+@pytest.fixture
+def single_block_tensor():
+    return random_single_block_no_components_tensor_map()
 
 
 class MockModule(Module):
@@ -24,7 +32,7 @@ class MockModule(Module):
 @pytest.fixture(scope="module", autouse=True)
 def set_random_generator():
     """Set the random generator to same seed before each test is run.
-    Otherwise test behaviour is dependend on the order of the tests
+    Otherwise test behaviour is dependent on the order of the tests
     in this file and the number of parameters of the test.
     """
     torch.random.manual_seed(122578741812)
@@ -35,9 +43,7 @@ def set_random_generator():
 @pytest.mark.parametrize(
     "out_properties", [None, [Labels(["a", "b"], torch.tensor([[1, 1]]))]]
 )
-def test_module_map_single_block_tensor(
-    single_block_tensor, out_properties  # noqa F811
-):
+def test_module_map_single_block_tensor(single_block_tensor, out_properties):
     modules = []
     for key in single_block_tensor.keys:
         modules.append(
@@ -83,7 +89,7 @@ def test_module_map_single_block_tensor(
                 assert out_block.gradient(parameter).properties == out_properties[0]
 
 
-def test_torchscript_module_map(single_block_tensor):  # noqa F811
+def test_torchscript_module_map(single_block_tensor):
     modules = []
     for key in single_block_tensor.keys:
         modules.append(

--- a/python/metatensor-torch/tests/learn/utils.py
+++ b/python/metatensor-torch/tests/learn/utils.py
@@ -1,58 +1,26 @@
-from functools import partial
+import torch
 
-import pytest
+from metatensor.torch import Labels, TensorBlock, TensorMap
 
-
-torch = pytest.importorskip("torch")
 
 TORCH_KWARGS = {"device": "cpu", "dtype": torch.float32}
 
 
-def random_single_block_no_components_tensor_map(use_torch, use_metatensor_torch):
-    """
-    Create a dummy tensor map to be used in tests. This is the same one as the
-    tensor map used in `tensor.rs` tests.
-    """
-    if not use_torch and use_metatensor_torch:
-        raise ValueError(
-            "torch.TensorMap cannot be created without torch.Tensor block values."
-        )
-    if use_metatensor_torch:
-        import torch
-
-        from metatensor.torch import Labels, TensorBlock, TensorMap
-
-        create_int32_array = partial(torch.tensor, dtype=torch.int32)
-    else:
-        import numpy as np
-
-        from metatensor import Labels, TensorBlock, TensorMap
-
-        create_int32_array = partial(np.array, dtype=np.int32)
-
-    if use_torch:
-        import torch
-
-        create_random_array = partial(torch.rand, **TORCH_KWARGS)
-    else:
-        import numpy as np
-
-        create_random_array = np.random.rand
-
-    block_1 = TensorBlock(
-        values=create_random_array(4, 2),
+def random_single_block_no_components_tensor_map():
+    block = TensorBlock(
+        values=torch.rand(4, 2, **TORCH_KWARGS),
         samples=Labels(
             ["sample", "structure"],
-            create_int32_array([[0, 0], [1, 1], [2, 2], [3, 3]]),
+            torch.IntTensor([[0, 0], [1, 1], [2, 2], [3, 3]]),
         ),
         components=[],
-        properties=Labels(["properties"], create_int32_array([[0], [1]])),
+        properties=Labels(["properties"], torch.IntTensor([[0], [1]])),
     )
     positions_gradient = TensorBlock(
-        values=create_random_array(7, 3, 2),
+        values=torch.rand(7, 3, 2, **TORCH_KWARGS),
         samples=Labels(
             ["sample", "structure", "center"],
-            create_int32_array(
+            torch.IntTensor(
                 [
                     [0, 0, 1],
                     [0, 0, 2],
@@ -64,30 +32,25 @@ def random_single_block_no_components_tensor_map(use_torch, use_metatensor_torch
                 ],
             ),
         ),
-        components=[Labels(["direction"], create_int32_array([[0], [1], [2]]))],
-        properties=block_1.properties,
+        components=[Labels(["direction"], torch.IntTensor([[0], [1], [2]]))],
+        properties=block.properties,
     )
-    block_1.add_gradient("positions", positions_gradient)
+    block.add_gradient("positions", positions_gradient)
 
     cell_gradient = TensorBlock(
-        values=create_random_array(4, 6, 2),
+        values=torch.rand(4, 6, 2, **TORCH_KWARGS),
         samples=Labels(
             ["sample", "structure"],
-            create_int32_array([[0, 0], [1, 1], [2, 2], [3, 3]]),
+            torch.IntTensor([[0, 0], [1, 1], [2, 2], [3, 3]]),
         ),
         components=[
             Labels(
                 ["voigt_index"],
-                create_int32_array([[0], [1], [2], [3], [4], [5]]),
+                torch.IntTensor([[0], [1], [2], [3], [4], [5]]),
             )
         ],
-        properties=block_1.properties,
+        properties=block.properties,
     )
-    block_1.add_gradient("cell", cell_gradient)
+    block.add_gradient("cell", cell_gradient)
 
-    return TensorMap(Labels.single(), [block_1])
-
-
-@pytest.fixture(scope="class")
-def single_block_tensor():
-    return random_single_block_no_components_tensor_map(True, True)
+    return TensorMap(Labels.single(), [block])

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ package = external
 package_env = build-metatensor-core
 lint_folders = "{toxinidir}/python" "{toxinidir}/setup.py"
 build_single_wheel = --no-deps --no-build-isolation --check-build-dependencies
-test_options = --cov={env_site_packages_dir}/metatensor --cov-append --cov-report= --import-mode=append
+test_options = --cov={env_site_packages_dir}/metatensor --cov-append --cov-report= --import-mode=append -W error
 
 
 [testenv:build-metatensor-core]
@@ -167,7 +167,7 @@ commands =
     pip install python/metatensor-torch {[testenv]build_single_wheel} --force-reinstall
 
     # run documentation tests
-    pytest --doctest-modules --pyargs metatensor
+    pytest --doctest-modules --pyargs metatensor -W error
 
 
 [testenv:lint]


### PR DESCRIPTION
The tests for `.learn` inside metatensor-torch where still using numpy in some places, I've removed the corresponding code and in general separated tests using `metatensor.Labels` (in `metatensor-learn`) and tests using `metatensor.torch.Labels` (in `metatensor-torch`)


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--493.org.readthedocs.build/en/493/

<!-- readthedocs-preview metatensor end -->