### PR TITLE
Check the `selected_atoms` given by the engine

### DIFF
--- a/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 import torch
 
@@ -6,7 +6,7 @@ from .. import Labels, TensorMap
 from . import ModelOutput, System
 
 
-def check_outputs(
+def _check_outputs(
     systems: List[System],
     requested: Dict[str, ModelOutput],
     selected_atoms: Optional[Labels],
@@ -66,10 +66,10 @@ def _check_energy(
 
     # check samples values from systems & selected_atoms
     if request.per_atom:
-        expected_values: List[Tuple[int, int]] = []
+        expected_values: List[List[int]] = []
         for s, system in enumerate(systems):
             for a in range(len(system)):
-                expected_values.append((s, a))
+                expected_values.append([s, a])
 
         expected_samples = Labels(["system", "atom"], torch.tensor(expected_values))
         if selected_atoms is not None:

--- a/python/metatensor-torch/tests/atomistic/ase_calculator.py
+++ b/python/metatensor-torch/tests/atomistic/ase_calculator.py
@@ -30,18 +30,15 @@ class LennardJones(torch.nn.Module):
     API. This is then compared against the implementation inside ASE.
     """
 
-    def __init__(self, cutoff, params):
+    def __init__(self, cutoff, epsilon, sigma):
         super().__init__()
         self._nl_options = NeighborsListOptions(model_cutoff=cutoff, full_list=False)
 
-        self._lj_params = {}
-        for (a, b), (s, e) in params.items():
-            # shift the energy to 0 at the cutoff
-            shift = 4 * e * ((s / cutoff) ** 12 - (s / cutoff) ** 6)
-            if a in self._lj_params:
-                self._lj_params[a][b] = (s, e, shift)
-            else:
-                self._lj_params[a] = {b: (s, e, shift)}
+        self._epsilon = epsilon
+        self._sigma = sigma
+
+        # shift the energy to 0 at the cutoff
+        self._shift = 4 * epsilon * ((sigma / cutoff) ** 12 - (sigma / cutoff) ** 6)
 
     def forward(
         self,
@@ -52,57 +49,50 @@ class LennardJones(torch.nn.Module):
         if "energy" not in outputs:
             return {}
 
-        if selected_atoms is not None:
-            # TODO: add selected_atoms
-            raise NotImplementedError("selected atoms is not yet implemented")
-
         per_atoms = outputs["energy"].per_atom
 
         all_energies = []
-        for system in systems:
+        for system_i, system in enumerate(systems):
             neighbors = system.get_neighbors_list(self._nl_options)
             all_i = neighbors.samples.column("first_atom").to(torch.long)
             all_j = neighbors.samples.column("second_atom").to(torch.long)
 
-            types = system.types
-            positions = system.positions
+            energy = torch.zeros(len(system), dtype=system.positions.dtype)
+
+            distances = neighbors.values.reshape(-1, 3)
+
+            sigma_r_6 = (self._sigma / torch.linalg.vector_norm(distances, dim=1)) ** 6
+            sigma_r_12 = sigma_r_6 * sigma_r_6
+            e = 4.0 * self._epsilon * (sigma_r_12 - sigma_r_6) - self._shift
+
+            # We only compute each pair once (full_list=False in self._nl_options),
+            # and assign half of the energy to each atom
+            energy = energy.index_add(0, all_i, e, alpha=0.5)
+            energy = energy.index_add(0, all_j, e, alpha=0.5)
+
+            if selected_atoms is not None:
+                current_system = torch.where(
+                    selected_atoms.column("system") == system_i
+                )
+                current_atoms = selected_atoms.column("atom")
+                current_atoms = current_atoms[current_system].to(torch.long)
+                energy = energy[current_atoms]
 
             if per_atoms:
-                energy = torch.zeros(positions.shape[0], dtype=positions.dtype)
+                all_energies.append(energy)
             else:
-                energy = torch.zeros(1, dtype=positions.dtype)
-
-            for i, j, distance in zip(all_i, all_j, neighbors.values.reshape(-1, 3)):
-                sigma, epsilon, shift = self._lj_params[int(types[i])][int(types[j])]
-                r2 = distance.dot(distance)
-
-                r6 = r2 * r2 * r2
-
-                sigma3 = sigma * sigma * sigma
-                sigma6 = sigma3 * sigma3
-
-                sigma_r_6 = sigma6 / r6
-                sigma_r_12 = sigma_r_6 * sigma_r_6
-
-                e = 4.0 * epsilon * (sigma_r_12 - sigma_r_6) - shift
-
-                if per_atoms:
-                    # We only compute each pair once (full_list=False in
-                    # self._nl_options), and assign half of the energy to each atom
-                    energy[i] += e / 2.0
-                    energy[j] += e / 2.0
-                else:
-                    energy[0] += e
-
-            all_energies.append(energy)
+                all_energies.append(energy.sum(0, keepdim=True))
 
         if per_atoms:
-            samples_list: List[List[int]] = []
-            for s, system in enumerate(systems):
-                for a in range(len(system)):
-                    samples_list.append([s, a])
+            if selected_atoms is None:
+                samples_list: List[List[int]] = []
+                for s, system in enumerate(systems):
+                    for a in range(len(system)):
+                        samples_list.append([s, a])
 
-            samples = Labels(["system", "atom"], torch.tensor(samples_list))
+                samples = Labels(["system", "atom"], torch.tensor(samples_list))
+            else:
+                samples = selected_atoms
         else:
             samples = Labels(["system"], torch.arange(len(systems)).reshape(-1, 1))
 
@@ -127,10 +117,7 @@ EPSILON = 0.1729
 
 @pytest.fixture
 def model():
-    model = LennardJones(
-        cutoff=CUTOFF,
-        params={(28, 28): (SIGMA, EPSILON)},
-    )
+    model = LennardJones(cutoff=CUTOFF, sigma=SIGMA, epsilon=EPSILON)
     model.train(False)
 
     capabilities = ModelCapabilities(
@@ -141,7 +128,7 @@ def model():
             "energy": ModelOutput(
                 quantity="energy",
                 unit="eV",
-                per_atom=False,
+                per_atom=True,
                 explicit_gradients=[],
             ),
         },
@@ -156,12 +143,8 @@ def model():
 def model_different_units():
     model = LennardJones(
         cutoff=CUTOFF / ase.units.Bohr,
-        params={
-            (28, 28): (
-                SIGMA / ase.units.Bohr,
-                EPSILON / ase.units.kJ * ase.units.mol,
-            )
-        },
+        sigma=SIGMA / ase.units.Bohr,
+        epsilon=EPSILON / ase.units.kJ * ase.units.mol,
     )
     model.train(False)
 
@@ -173,7 +156,7 @@ def model_different_units():
             "energy": ModelOutput(
                 quantity="energy",
                 unit="kJ/mol",
-                per_atom=False,
+                per_atom=True,
                 explicit_gradients=[],
             ),
         },
@@ -182,6 +165,18 @@ def model_different_units():
 
     metadata = ModelMetadata()
     return MetatensorAtomisticModel(model, metadata, capabilities)
+
+
+@pytest.fixture
+def atoms():
+    np.random.seed(0xDEADBEEF)
+
+    atoms = ase.build.make_supercell(
+        ase.build.bulk("Ni", "fcc", a=3.6, cubic=True), 2 * np.eye(3)
+    )
+    atoms.positions += 0.2 * np.random.rand(*atoms.positions.shape)
+
+    return atoms
 
 
 def check_against_ase_lj(atoms, calculator):
@@ -198,48 +193,85 @@ def check_against_ase_lj(atoms, calculator):
     assert np.allclose(ref.get_stress(), atoms.get_stress())
 
 
-@pytest.fixture
-def atoms():
-    np.random.seed(0xDEADBEEF)
-
-    atoms = ase.build.make_supercell(
-        ase.build.bulk("Ni", "fcc", a=3.6, cubic=True), 2 * np.eye(3)
-    )
-    atoms.positions += 0.2 * np.random.rand(*atoms.positions.shape)
-
-    return atoms
-
-
 def test_python_model(model, model_different_units, atoms):
-    check_against_ase_lj(atoms, MetatensorCalculator(model))
-    check_against_ase_lj(atoms, MetatensorCalculator(model_different_units))
+    check_against_ase_lj(atoms, MetatensorCalculator(model, check_consistency=True))
+    check_against_ase_lj(
+        atoms, MetatensorCalculator(model_different_units, check_consistency=True)
+    )
 
 
 def test_torch_script_model(model, model_different_units, atoms):
     model = torch.jit.script(model)
-    check_against_ase_lj(atoms, MetatensorCalculator(model))
+    check_against_ase_lj(atoms, MetatensorCalculator(model, check_consistency=True))
 
     model_different_units = torch.jit.script(model_different_units)
-    check_against_ase_lj(atoms, MetatensorCalculator(model_different_units))
+    check_against_ase_lj(
+        atoms, MetatensorCalculator(model_different_units, check_consistency=True)
+    )
 
 
 def test_exported_model(tmpdir, model, model_different_units, atoms):
     path = os.path.join(tmpdir, "exported-model.pt")
     model.export(path)
-    check_against_ase_lj(atoms, MetatensorCalculator(path))
+    check_against_ase_lj(atoms, MetatensorCalculator(path, check_consistency=True))
 
     model_different_units.export(path)
-    check_against_ase_lj(atoms, MetatensorCalculator(path))
+    check_against_ase_lj(atoms, MetatensorCalculator(path, check_consistency=True))
 
 
 def test_get_properties(model, atoms):
     atoms.calc = MetatensorCalculator(model, check_consistency=True)
 
-    properties = atoms.get_properties(["energy", "forces", "stress"])
+    properties = atoms.get_properties(["energy", "energies", "forces", "stress"])
 
+    assert np.all(properties["energies"] == atoms.get_potential_energies())
     assert np.all(properties["energy"] == atoms.get_potential_energy())
     assert np.all(properties["forces"] == atoms.get_forces())
     assert np.all(properties["stress"] == atoms.get_stress())
+
+
+def test_selected_atoms(model, atoms):
+    ref = atoms.copy()
+    ref.calc = ase.calculators.lj.LennardJones(
+        sigma=SIGMA, epsilon=EPSILON, rc=CUTOFF, ro=CUTOFF, smooth=False
+    )
+
+    calculator = MetatensorCalculator(model, check_consistency=True)
+
+    first_mask = [a % 2 == 0 for a in range(len(atoms))]
+    first_half = Labels(
+        ["system", "atom"],
+        torch.tensor([[0, a] for a in range(len(atoms)) if a % 2 == 0]),
+    )
+
+    second_mask = [a % 2 == 1 for a in range(len(atoms))]
+    second_half = Labels(
+        ["system", "atom"],
+        torch.tensor([[0, a] for a in range(len(atoms)) if a % 2 == 1]),
+    )
+
+    # check per atom energy
+    requested = {"energy": ModelOutput(per_atom=True)}
+    outputs = calculator.run_model(atoms, outputs=requested, selected_atoms=first_half)
+    first_energies = outputs["energy"].block().values.numpy().reshape(-1)
+
+    outputs = calculator.run_model(atoms, outputs=requested, selected_atoms=second_half)
+    second_energies = outputs["energy"].block().values.numpy().reshape(-1)
+
+    expected = ref.get_potential_energies()
+    assert np.allclose(expected[first_mask], first_energies)
+    assert np.allclose(expected[second_mask], second_energies)
+
+    # check total energy
+    requested = {"energy": ModelOutput(per_atom=False)}
+    outputs = calculator.run_model(atoms, outputs=requested, selected_atoms=first_half)
+    first_energies = outputs["energy"].block().values.numpy().reshape(-1)
+
+    outputs = calculator.run_model(atoms, outputs=requested, selected_atoms=second_half)
+    second_energies = outputs["energy"].block().values.numpy().reshape(-1)
+
+    expected = ref.get_potential_energy()
+    assert np.allclose(expected, first_energies + second_energies)
 
 
 def test_serialize_ase(tmpdir, model, atoms):


### PR DESCRIPTION
When `check_consistency=True`, we also want to check that the data given by the engine matches what we expects.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--528.org.readthedocs.build/en/528/

<!-- readthedocs-preview metatensor end -->