### PR TITLE
Re-export the C API in Rust bindings

### DIFF
--- a/rust/metatensor/CHANGELOG.md
+++ b/rust/metatensor/CHANGELOG.md
@@ -15,6 +15,12 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
+## [Version 0.1.5](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-rust-v0.1.5) - 2024-03-12
+
+### Fixed
+
+- Re-export C API bindings in the `metatensor::c_api` module (#549)
+
 ## [Version 0.1.4](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-rust-v0.1.4) - 2024-03-12
 
 ### Changed

--- a/rust/metatensor/Cargo.toml
+++ b/rust/metatensor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metatensor"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 rust-version = "1.65"
 

--- a/rust/metatensor/src/lib.rs
+++ b/rust/metatensor/src/lib.rs
@@ -29,7 +29,7 @@
 #![allow(clippy::missing_errors_doc, clippy::missing_panics_doc, clippy::missing_safety_doc)]
 #![allow(clippy::similar_names, clippy::borrow_as_ptr, clippy::uninlined_format_args)]
 
-use metatensor_sys as c_api;
+pub use metatensor_sys as c_api;
 
 pub mod errors;
 pub use self::errors::Error;


### PR DESCRIPTION
Rascaline is using these to implement a custom `Array`.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--549.org.readthedocs.build/en/549/

<!-- readthedocs-preview metatensor end -->