### PR TITLE
 Remove Python build-tests from CI

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -177,6 +177,7 @@ jobs:
         run: |
           rm dist/metatensor-core-*.tar.gz
           rm dist/metatensor-torch-*.tar.gz
+          rm dist/metatensor-learn-*.tar.gz
           rm dist/metatensor-operations-*.tar.gz
 
       - name: upload to GitHub release (metatensor-python)

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -55,7 +55,7 @@ jobs:
           python-version: "3.11"
 
       - name: install dependencies
-        run: python -m pip install cibuildwheel
+        run: python -m pip install cibuildwheel twine
 
       - name: build manylinux with rust docker image
         if: matrix.os == 'ubuntu-20.04'
@@ -69,6 +69,9 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
           CIBW_BUILD_VERBOSITY: 2
           CIBW_MANYLINUX_X86_64_IMAGE: rustc-manylinux2014_x86_64
+
+      - name: check wheels with twine
+        run: twine check wheelhouse/*
 
       - uses: actions/upload-artifact@v3
         with:
@@ -97,7 +100,7 @@ jobs:
           python-version: "3.11"
 
       - name: install dependencies
-        run: python -m pip install wheel build
+        run: python -m pip install wheel build twine
 
       - name: create C++ tarballs
         run: |
@@ -118,6 +121,9 @@ jobs:
 
       - name: build metatensor sdist and wheel
         run: python -m build . --outdir=dist/
+
+      - name: check sdist and wheels with twine
+        run: twine check dist/*.tar.gz dist/*.whl
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -64,8 +64,3 @@ jobs:
         run: tox
         env:
           PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
-
-      - name: check we can build the wheels
-        run: tox -e build-tests
-        env:
-          PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu

--- a/scripts/build-all-wheels.sh
+++ b/scripts/build-all-wheels.sh
@@ -19,6 +19,7 @@ METATENSOR_CORE_VERSION=$(basename "$(find "$TMP_DIR"/dist -name "metatensor-cor
 METATENSOR_CORE_VERSION=${METATENSOR_CORE_VERSION%.tar.gz}
 
 python -m build python/metatensor-operations --outdir "$TMP_DIR"/dist
+python -m build python/metatensor-learn --outdir "$TMP_DIR"/dist
 python -m build . --outdir "$TMP_DIR"/dist
 
 # for metatensor-torch, we need a pre-built version of metatensor-core, so

--- a/tox.ini
+++ b/tox.ini
@@ -238,7 +238,7 @@ allowlist_externals = bash
 commands =
     python --version  # print the version of python used in this test
 
-    bash ./scripts/build-python.sh {envtmpdir}
+    bash ./scripts/build-all-wheels.sh {envtmpdir}
 
     twine check {envtmpdir}/dist/*.tar.gz
     twine check {envtmpdir}/dist/*.whl
@@ -246,6 +246,7 @@ commands =
     # check building wheels directly from the a checkout
     python -m build python/metatensor-core --wheel --outdir {envtmpdir}/dist
     python -m build python/metatensor-operations --wheel --outdir {envtmpdir}/dist
+    python -m build python/metatensor-learn --wheel --outdir {envtmpdir}/dist
     python -m build python/metatensor-torch --wheel --outdir {envtmpdir}/dist
     python -m build .  --wheel --outdir {envtmpdir}/dist
 


### PR DESCRIPTION
It takes a lot of CI time for very few issues caught. For now the code remains in tox for easier local debugging of future wheel building issues, it might be removed later. The wheels and sdists are checked with twine in a separate CI job.


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--497.org.readthedocs.build/en/497/

<!-- readthedocs-preview metatensor end -->