### PR TITLE
Do not re-export metatensor-learn

### DIFF
--- a/docs/src/learn/reference/data/index.rst
+++ b/docs/src/learn/reference/data/index.rst
@@ -5,25 +5,25 @@ Data utilites
 * :ref:`learn-data-dataloader`
 * :ref:`learn-data-collate`
 
-.. automodule:: metatensor.learn.data
-
 .. _learn-data-dataset:
 
 Dataset
 -------
 
-.. autoclass:: metatensor.learn.data.Dataset
+.. autoclass:: metatensor.learn.Dataset
    :members:
+   :special-members: __getitem__
 
-.. autoclass:: metatensor.learn.data.IndexedDataset
+.. autoclass:: metatensor.learn.IndexedDataset
    :members:
+   :special-members: __getitem__
 
 .. _learn-data-dataloader:
 
 Dataloader
 ----------
 
-.. autoclass:: metatensor.learn.data.DataLoader
+.. autoclass:: metatensor.learn.DataLoader
    :members:
 
 .. _learn-data-collate:

--- a/docs/src/learn/reference/nn/index.rst
+++ b/docs/src/learn/reference/nn/index.rst
@@ -3,8 +3,6 @@ Neural Network
 
 * :ref:`learn-nn-modules`
 
-.. automodule:: metatensor.learn.nn
-
 .. _learn-nn-modules:
 
 Modules

--- a/python/metatensor-core/metatensor/__init__.py
+++ b/python/metatensor-core/metatensor/__init__.py
@@ -14,18 +14,18 @@
 # only declares dependencies on `metatensor-core` and `metatensor-operation`; as well
 # an an optional dependency on `metatensor-torch`.
 
-from .version import __version__  # noqa
-from . import utils  # noqa
-from .block import TensorBlock  # noqa
-from .labels import Labels, LabelsEntry  # noqa
-from .status import MetatensorError  # noqa
-from .tensor import TensorMap  # noqa
-from .data import DeviceWarning  # noqa
+from .version import __version__  # noqa: F401
+from . import utils  # noqa: F401
+from .block import TensorBlock  # noqa: F401
+from .labels import Labels, LabelsEntry  # noqa: F401
+from .status import MetatensorError  # noqa: F401
+from .tensor import TensorMap  # noqa: F401
+from .data import DeviceWarning  # noqa: F401
 
-from .io import load, load_labels, save  # noqa
+from .io import load, load_labels, save  # noqa: F401
 
 try:
-    from . import operations  # noqa
+    from . import operations  # noqa: F401
 
     HAS_METATENSOR_OPERATIONS = True
 except ImportError:
@@ -33,16 +33,22 @@ except ImportError:
 
 
 if HAS_METATENSOR_OPERATIONS:
-    from .operations import *  # noqa
+    from .operations import *  # noqa: F401, F403
 
 else:
-    # __getattr__ is called when a symbol can not be found, we use it to give
+    # __getattr__ is called when a module attribute can not be found, we use it to give
     # the user a better error message if they don't have metatensor-operations
     def __getattr__(name):
         raise AttributeError(
             f"metatensor.{name} is not defined, are you sure you have the "
             "metatensor-operations package installed?"
         )
