### PR TITLE
Upgrade CI

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -39,7 +39,7 @@ jobs:
             rust-target: x86_64-pc-windows-msvc
             cibw_arch: AMD64
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -50,7 +50,7 @@ jobs:
           target: ${{ matrix.rust-target }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -90,12 +90,12 @@ jobs:
   build-others:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: install dependencies
         run: python -m pip install cibuildwheel twine
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: install dependencies
         run: python -m pip install wheel build twine

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-22.04
     name: collect code coverage
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -34,9 +34,9 @@ jobs:
           key: tox-${{ hashFiles('pyproject.toml', 'setup.cfg', 'tox.ini') }}
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.4
         with:
-          version: "v0.5.4"
+          version: "v0.7.7"
 
       - name: Setup sccache environnement variables
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
       - name: setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: install python dependencies
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: install dependencies
         run: |
           python -m pip install tox

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: setup rust
@@ -23,7 +23,7 @@ jobs:
         with:
           toolchain: stable
       - name: setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: install dependencies

--- a/.github/workflows/julia-tests.yml
+++ b/.github/workflows/julia-tests.yml
@@ -31,7 +31,7 @@ jobs:
           # - os: windows-2019
           #   julia-version: "1.9"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -46,9 +46,9 @@ jobs:
           toolchain: stable
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.4
         with:
-          version: "v0.5.4"
+          version: "v0.7.7"
 
       - name: Setup sccache environnement variables
         run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -26,12 +26,12 @@ jobs:
           - os: windows-2019
             python-version: "3.12"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -41,9 +41,9 @@ jobs:
           toolchain: stable
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.4
         with:
-          version: "v0.5.4"
+          version: "v0.7.7"
 
       - name: setup MSVC command prompt
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -20,11 +20,11 @@ jobs:
           - os: ubuntu-20.04
             python-version: "3.8"
           - os: ubuntu-20.04
-            python-version: "3.11"
+            python-version: "3.12"
           - os: macos-11
-            python-version: "3.11"
+            python-version: "3.12"
           - os: windows-2019
-            python-version: "3.11"
+            python-version: "3.12"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -66,7 +66,7 @@ jobs:
           apt install -y software-properties-common
           apt install -y cmake make gcc g++ git curl
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -87,9 +87,9 @@ jobs:
           sudo apt-get install -y valgrind
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.4
         with:
-          version: "v0.5.4"
+          version: "v0.7.7"
 
       - name: Setup sccache environnement variables
         run: |
@@ -113,10 +113,10 @@ jobs:
     runs-on: ubuntu-20.04
     name: check C API declarations
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -147,7 +147,7 @@ jobs:
     name: check leftover debug print
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: install ripgrep
         run: |

--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -24,18 +24,18 @@ jobs:
             do-valgrind: true
 
           - os: ubuntu-20.04
-            torch-version: 2.1.*
+            torch-version: 2.2.*
             python-version: "3.11"
             cargo-test-flags:
             cxx-flags: -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -g
 
           - os: macos-11
-            torch-version: 2.1.*
+            torch-version: 2.2.*
             python-version: "3.11"
             cargo-test-flags: --release
 
           - os: windows-2019
-            torch-version: 2.1.*
+            torch-version: 2.2.*
             python-version: "3.11"
             cargo-test-flags: --release
     steps:

--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -39,7 +39,7 @@ jobs:
             python-version: "3.12"
             cargo-test-flags: --release
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -50,7 +50,7 @@ jobs:
 
       # we get torch from pip to run the C++ test
       - name: setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -61,9 +61,9 @@ jobs:
           sudo apt-get install -y valgrind
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.4
         with:
-          version: "v0.5.4"
+          version: "v0.7.7"
 
       - name: Setup sccache environnement variables
         run: |

--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -25,18 +25,18 @@ jobs:
 
           - os: ubuntu-20.04
             torch-version: 2.2.*
-            python-version: "3.11"
-            cargo-test-flags:
+            python-version: "3.12"
+            cargo-test-flags: ""
             cxx-flags: -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -g
 
           - os: macos-11
             torch-version: 2.2.*
-            python-version: "3.11"
+            python-version: "3.12"
             cargo-test-flags: --release
 
           - os: windows-2019
             torch-version: 2.2.*
-            python-version: "3.11"
+            python-version: "3.12"
             cargo-test-flags: --release
     steps:
       - uses: actions/checkout@v3

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,8 +11,8 @@ build:
     - cmake
   tools:
     # Set the version of Python and other tools we need
-    python: "3.11"
-    rust: "1.70"
+    python: "3.12"
+    rust: "1.75"
   jobs:
     post_install:
       # install metatensor-torch with the CPU version of PyTorch we can not use

--- a/metatensor-torch/tests/utils/mod.rs
+++ b/metatensor-torch/tests/utils/mod.rs
@@ -84,7 +84,7 @@ pub fn setup_pytorch(build_dir: PathBuf) -> PathBuf {
         .expect("failed to run python");
     assert!(status.success(), "failed to run `python -m pip install --upgrade pip`");
 
-    let torch_version = std::env::var("METATENSOR_TORCH_TEST_VERSION").unwrap_or("2.1.*".into());
+    let torch_version = std::env::var("METATENSOR_TORCH_TEST_VERSION").unwrap_or("2.2.*".into());
     let status = Command::new(&python)
         .arg("-m")
         .arg("pip")

--- a/python/metatensor-core/pyproject.toml
+++ b/python/metatensor-core/pyproject.toml
@@ -39,7 +39,7 @@ requires = [
     "setuptools >=68",
     "packaging >=23",
     "wheel >=0.41",
-    "cmake <3.28",  # this should be changed once cmake 3.28.1 is on PyPI
+    "cmake",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/python/metatensor-torch/pyproject.toml
+++ b/python/metatensor-torch/pyproject.toml
@@ -36,7 +36,7 @@ changelog = "https://lab-cosmo.github.io/metatensor/latest/torch/CHANGELOG.html"
 requires = [
     "setuptools >=68",
     "packaging >=23",
-    "cmake <3.28",  # this should be changed once cmake 3.28.1 is on PyPI
+    "cmake",
     "torch >= 1.11",
 ]
 

--- a/python/scripts/rustc-manylinux2014_x86_64/Dockerfile
+++ b/python/scripts/rustc-manylinux2014_x86_64/Dockerfile
@@ -5,7 +5,7 @@ RUN yum install git -y
 RUN git config --global --add safe.directory /code
 
 # Download rustup-init asn install
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.65
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.75
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV RUST_BUILD_TARGET="x86_64-unknown-linux-gnu"

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,23 @@ package = external
 package_env = build-metatensor-core
 lint_folders = "{toxinidir}/python" "{toxinidir}/setup.py"
 build_single_wheel = --no-deps --no-build-isolation --check-build-dependencies
-test_options = --cov={env_site_packages_dir}/metatensor --cov-append --cov-report= --import-mode=append -W error
+warning_options = -W error \
+    -W "ignore:ast.Str is deprecated and will be removed in Python 3.14:DeprecationWarning" \
+    -W "ignore:Attribute s is deprecated and will be removed in Python 3.14:DeprecationWarning" \
+    -W "ignore:ast.NameConstant is deprecated and will be removed in Python 3.14:DeprecationWarning"
+# the "-W ignore" flags above are for PyTorch, which triggers a bunch of
+# internal warnings with Python 3.12
+
+
+test_options =
+    --cov={env_site_packages_dir}/metatensor --cov-append --cov-report= \
+    --import-mode=append \
+    {[testenv]warning_options}
+
+packaging_deps =
+    setuptools
+    packaging
+    wheel
 
 
 [testenv:build-metatensor-core]
@@ -28,10 +44,8 @@ description =
     requiring metatensor to be installed
 passenv = *
 deps =
-    cmake <3.28
-    setuptools
-    packaging
-    wheel
+    {[testenv]packaging_deps}
+    cmake
 
 commands =
     pip wheel python/metatensor-core {[testenv]build_single_wheel} --wheel-dir {envtmpdir}/dist
@@ -53,7 +67,7 @@ commands =
 description =
     Run the tests of the metatensor-operations Python package using numpy arrays
 deps =
-    packaging
+    {[testenv]packaging_deps}
     numpy
     pytest
     pytest-cov
@@ -85,7 +99,7 @@ commands =
 description =
     Run the tests of the metatensor-learn Python package using numpy arrays
 deps =
-    packaging
+    {[testenv]packaging_deps}
     numpy
     pytest
     pytest-cov
@@ -106,7 +120,7 @@ description =
     Run the tests of the metatensor-learn Python package using torch arrays
 deps =
     torch
-    cmake <3.28
+    cmake
     {[testenv:learn-numpy-tests]deps}
 changedir =
     {[testenv:learn-numpy-tests]changedir}
@@ -117,9 +131,10 @@ commands =
 [testenv:torch-tests]
 description = Run the tests of the metatensor-torch Python package
 deps =
-    cmake <3.28
+    {[testenv]packaging_deps}
+    cmake
+
     numpy
-    packaging
     pytest
     pytest-cov
     torch
@@ -144,11 +159,13 @@ commands =
 [testenv:docs-tests]
 description = Run the doctests defined in any metatensor package
 deps =
+    {[testenv]packaging_deps}
+    cmake
+
     pytest
     numpy
     torch
     ase
-    cmake <3.28
 
 setenv =
     # ignore the fact that metatensor.torch.operations was loaded from a file
@@ -167,7 +184,7 @@ commands =
     pip install python/metatensor-torch {[testenv]build_single_wheel} --force-reinstall
 
     # run documentation tests
-    pytest --doctest-modules --pyargs metatensor -W error
+    pytest --doctest-modules --pyargs metatensor {[testenv]warning_options}
 
 
 [testenv:lint]
@@ -204,7 +221,8 @@ commands =
 description = build the documentation with sphinx
 deps =
     -r docs/requirements.txt
-    cmake <3.28
+    {[testenv]packaging_deps}
+    cmake
 
 allowlist_externals = bash
 commands =


### PR DESCRIPTION
This does multiple upgrades to the CI environement:

- ~Use M1 runners for macOS CI;~ EDIT: no longer part of this PR, will be done later
- Use rustc 1.75 to build the linux wheels 
- Use Python 3.12 instead of 3.11 as out highest supported version
- Use Torch 2.2 for the C++ tests

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--503.org.readthedocs.build/en/503/

<!-- readthedocs-preview metatensor end -->