### PR TITLE
Improve sdist generation

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -102,11 +102,6 @@ jobs:
       - name: install dependencies
         run: python -m pip install wheel build twine
 
-      - name: create C++ tarballs
-        run: |
-          ./scripts/package-core.sh
-          ./scripts/package-torch.sh
-
       - name: build metatensor-core sdist
         run: python -m build python/metatensor-core --sdist --outdir=dist/
 
@@ -124,6 +119,11 @@ jobs:
 
       - name: check sdist and wheels with twine
         run: twine check dist/*.tar.gz dist/*.whl
+
+      - name: create C++ tarballs
+        run: |
+          ./scripts/package-core.sh dist/cxx/
+          ./scripts/package-torch.sh dist/cxx/
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -104,7 +104,7 @@ jobs:
       - name: check the code can be compiled as a standalone crate
         if: matrix.os != 'windows-2019'
         run: |
-          ./scripts/package-core.sh
+          ./scripts/package-core.sh rust/metatensor-sys/
           cd rust/metatensor-sys
           cargo package --allow-dirty
 

--- a/python/metatensor-core/setup.py
+++ b/python/metatensor-core/setup.py
@@ -122,20 +122,57 @@ class bdist_egg_disabled(bdist_egg):
         )
 
 
-class sdist_git_version(sdist):
+class sdist_generate_data(sdist):
     """
-    Create a sdist with an additional generated file containing the extra
-    version from git.
+    Create a sdist with an additional generated files:
+        - `n_commits_since_last_tag`
+        - `metatensor-core-cxx-*.tar.gz`
     """
 
     def run(self):
         with open("n_commits_since_last_tag", "w") as fd:
             fd.write(str(n_commits_since_last_tag()))
 
+        generate_cxx_tar()
+
         # run original sdist
         super().run()
 
         os.unlink("n_commits_since_last_tag")
+        for path in glob.glob("metatensor-core-cxx-*.tar.gz"):
+            os.unlink(path)
+
+
+def generate_cxx_tar():
+    script = os.path.join(ROOT, "..", "..", "scripts", "package-core.sh")
+    assert os.path.exists(script)
+
+    try:
+        output = subprocess.run(
+            ["bash", "--version"],
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            encoding="utf8",
+        )
+    except Exception as e:
+        raise RuntimeError("could not run `bash`, is it installed?") from e
+
+    stderr = ""
+    stdout = ""
+
+    output = subprocess.run(
+        ["bash", script, os.getcwd()],
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        encoding="utf8",
+    )
+    if output.returncode != 0:
+        stderr = output.stderr
+        stdout = output.stdout
+        raise RuntimeError(
+            "failed to collect C++ sources for Python sdist\n"
+            f"stdout:\n {stdout}\n\nstderr:\n {stderr}"
+        )
 
 
 def get_rust_version():
@@ -258,7 +295,7 @@ if __name__ == "__main__":
             "build_ext": cmake_ext,
             "bdist_egg": bdist_egg if "bdist_egg" in sys.argv else bdist_egg_disabled,
             "bdist_wheel": universal_wheel,
-            "sdist": sdist_git_version,
+            "sdist": sdist_generate_data,
         },
         package_data={
             "metatensor-core": [

--- a/python/metatensor-torch/build-backend/backend.py
+++ b/python/metatensor-torch/build-backend/backend.py
@@ -1,6 +1,9 @@
-# this is a custom Python build backend wrapping setuptool's to add a build-time
-# dependencies to metatensor-core, using the local version if it exists, and
-# otherwise falling back to the one on PyPI.
+# This is a custom Python build backend wrapping setuptool's to add a build-time
+# dependencies to metatensor-core, using the local version if it exists, and otherwise
+# falling back to the one on PyPI.
+#
+# This also allows to only depend on torch/cmake when building the wheel and not the
+# sdist
 import os
 import uuid
 
@@ -37,7 +40,7 @@ build_sdist = build_meta.build_sdist
 
 def get_requires_for_build_wheel(config_settings=None):
     defaults = build_meta.get_requires_for_build_wheel(config_settings)
-    return defaults + [METATENSOR_CORE_DEP]
+    return defaults + ["cmake", "torch >=1.11", METATENSOR_CORE_DEP]
 
 
 get_requires_for_build_sdist = build_meta.get_requires_for_build_sdist

--- a/python/metatensor-torch/pyproject.toml
+++ b/python/metatensor-torch/pyproject.toml
@@ -36,12 +36,11 @@ changelog = "https://lab-cosmo.github.io/metatensor/latest/torch/CHANGELOG.html"
 requires = [
     "setuptools >=68",
     "packaging >=23",
-    "cmake",
-    "torch >= 1.11",
 ]
 
-# use a custom build backend to add a dependency on the right version of
-# metatensor-core
+# use a custom build backend to :
+# - add a dependency on the right version of metatensor-core
+# - only depend on torch/cmake when building the wheel and not the sdist
 build-backend = "backend"
 backend-path = ["build-backend"]
 

--- a/scripts/build-all-wheels.sh
+++ b/scripts/build-all-wheels.sh
@@ -8,9 +8,6 @@ cd "$ROOT_DIR"
 TMP_DIR="$1"
 rm -rf "$TMP_DIR"/dist
 
-./scripts/package-core.sh
-./scripts/package-torch.sh
-
 # check building sdist from a checkout, and wheel from the sdist
 python -m build python/metatensor-core --outdir "$TMP_DIR"/dist
 

--- a/scripts/package-core.sh
+++ b/scripts/package-core.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 
 # This script creates an archive containing the sources for the metatensor-core
-# Rust crate, and copy it to be included in the metatensor crate source release,
-# and the metatensor-core python package sdist.
+# Rust crate, and copy it to the path given as argument
+
+set -eux
+
+OUTPUT_DIR="$1"
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR=$(cd "$OUTPUT_DIR" 2>/dev/null && pwd)
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)
-set -eux
 
 rm -rf "$ROOT_DIR/target/package"
 cd "$ROOT_DIR/metatensor-core"
@@ -44,12 +48,5 @@ cargo generate-lockfile --manifest-path "$ARCHIVE_NAME/Cargo.toml"
 tar cf "$ARCHIVE_NAME.tar" "$ARCHIVE_NAME"
 gzip -9 "$ARCHIVE_NAME.tar"
 
-rm -f "$ROOT_DIR"/metatensor/metatensor-core-cxx-*.tar.gz
-cp "$TMP_DIR/$ARCHIVE_NAME.tar.gz" "$ROOT_DIR/rust/metatensor-sys/"
-
 rm -f "$ROOT_DIR"/python/metatensor-core/metatensor-core-cxx-*.tar.gz
-cp "$TMP_DIR/$ARCHIVE_NAME.tar.gz" "$ROOT_DIR/python/metatensor-core/"
-
-mkdir -p "$ROOT_DIR/dist/cxx"
-rm -f "$ROOT_DIR"/dist/cxx/metatensor-core-cxx-*.tar.gz
-cp "$TMP_DIR/$ARCHIVE_NAME.tar.gz" "$ROOT_DIR/dist/cxx/"
+cp "$TMP_DIR/$ARCHIVE_NAME.tar.gz" "$OUTPUT_DIR/"

--- a/scripts/package-torch.sh
+++ b/scripts/package-torch.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 
 # This script creates an archive containing the sources for the C++ part of
-# metatensor-torch, and copy it to be included in the metatensor-torch python
-# package sdist.
+# metatensor-torch, and copy it to the path given as argument
+
+set -eux
+
+OUTPUT_DIR="$1"
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR=$(cd "$OUTPUT_DIR" 2>/dev/null && pwd)
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)
-set -eux
 
 VERSION=$(cat "$ROOT_DIR/metatensor-torch/VERSION")
 ARCHIVE_NAME="metatensor-torch-cxx-$VERSION"
@@ -28,8 +32,4 @@ tar cf "$ARCHIVE_NAME".tar "$ARCHIVE_NAME"
 gzip -9 "$ARCHIVE_NAME".tar
 
 rm -f "$ROOT_DIR"/python/metatensor-torch/metatensor-torch-cxx-*.tar.gz
-cp "$ARCHIVE_NAME".tar.gz "$ROOT_DIR/python/metatensor-torch/"
-
-mkdir -p "$ROOT_DIR/dist/cxx"
-rm -f "$ROOT_DIR"/dist/cxx/metatensor-torch-cxx-*.tar.gz
-cp "$ARCHIVE_NAME".tar.gz "$ROOT_DIR/dist/cxx/"
+cp "$ARCHIVE_NAME".tar.gz "$OUTPUT_DIR/"

--- a/scripts/update-declarations.sh
+++ b/scripts/update-declarations.sh
@@ -9,8 +9,6 @@ set -eux
 
 cd "$ROOT_DIR"
 
-./scripts/package-core.sh
-
 # Regenerate Rust bindings to the C API
 bindgen ./metatensor-core/include/metatensor.h -o ./rust/metatensor-sys/src/c_api.rs \
     --disable-header-comment \


### PR DESCRIPTION
This makes sdist creation for metatensor-torch a lot faster by no requiring `torch` to be installed when building the sdist (but still required it to build the wheel).

This also automatically package the C++ version of metatensor-core and metatensor-torch in their respective `setup.py`, so we can never forget to run them when generating the sdist.


# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [x] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--540.org.readthedocs.build/en/540/

<!-- readthedocs-preview metatensor end -->