### PR TITLE
Better error message when saving TensorMap with dtype != float64

### DIFF
--- a/python/metatensor-core/metatensor/data/array.py
+++ b/python/metatensor-core/metatensor/data/array.py
@@ -244,7 +244,11 @@ def _mts_array_data(this, data):
         raise ValueError("can not get data pointer for non contiguous array")
 
     if not array.dtype == np.float64:
-        raise ValueError(f"can not get data pointer for array type {array.dtype}")
+        raise ValueError(
+            f"can not get data pointer for array type {array.dtype}, "
+            "only float64 is supported. If you are trying to save a TensorMap "
+            "to a file, you can set `use_numpy=True`."
+        )
 
     data[0] = array.ctypes.data_as(ctypes.POINTER(ctypes.c_double))
 


### PR DESCRIPTION
Trying to save a float32 TensorMap will result in a slightly confusing error message, hopefully this improves it.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--523.org.readthedocs.build/en/523/

<!-- readthedocs-preview metatensor end -->