### PR TITLE
Use dependabot 🤖 to update our github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 1
+    groups:
+      patterns:
+        - "*" # A wildcard to create one PR for all dependencies in the ecosystem


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Updating the github actions for our CI is an repeating and tedious work. Also we always forget to update some in the jungle of actions we use.

Maybe [Githubs dependabot](https://docs.github.com/en/code-security/dependabot) can help us 🤖. This is a test which checks the dependencies of all actions once per month and groups all of them into one commit. If this is still to noisy or introduces too many errors we can disable this again.

# Contributor (creator of pull-request) checklist

 - ~[ ] Tests updated (for new features and bugfixes)?~
 - ~[ ] Documentation updated (for new features)?~
 - ~[ ] Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - ~[ ] CHANGELOG updated with public API or any other important changes?~


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--530.org.readthedocs.build/en/530/

<!-- readthedocs-preview metatensor end -->