### PR TITLE
Pin last rustc 1.65 version of ahash

### DIFF
--- a/metatensor-core/Cargo.toml
+++ b/metatensor-core/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "staticlib"]
 bench = false
 
 [dependencies]
-ahash = "0.8"
+ahash = "=0.8.7"  # last version supporting rustc 1.65
 hashbrown = "0.14"
 indexmap = "2"
 once_cell = "1"


### PR DESCRIPTION
The latest version of `ahash` requires rustc 1.72, which for now we don't want to enforce.

<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--505.org.readthedocs.build/en/505/

<!-- readthedocs-preview metatensor end -->