### PR TITLE
Update version number in metatensor-sys

### DIFF
--- a/docs/src/devdoc/versions.rst
+++ b/docs/src/devdoc/versions.rst
@@ -15,9 +15,10 @@ dynamically change this version number if necessary.
 The overall sources of truth for version numbers are:
 
 - the ``version`` field in ``metatensor-core/Cargo.toml`` for
-  ``metatensor-core`` C, C++ API and Python API.
-- the ``version`` field in ``metatensor/Cargo.toml`` for the ``metatensor`` Rust
-  crate.
+  ``metatensor-core`` C, C++ API and Python API. This needs to be manually
+  duplicated as the version field in ``rust/metatensor-sys/Cargo.toml``.
+- the ``version`` field in ``rust/metatensor/Cargo.toml`` for the ``metatensor``
+  Rust crate.
 - the ``VERSION`` file in ``metatensor-torch/`` for ``metatensor-torch`` C++ and
   Python API.
 - the ``METATENSOR_OPERATIONS_VERSION`` variable in

--- a/rust/metatensor-sys/Cargo.toml
+++ b/rust/metatensor-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metatensor-sys"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 description = "Bindings to the metatensor C library"

--- a/rust/metatensor/Cargo.toml
+++ b/rust/metatensor/Cargo.toml
@@ -14,7 +14,7 @@ license = "BSD-3-Clause"
 bench = false
 
 [dependencies]
-metatensor-sys = {version = "0.1.3", path="../metatensor-sys"}
+metatensor-sys = {version = "0.1", path="../metatensor-sys"}
 
 once_cell = "1"
 smallvec = {version = "1", features = ["union"]}


### PR DESCRIPTION
CI is failing on master due to a bad interaction between #535 and #536  (the release was merged first, but the code also needed to be updated for the rust crate split)

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--538.org.readthedocs.build/en/538/

<!-- readthedocs-preview metatensor end -->