+
+
+try:
+    from . import learn  # noqa: F401
+except ImportError:
+    pass
 
 
 __all__ = [

--- a/python/metatensor-learn/metatensor/learn/__init__.py
+++ b/python/metatensor-learn/metatensor/learn/__init__.py
@@ -12,8 +12,6 @@ except ImportError:
 
 
 if HAS_TORCH:
-    from . import data, nn  # noqa
-
-    __all__ = ["data", "nn"]
-
-__all__ = []
+    from . import data, nn  # noqa: F401
+    from .data import DataLoader, Dataset, IndexedDataset  # noqa: F401
+    from .nn import ModuleMap, Linear  # noqa: F401

--- a/python/metatensor-learn/metatensor/learn/data/dataloader.py
+++ b/python/metatensor-learn/metatensor/learn/data/dataloader.py
@@ -2,8 +2,6 @@
 Module containing the DataLoader.
 """
 
-from typing import Callable
-
 import torch
 
 from .collate import group_and_join
@@ -11,20 +9,17 @@ from .collate import group_and_join
 
 class DataLoader(torch.utils.data.DataLoader):
     """
-    Class for loading data from an `:py:class:`torch.utils.data.Dataset` object
-    with a default collate function that supports :py:class:`torch.Tensor`,
-    :py:class:`atomistic.Systems`, or :py:class:`TensorMap`.
+    Class for loading data from an :py:class:`torch.utils.data.Dataset` object with a
+    default collate function (:py:func:`metatensor.learn.data.group_and_join`) that
+    supports :py:class:`torch.Tensor`, :py:class:`metatensor.torch.atomistic.System`,
+    :py:class:`metatensor.TensorMap`, and :py:class:`metatensor.torch.TensorMap`.
 
-    Any argument as accepted by the torch
-    :py:class:`torch.utils.data.DataLoader` parent class is supported. Please
-    refer to
-    https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader
+    The dataset wil typically be :py:class:`metatensor.learn.Dataset` or
+    :py:class:`metatensor.learn.IndexedDataset`.
+
+    Any argument as accepted by the torch :py:class:`torch.utils.data.DataLoader` parent
+    class is supported.
     """
 
-    def __init__(
-        self,
-        dataset: torch.utils.data.Dataset,
-        collate_fn: Callable = group_and_join,
-        **kwargs,
-    ):
+    def __init__(self, dataset, collate_fn=group_and_join, **kwargs):
         super().__init__(dataset, collate_fn=collate_fn, **kwargs)

--- a/python/metatensor-learn/metatensor/learn/data/dataset.py
+++ b/python/metatensor-learn/metatensor/learn/data/dataset.py
@@ -80,34 +80,34 @@ class _BaseDataset(torch.utils.data.Dataset):
 
 class Dataset(_BaseDataset):
     """
-    Defines a dataset class for various named data fields.
+    Defines a PyTorch compatible :py:class:`torch.data.Dataset` class for various named
+    data fields.
 
-    The data fields are specified as keyword arguments to the constructor, where
-    the keyword is the name of the field, and the value is either a list of data
-    objects or a callable.
+    The data fields are specified as keyword arguments to the constructor, where the
+    keyword is the name of the field, and the value is either a list of data objects or
+    a callable.
 
-    `size` specifies the number of samples in the dataset. This only needs to be
-    passed if all data fields are passed as callables. Otherwise, the size is
-    inferred from the length of the data fields passed as lists.
+    ``size`` specifies the number of samples in the dataset. This only needs to be
+    passed if all data fields are passed as callables. Otherwise, the size is inferred
+    from the length of the data fields passed as lists.
 
-    Every sample in the dataset is assigned a numeric ID from 0 to `size` - 1.
-    This ID can be used to access the corresponding sample. For instance,
-    `dataset[0]` returns a named tuple of all data fields for the first sample
-    in the dataset.
+    Every sample in the dataset is assigned a numeric ID from 0 to ``size - 1``. This ID
+    can be used to access the corresponding sample. For instance, ``dataset[0]`` returns
+    a named tuple of all data fields for the first sample in the dataset.
 
-    A data field kwarg passed as a list must be comprised of the same type of
-    object, and its length must be consistent with the `size` argument (if
-    specified) and the length of all other data fields passed as lists.
+    A data field kwarg passed as a list must be comprised of the same type of object,
+    and its length must be consistent with the ``size`` argument (if specified) and the
+    length of all other data fields passed as lists.
 
-    Otherwise a data field kwarg passed as a callable must take a single
-    argument corresponding to the numeric sample ID and return the data object
-    for that sample ID. This data field for a given sample is then only lazily
-    loaded into memory when the Dataset.__getitem__ method is called.
+    Otherwise a data field kwarg passed as a callable must take a single argument
+    corresponding to the numeric sample ID and return the data object for that sample
+    ID. This data field for a given sample is then only lazily loaded into memory when
+    the :py:meth:`Dataset.__getitem__` method is called.
 
-    :param size: Optional, an integer indicating the size of the dataset, i.e.
-        the number of samples. This only needs to be specified if all data
-    :param kwargs: List or Callable. Keyword arguments specifying the data
-        fields for the dataset.
+    :param size: Optional, an integer indicating the size of the dataset, i.e. the
+        number of samples. This only needs to be specified if all data
+    :param kwargs: List or Callable. Keyword arguments specifying the data fields for
+        the dataset.
     """
 
     def __init__(self, size: Optional[int] = None, **kwargs):
@@ -122,12 +122,11 @@ class Dataset(_BaseDataset):
 
     def __getitem__(self, idx: int) -> NamedTuple:
         """
-        Returns the data for each field corresponding to the internal index
-        `idx`.
+        Returns the data for each field corresponding to the internal index ``idx``.
 
-        Each item can be accessed with `self[idx]`. Returned is a named tuple
-        with fields corresponding to those passed (in order) to the constructor
-        upon class initialization.
+        Each item can be accessed with ``self[idx]``. Returned is a named tuple with
+        fields corresponding to those passed (in order) to the constructor upon class
+        initialization.
         """
         if idx not in self._indices:
             raise ValueError(f"Index {idx} not in dataset")
@@ -151,30 +150,30 @@ class Dataset(_BaseDataset):
 
 class IndexedDataset(_BaseDataset):
     """
-    Defines a dataset class for various named data fields, with sample indexed
-    by a list of unique sample IDs.
+    Defines a PyTorch compatible :py:class:`torch.data.Dataset` class for various named
+    data fields, with sample indexed by a list of unique sample IDs.
 
-    The data fields are specified as keyword arguments to the constructor, where
-    the keyword is the name of the field, and the value is either a list of data
-    objects or a callable.
+    The data fields are specified as keyword arguments to the constructor, where the
+    keyword is the name of the field, and the value is either a list of data objects or
+    a callable.
 
-    `sample_id` must be a unique list of any hashable object. Each respective
-    sample ID is assigned an internal numeric index from 0 to `len(sample_id)`
-    - 1. This is used to internally index the dataset, and can be used to access
-    a given sample. For instance, `dataset[0]` returns a named tuple of all data
-    fields for the first sample in the dataset, i.e. the one with unique sample
-    ID at `sample_id[0]`. In order to access a sample by its ID, use the
-    Dataset.get_sample method.
+    ``sample_id`` must be a unique list of any hashable object. Each respective sample
+    ID is assigned an internal numeric index from 0 to ``len(sample_id) - 1``. This is
+    used to internally index the dataset, and can be used to access a given sample. For
+    instance, ``dataset[0]`` returns a named tuple of all data fields for the first
+    sample in the dataset, i.e. the one with unique sample ID at ``sample_id[0]``. In
+    order to access a sample by its ID, use the :py:meth:`IndexedDataset.get_sample`
+    method.
 
-    A data field kwarg passed as a list must be comprised of the same type of
-    object, and its length must be consistent with the length of `sample_id`
-    and the length of all other data fields passed as lists.
+    A data field kwarg passed as a list must be comprised of the same type of object,
+    and its length must be consistent with the length of ``sample_id`` and the length of
+    all other data fields passed as lists.
 
-    Otherwise a data field kwarg passed as a callable must take a single
-    argument corresponding to the unique sample ID (i.e. those passed in
-    `sample_id`) and return the data object for that sample ID. This data field
-    for a given sample is then only lazily loaded into memory when the
-    Dataset.__getitem__ or Dataset.get_sample methods are called.
+    Otherwise a data field kwarg passed as a callable must take a single argument
+    corresponding to the unique sample ID (i.e. those passed in ``sample_id``) and
+    return the data object for that sample ID. This data field for a given sample is
+    then only lazily loaded into memory when :py:meth:`IndexedDataset.__getitem__` or
+    :py:meth:`IndexedDataset.get_sample` methods are called.
 
     :param sample_id: A list of unique IDs for each sample in the dataset.
     :param kwargs: Keyword arguments specifying the data fields for the dataset.
@@ -198,12 +197,11 @@ class IndexedDataset(_BaseDataset):
 
     def __getitem__(self, idx: int) -> NamedTuple:
         """
-        Returns the data for each field corresponding to the internal index
-        `idx`.
+        Returns the data for each field corresponding to the internal index ``idx``.
 
-        Each item can be accessed with `self[idx]`. Returned is a named tuple,
-        whose first field is the sample ID, and the remaining fields correspond
-        those passed (in order) to the constructor upon class initialization.
+        Each item can be accessed with ``self[idx]``. Returned is a named tuple, whose
+        first field is the sample ID, and the remaining fields correspond those passed
+        (in order) to the constructor upon class initialization.
         """
         if idx not in self._indices:
             raise ValueError(f"Index {idx} not in dataset")
@@ -226,8 +224,7 @@ class IndexedDataset(_BaseDataset):
 
     def get_sample(self, sample_id) -> NamedTuple:
         """
-        Returns a named tuple for the sample corresponding to the given
-        `sample_id`.
+        Returns a named tuple for the sample corresponding to the given ``sample_id``.
         """
         if sample_id not in self._sample_id_to_idx:
             raise ValueError(f"Sample ID '{sample_id}' not in dataset")

--- a/python/metatensor-torch/metatensor/torch/__init__.py
+++ b/python/metatensor-torch/metatensor/torch/__init__.py
@@ -1,9 +1,9 @@
 import os
 import torch
 
-from .version import __version__  # noqa
+from .version import __version__  # noqa: F401
 from ._c_lib import _load_library
-from . import utils  # noqa
+from . import utils  # noqa: F401
 
 
 if os.environ.get("METATENSOR_IMPORT_FOR_SPHINX") is not None:
@@ -24,12 +24,9 @@ else:
     save = torch.ops.metatensor.save
     save_buffer = torch.ops.metatensor.save_buffer
 
-from . import atomistic  # noqa
-
-MISSING_SUBPACKAGES = []
 
 try:
-    import metatensor.operations  # noqa
+    import metatensor.operations  # noqa: F401
 
     HAS_METATENSOR_OPERATIONS = True
 except ImportError:
@@ -37,37 +34,26 @@ except ImportError:
 
 
 if HAS_METATENSOR_OPERATIONS:
-    from . import operations  # noqa
-    from .operations import *  # noqa
+    from . import operations  # noqa: F401
+    from .operations import *  # noqa: F401, F403
 else:
-    MISSING_SUBPACKAGES.append("metatensor-operations")
+    # __getattr__ is called when a module attribute can not be found, we use it to give
+    # the user a better error message if they don't have metatensor-operations
+    def __getattr__(name):
+        raise AttributeError(
+            f"metatensor.torch.{name} is not defined, are you sure you have the "
+            "metatensor-operations package installed?"
+        )
 
 
 try:
-    import metatensor.learn  # noqa
+    import metatensor.learn  # noqa: F401
+    from . import learn  # noqa: F401
 
-    HAS_METATENSOR_LEARN = True
 except ImportError:
-    HAS_METATENSOR_LEARN = False
+    pass
 
-
-if HAS_METATENSOR_LEARN:
-    from . import learn  # noqa
-    from .learn import *  # noqa
-else:
-    MISSING_SUBPACKAGES.append("metatensor-learn")
-
-
-if not (HAS_METATENSOR_LEARN) or not (HAS_METATENSOR_OPERATIONS):
-    # __getattr__ is called when a symbol can not be found, we use it to give
-    # the user a better error message if they don't have all metatensor subpackages
-    def __getattr__(name):
-        raise AttributeError(
-            f"metatensor.torch.{name} is not defined, you might have not "
-            "installed the corresponding metatensor subpackage "
-            f"({' or '.join(MISSING_SUBPACKAGES)})."
-        )
-
+from . import atomistic  # noqa: F401
 
 __all__ = [
     "Labels",


### PR DESCRIPTION
Otherwise it gets confusing what is coming from metatensor-learn and what is coming from metatensor-operations. This was already different between -core and -torch anyway, so this PR makes everything the same, following the current -core version.

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [x] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--502.org.readthedocs.build/en/502/

<!-- readthedocs-preview metatensor end -->