### PR TITLE
Don't check patch torch version when loading from CMake

### DIFF
--- a/metatensor-torch/cmake/metatensor_torch-config.in.cmake
+++ b/metatensor-torch/cmake/metatensor_torch-config.in.cmake
@@ -4,11 +4,20 @@ include(CMakeFindDependencyMacro)
 set(REQUIRED_METATENSOR_VERSION @REQUIRED_METATENSOR_VERSION@)
 find_package(metatensor ${REQUIRED_METATENSOR_VERSION} CONFIG REQUIRED)
 
-# We can only load metatensor_torch with the exact same version of Torch that
+# We can only load metatensor_torch with the same minor version of Torch that
 # was used to compile it (and is stored in BUILD_TORCH_VERSION)
 set(BUILD_TORCH_VERSION @Torch_VERSION@)
+set(BUILD_TORCH_MAJOR @Torch_VERSION_MAJOR@)
+set(BUILD_TORCH_MINOR @Torch_VERSION_MINOR@)
 
-find_package(Torch ${BUILD_TORCH_VERSION} REQUIRED EXACT)
+find_package(Torch ${BUILD_TORCH_VERSION} REQUIRED)
 
+if (NOT "${BUILD_TORCH_MAJOR}" STREQUAL "${Torch_VERSION_MAJOR}")
+    message(FATAL_ERROR "found incompatible torch version: metatensor-torch was built against v${BUILD_TORCH_VERSION} but we found v${Torch_VERSION}")
+endif()
+
+if (NOT "${BUILD_TORCH_MINOR}" STREQUAL "${Torch_VERSION_MINOR}")
+    message(FATAL_ERROR "found incompatible torch version: metatensor-torch was built against v${BUILD_TORCH_VERSION} but we found v${Torch_VERSION}")
+endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/metatensor_torch-targets.cmake)


### PR DESCRIPTION
Otherwise wheels built with torch x.y.0 can not be used to build e.g. rascaline-torch with torch x.y.z

This hit me today with the release of torch 2.2.1, and I had to purge the pip cache to re-create metatensor-torch wheel.


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--527.org.readthedocs.build/en/527/

<!-- readthedocs-preview metatensor end -->