### PR TITLE
Release metatensor-rust v0.1.4

### DIFF
--- a/rust/metatensor/CHANGELOG.md
+++ b/rust/metatensor/CHANGELOG.md
@@ -15,6 +15,12 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
+## [Version 0.1.4](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-rust-v0.1.4) - 2024-03-12
+
+### Changed
+
+- Bindings to the raw C API are now part of the `metatensor-sys` crate (#535)
+
 ## [Version 0.1.3](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-rust-v0.1.3) - 2024-02-12
 
 ### Fixed

--- a/rust/metatensor/Cargo.toml
+++ b/rust/metatensor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metatensor"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.65"
 


### PR DESCRIPTION
This will be the first version using #535. Future changes to metatensor-core will be made accessible from rust by releasing new versions of the `metatensor-sys` crate instead of having to update the Rust API.

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--547.org.readthedocs.build/en/547/

<!-- readthedocs-preview metatensor end -->