### PR TITLE
Generate and use a lockfile in metatensor-core

### DIFF
--- a/metatensor-core/CMakeLists.txt
+++ b/metatensor-core/CMakeLists.txt
@@ -127,16 +127,21 @@ endif()
 # ============================================================================ #
 # determine Cargo flags
 
+set(CARGO_BUILD_ARG "")
+
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.lock)
+    set(CARGO_BUILD_ARG "${CARGO_BUILD_ARG};--locked")
+endif()
+
 # TODO: support multiple configuration generators (MSVC, ...)
 string(TOLOWER ${CMAKE_BUILD_TYPE} BUILD_TYPE)
 if ("${BUILD_TYPE}" STREQUAL "debug")
-    set(CARGO_BUILD_ARG "")
     set(CARGO_BUILD_TYPE "debug")
 elseif("${BUILD_TYPE}" STREQUAL "release")
-    set(CARGO_BUILD_ARG "--release")
+    set(CARGO_BUILD_ARG "${CARGO_BUILD_ARG};--release")
     set(CARGO_BUILD_TYPE "release")
 elseif("${BUILD_TYPE}" STREQUAL "relwithdebinfo")
-    set(CARGO_BUILD_ARG "--release")
+    set(CARGO_BUILD_ARG "${CARGO_BUILD_ARG};--release")
     set(CARGO_BUILD_TYPE "release")
 else()
     message(FATAL_ERROR "unsuported build type: ${CMAKE_BUILD_TYPE}")
@@ -190,7 +195,7 @@ if (CARGO_VERSION_CHANGED)
     file(APPEND "${TMPDIR}/_cargo_required_libs/Cargo.toml" "[lib]\ncrate-type=[\"staticlib\"]")
 
     execute_process(
-        COMMAND ${CARGO_EXE} rustc --verbose --color never --target=${RUST_BUILD_TARGET} -- --print=native-static-libs
+        COMMAND ${CARGO_EXE} rustc --color never --target=${RUST_BUILD_TARGET} -- --print=native-static-libs
         WORKING_DIRECTORY "${TMPDIR}/_cargo_required_libs"
         RESULT_VARIABLE cargo_build_result
         ERROR_VARIABLE cargo_build_error_message

--- a/metatensor-core/CMakeLists.txt
+++ b/metatensor-core/CMakeLists.txt
@@ -232,8 +232,6 @@ if (CARGO_VERSION_CHANGED)
     endif()
 endif()
 
-# ============================================================================ #
-
 file(GLOB_RECURSE ALL_RUST_SOURCES
     ${PROJECT_SOURCE_DIR}/Cargo.toml
     ${PROJECT_SOURCE_DIR}/src/**.rs
@@ -275,6 +273,19 @@ if (NOT "${EXTRA_RUST_FLAGS}" STREQUAL "")
     set(CARGO_RUSTC_ARGS "${CARGO_RUSTC_ARGS};${EXTRA_RUST_FLAGS}")
 endif()
 
+if (METATENSOR_INSTALL_BOTH_STATIC_SHARED)
+    set(CARGO_BUILD_ARG "${CARGO_BUILD_ARG};--crate-type=cdylib;--crate-type=staticlib")
+    set(FILES_CREATED_BY_CARGO "${METATENSOR_SHARED_LIB_NAME} and ${METATENSOR_STATIC_LIB_NAME}")
+else()
+    if (BUILD_SHARED_LIBS)
+        set(CARGO_BUILD_ARG "${CARGO_BUILD_ARG};--crate-type=cdylib")
+        set(FILES_CREATED_BY_CARGO "${METATENSOR_SHARED_LIB_NAME}")
+    else()
+        set(CARGO_BUILD_ARG "${CARGO_BUILD_ARG};--crate-type=staticlib")
+        set(FILES_CREATED_BY_CARGO "${METATENSOR_STATIC_LIB_NAME}")
+    endif()
+endif()
+
 add_custom_target(cargo-build-metatensor ALL
     COMMAND
         ${CMAKE_COMMAND} -E env
@@ -284,7 +295,7 @@ add_custom_target(cargo-build-metatensor ALL
         cargo rustc ${CARGO_BUILD_ARG} -- ${CARGO_RUSTC_ARGS}
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     DEPENDS ${ALL_RUST_SOURCES}
-    COMMENT "Building ${METATENSOR_SHARED_LIB_NAME} and ${METATENSOR_STATIC_LIB_NAME} with cargo"
+    COMMENT "Building ${FILES_CREATED_BY_CARGO} with cargo"
     BYPRODUCTS ${METATENSOR_STATIC_LOCATION} ${METATENSOR_SHARED_LOCATION} ${METATENSOR_IMPLIB_LOCATION}
 )
 

--- a/metatensor-core/Cargo.toml
+++ b/metatensor-core/Cargo.toml
@@ -9,10 +9,7 @@ exclude = [
 ]
 
 [lib]
-# When our minimal Rust version becomes 1.65, we can pass these options directly
-# to Cargo. Until then, we build all the crate-type we need.
 name = "metatensor"
-crate-type = ["cdylib", "staticlib"]
 bench = false
 
 [dependencies]
@@ -28,7 +25,6 @@ num-traits = {version = "0.2", default-features = false}
 zip = {version = "0.6", default-features = false}
 
 [build-dependencies]
-# pin cbdingen until https://github.com/mozilla/cbindgen/issues/841 is fixed
 cbindgen = { version = "0.26", default-features = false }
 
 [dev-dependencies]

--- a/scripts/package-core.sh
+++ b/scripts/package-core.sh
@@ -39,6 +39,8 @@ cd "$TMP_DIR"
 # use metatensor rust crate in a project using workspaces).
 echo "[workspace]" >> "$ARCHIVE_NAME/Cargo.toml"
 
+cargo generate-lockfile --manifest-path "$ARCHIVE_NAME/Cargo.toml"
+
 tar cf "$ARCHIVE_NAME.tar" "$ARCHIVE_NAME"
 gzip -9 "$ARCHIVE_NAME.tar"
 


### PR DESCRIPTION
This makes sure a given version of metatensor-core will always use the exact same dependencies version, saving us a lot of headache in the long term.

In particular, this would prevent the issue in https://github.com/Luthaf/rascaline/pull/280 from happening.


# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
