### PR TITLE
Run C++ Torch tests with Cmake 3.16 in CI

### DIFF
--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -13,7 +13,8 @@ concurrency:
 jobs:
   rust-tests:
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }} / Torch ${{ matrix.torch-version }}
+    name: ${{ matrix.os }} / Torch ${{ matrix.torch-version }}${{ matrix.extra-name }}
+    container: ${{ matrix.container }}
     strategy:
       matrix:
         include:
@@ -24,6 +25,8 @@ jobs:
             do-valgrind: true
 
           - os: ubuntu-20.04
+            container: ubuntu:20.04
+            extra-name: ", cmake 3.16"
             torch-version: 2.2.*
             python-version: "3.12"
             cargo-test-flags: ""
@@ -39,9 +42,20 @@ jobs:
             python-version: "3.12"
             cargo-test-flags: --release
     steps:
+      - name: install dependencies in container
+        if: matrix.container == 'ubuntu:20.04'
+        run: |
+          apt update
+          apt install -y software-properties-common
+          apt install -y cmake make gcc g++ git curl
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Configure git safe directory
+        if: matrix.container == 'ubuntu:20.04'
+        run: git config --global --add safe.directory /__w/metatensor/metatensor
 
       - name: setup rust
         uses: dtolnay/rust-toolchain@master

--- a/metatensor-core/tests/cmake-project/CMakeLists.txt
+++ b/metatensor-core/tests/cmake-project/CMakeLists.txt
@@ -1,16 +1,20 @@
 cmake_minimum_required(VERSION 3.16)
 
+message(STATUS "Running with CMake version ${CMAKE_VERSION}")
+
 project(metatensor-test-cmake-project C CXX)
 
 option(USE_CMAKE_SUBDIRECTORY OFF)
 
 if (USE_CMAKE_SUBDIRECTORY)
+    message(STATUS "Using metatensor with add_subdirectory")
     # build metatensor as part of this project
     add_subdirectory(../../../ metatensor)
 
     # load metatensor from the build path
     set(CMAKE_BUILD_RPATH "$<TARGET_FILE_DIR:metatensor::shared>")
 else()
+    message(STATUS "Using metatensor with find_package")
     # If building a dev version, we also need to update the REQUIRED_METATENSOR_VERSION
     # in the same way we update the metatensor-torch version
     include(../../cmake/dev-versions.cmake)

--- a/metatensor-torch/tests/cmake-project/CMakeLists.txt
+++ b/metatensor-torch/tests/cmake-project/CMakeLists.txt
@@ -1,10 +1,13 @@
 cmake_minimum_required(VERSION 3.16)
 
+message(STATUS "Running with CMake version ${CMAKE_VERSION}")
+
 project(metatensor-torch-test-cmake-project CXX)
 
 option(USE_CMAKE_SUBDIRECTORY OFF)
 
 if (USE_CMAKE_SUBDIRECTORY)
+    message(STATUS "Using metatensor-torch with add_subdirectory")
     set(BUILD_METATENSOR_TORCH ON)
     # build metatensor_torch as part of this project
     add_subdirectory(../../../ metatensor)
@@ -13,6 +16,7 @@ if (USE_CMAKE_SUBDIRECTORY)
     # load metatensor and metatensor-torch from the build path
     set(CMAKE_BUILD_RPATH "$<TARGET_FILE_DIR:torch>;$<TARGET_FILE_DIR:metatensor::shared>;$<TARGET_FILE_DIR:metatensor_torch>")
 else()
+    message(STATUS "Using metatensor-torch with find_package")
     # If building a dev version, we also need to update the REQUIRED_METATENSOR_VERSION
     # in the same way we update the metatensor-torch version
     include(../../cmake/dev-versions.cmake)

--- a/tox.ini
+++ b/tox.ini
@@ -49,10 +49,13 @@ testing_deps =
 
 
 [testenv:build-metatensor-core]
+# note: this is not redundant with the same value in the root [testenv]
+# without this one, cmake can not find the MSVC compiler on Windows CI
+passenv = *
+
 description =
     Used to only build the wheels which are then re-used by all other environments
     requiring metatensor to be installed
-passenv = *
 deps =
     {[testenv]packaging_deps}
 


### PR DESCRIPTION
We claim to support CMake 3.16, but we did not have a test checking this for metatensor-torch. So let's add it!


# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--544.org.readthedocs.build/en/544/

<!-- readthedocs-preview metatensor end -->