### PR TITLE
Add ModelCapabilities::dtype, picked by the model

### DIFF
--- a/metatensor-torch/CHANGELOG.md
+++ b/metatensor-torch/CHANGELOG.md
@@ -17,6 +17,21 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 #### Removed
 -->
 
+### metatensor-torch C++
+
+#### Added
+
+- `ModelCapabilities::dtype`, used by the model to communicate the dtype it
+  wants to use for inputs and outputs.
+
+### metatensor-torch Python
+
+#### Added
+
+- `ModelCapabilities.dtype`, used by the model to communicate the dtype it
+  wants to use for inputs and outputs.
+
+
 ## [Version 0.3.0](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-torch-v0.3.0) - 2024-03-01
 
 ### metatensor-torch C++

--- a/metatensor-torch/include/metatensor/torch/atomistic/model.hpp
+++ b/metatensor-torch/include/metatensor/torch/atomistic/model.hpp
@@ -136,7 +136,7 @@ public:
     /// long range model, this should be set to infinity.
     ///
     /// This will default to -1 if not explicitly set by the user.
-    double interaction_range = -1;
+    double interaction_range = -1.0;
 
     /// unit of lengths the model expects as input
     const std::string& length_unit() const {

--- a/metatensor-torch/include/metatensor/torch/atomistic/model.hpp
+++ b/metatensor-torch/include/metatensor/torch/atomistic/model.hpp
@@ -107,7 +107,8 @@ public:
         std::vector<int64_t> atomic_types_,
         double interaction_range_,
         std::string length_unit,
-        std::vector<std::string> supported_devices_
+        std::vector<std::string> supported_devices_,
+        std::string dtype
     ):
         outputs(outputs_),
         atomic_types(std::move(atomic_types_)),
@@ -115,6 +116,10 @@ public:
         supported_devices(std::move(supported_devices_))
     {
         this->set_length_unit(std::move(length_unit));
+
+        if (!dtype.empty()) {
+            this->set_dtype(std::move(dtype));
+        }
     }
 
     ~ModelCapabilitiesHolder() override = default;
@@ -156,6 +161,16 @@ public:
     /// the best device for this model, and so on.
     std::vector<std::string> supported_devices;
 
+    /// Get the dtype of this model. This can be "float32" or "float64", and
+    /// must be used by the engine as the dtype of all inputs and outputs for
+    /// this model.
+    const std::string& dtype() const {
+        return dtype_;
+    }
+
+    /// Set the dtype of this model.
+    void set_dtype(std::string dtype);
+
     /// Serialize a `ModelCapabilities` to a JSON string.
     std::string to_json() const;
     /// Load a serialized `ModelCapabilities` from a JSON string.
@@ -163,6 +178,7 @@ public:
 
 private:
     std::string length_unit_;
+    std::string dtype_;
 };
 
 

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -422,7 +422,7 @@ TORCH_LIBRARY(metatensor, m) {
             DOCSTRING, {
                 torch::arg("outputs") = torch::Dict<std::string, ModelOutput>(),
                 torch::arg("atomic_types") = std::vector<int64_t>(),
-                torch::arg("interaction_range") = HUGE_VAL,
+                torch::arg("interaction_range") = -1.0,
                 torch::arg("length_unit") = "",
                 torch::arg("supported_devices") = std::vector<std::string>{},
             }

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -417,7 +417,8 @@ TORCH_LIBRARY(metatensor, m) {
                 std::vector<int64_t>,
                 double,
                 std::string,
-                std::vector<std::string>
+                std::vector<std::string>,
+                std::string
             >(),
             DOCSTRING, {
                 torch::arg("outputs") = torch::Dict<std::string, ModelOutput>(),
@@ -425,6 +426,7 @@ TORCH_LIBRARY(metatensor, m) {
                 torch::arg("interaction_range") = -1.0,
                 torch::arg("length_unit") = "",
                 torch::arg("supported_devices") = std::vector<std::string>{},
+                torch::arg("dtype") = "",
             }
         )
         .def_readwrite("outputs", &ModelCapabilitiesHolder::outputs)
@@ -433,6 +435,7 @@ TORCH_LIBRARY(metatensor, m) {
         .def("engine_interaction_range", &ModelCapabilitiesHolder::engine_interaction_range)
         .def_property("length_unit", &ModelCapabilitiesHolder::length_unit, &ModelCapabilitiesHolder::set_length_unit)
         .def_readwrite("supported_devices", &ModelCapabilitiesHolder::supported_devices)
+        .def_property("dtype", &ModelCapabilitiesHolder::dtype, &ModelCapabilitiesHolder::set_dtype)
         .def_pickle(
             [](const ModelCapabilities& self) -> std::string {
                 return self->to_json();

--- a/metatensor-torch/tests/atomistic.cpp
+++ b/metatensor-torch/tests/atomistic.cpp
@@ -194,6 +194,7 @@ TEST_CASE("Models metadata") {
         capabilities->set_length_unit("nm");
         capabilities->interaction_range = 1.4;
         capabilities->atomic_types = {1, 2, -43};
+        capabilities->set_dtype("float32");
         capabilities->supported_devices = {"cuda", "xla", "cpu"};
 
         auto output = torch::make_intrusive<ModelOutputHolder>();
@@ -209,6 +210,7 @@ TEST_CASE("Models metadata") {
         -43
     ],
     "class": "ModelCapabilities",
+    "dtype": "float32",
     "interaction_range": 4608983858650965606,
     "length_unit": "nm",
     "outputs": {
@@ -249,6 +251,7 @@ TEST_CASE("Models metadata") {
 
         capabilities = ModelCapabilitiesHolder::from_json(json);
         CHECK(capabilities->length_unit() == "nm");
+        CHECK(capabilities->dtype().empty());
         CHECK(capabilities->atomic_types == std::vector<int64_t>{1, -2});
 
         output = capabilities->outputs.at("foo");

--- a/python/examples/atomistic/1-export-atomistic-model.py
+++ b/python/examples/atomistic/1-export-atomistic-model.py
@@ -198,6 +198,7 @@ outputs = {
 #   will handle the necessary unit conversions for you;
 # - the set of ``supported_devices`` on which the model can run. These should be ordered
 #   according to the model preference.
+# - the dtype ("float32" or "float64") that the model uses for its inputs and outputs
 
 capabilities = ModelCapabilities(
     outputs=outputs,
@@ -205,6 +206,7 @@ capabilities = ModelCapabilities(
     interaction_range=0.0,
     length_unit="Angstrom",
     supported_devices=["cpu"],
+    dtype="float64",
 )
 
 # %%

--- a/python/examples/atomistic/2-running-ase-md.py
+++ b/python/examples/atomistic/2-running-ase-md.py
@@ -186,6 +186,7 @@ capabilities = ModelCapabilities(
     interaction_range=0.0,
     length_unit="Angstrom",
     supported_devices=["cpu"],
+    dtype="float32",
 )
 
 # we don't want to bother with model metadata, so we define it as empty

--- a/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
@@ -271,7 +271,7 @@ class ModelCapabilities:
         self,
         outputs: Dict[str, ModelOutput] = {},  # noqa B006
         atomic_types: List[int] = [],  # noqa B006
-        interaction_range: float = float("inf"),
+        interaction_range: float = -1,
         length_unit: str = "",
         supported_devices: List[str] = [],  # noqa B006
     ):

--- a/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
@@ -274,6 +274,7 @@ class ModelCapabilities:
         interaction_range: float = -1,
         length_unit: str = "",
         supported_devices: List[str] = [],  # noqa B006
+        dtype: str = "",
     ):
         pass
 
@@ -308,6 +309,15 @@ class ModelCapabilities:
         atoms positions and the system cell.
 
         The list of possible units is available :ref:`here <known-quantities-units>`.
+        """
+
+    @property
+    def dtype() -> str:
+        """
+        The dtype of this model
+
+        This can be ``"float32"`` or ``"float64"``, and must be used by the engine as
+        the dtype of all inputs and outputs for this model.
         """
 
     def engine_interaction_range(self, engine_length_unit: str) -> float:

--- a/python/metatensor-torch/metatensor/torch/atomistic/model.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/model.py
@@ -1,6 +1,7 @@
 import datetime
 import hashlib
 import json
+import math
 import os
 import platform
 import shutil
@@ -254,6 +255,12 @@ class MetatensorAtomisticModel(torch.nn.Module):
             raise ValueError(
                 "`capabilities.interaction_range` was not set, "
                 "but it is required to run simulations"
+            )
+
+        if math.isnan(capabilities.interaction_range):
+            raise ValueError(
+                "`capabilities.interaction_range` should be a "
+                "float between 0 and infinity"
             )
 
         if len(capabilities.supported_devices) == 0:

--- a/python/metatensor-torch/tests/atomistic/ase_calculator.py
+++ b/python/metatensor-torch/tests/atomistic/ase_calculator.py
@@ -128,6 +128,7 @@ def model():
             ),
         },
         supported_devices=["cpu"],
+        dtype="float64",
     )
 
     metadata = ModelMetadata()
@@ -156,6 +157,7 @@ def model_different_units():
             ),
         },
         supported_devices=["cpu"],
+        dtype="float64",
     )
 
     metadata = ModelMetadata()
@@ -272,6 +274,9 @@ def test_selected_atoms(tmpdir, model, atoms):
 
 
 def test_serialize_ase(tmpdir, model, atoms):
+    # Run some tests with a different dtype
+    model._capabilities.dtype = "float32"
+
     calculator = MetatensorCalculator(model)
 
     message = (

--- a/python/metatensor-torch/tests/atomistic/metadata.py
+++ b/python/metatensor-torch/tests/atomistic/metadata.py
@@ -86,6 +86,12 @@ class ModelCapabilitiesWrap:
     def set_supported_devices(self, devices: List[str]):
         self._c.supported_devices = devices
 
+    def get_dtype(self) -> str:
+        return self._c.dtype
+
+    def set_dtype(self, dtype: str):
+        self._c.dtype = dtype
+
 
 def test_capabilities():
     class TestModule(torch.nn.Module):

--- a/python/metatensor-torch/tests/atomistic/model.py
+++ b/python/metatensor-torch/tests/atomistic/model.py
@@ -163,3 +163,38 @@ def test_requested_neighbors_lists():
         "other module",
         "FullModel.other",
     ]
+
+
+def test_bad_capabilities():
+    model = FullModel()
+    model.train(False)
+
+    capabilities = ModelCapabilities(
+        supported_devices=["cpu"],
+    )
+    message = (
+        "`capabilities.interaction_range` was not set, "
+        "but it is required to run simulations"
+    )
+    with pytest.raises(ValueError, match=message):
+        MetatensorAtomisticModel(model, ModelMetadata(), capabilities)
+
+    capabilities = ModelCapabilities(
+        interaction_range=12,
+    )
+    message = (
+        "`capabilities.supported_devices` was not set, "
+        "but it is required to run simulations"
+    )
+    with pytest.raises(ValueError, match=message):
+        MetatensorAtomisticModel(model, ModelMetadata(), capabilities)
+
+    capabilities = ModelCapabilities(
+        interaction_range=float("nan"),
+        supported_devices=["cpu"],
+    )
+    message = (
+        "`capabilities.interaction_range` should be a float between 0 and infinity"
+    )
+    with pytest.raises(ValueError, match=message):
+        MetatensorAtomisticModel(model, ModelMetadata(), capabilities)

--- a/python/metatensor-torch/tests/atomistic/model.py
+++ b/python/metatensor-torch/tests/atomistic/model.py
@@ -65,6 +65,7 @@ def model():
             ),
         },
         supported_devices=["cpu"],
+        dtype="float64",
     )
 
     metadata = ModelMetadata()
@@ -142,6 +143,7 @@ def test_requested_neighbors_lists():
     capabilities = ModelCapabilities(
         interaction_range=0.0,
         supported_devices=["cpu"],
+        dtype="float64",
     )
     atomistic = MetatensorAtomisticModel(model, ModelMetadata(), capabilities)
     requests = atomistic.requested_neighbors_lists()
@@ -171,6 +173,7 @@ def test_bad_capabilities():
 
     capabilities = ModelCapabilities(
         supported_devices=["cpu"],
+        dtype="float64",
     )
     message = (
         "`capabilities.interaction_range` was not set, "
@@ -181,6 +184,7 @@ def test_bad_capabilities():
 
     capabilities = ModelCapabilities(
         interaction_range=12,
+        dtype="float64",
     )
     message = (
         "`capabilities.supported_devices` was not set, "
@@ -192,9 +196,18 @@ def test_bad_capabilities():
     capabilities = ModelCapabilities(
         interaction_range=float("nan"),
         supported_devices=["cpu"],
+        dtype="float64",
     )
     message = (
         "`capabilities.interaction_range` should be a float between 0 and infinity"
     )
+    with pytest.raises(ValueError, match=message):
+        MetatensorAtomisticModel(model, ModelMetadata(), capabilities)
+
+    capabilities = ModelCapabilities(
+        interaction_range=12.0,
+        supported_devices=["cpu"],
+    )
+    message = "`capabilities.dtype` was not set, but it is required to run simulations"
     with pytest.raises(ValueError, match=message):
         MetatensorAtomisticModel(model, ModelMetadata(), capabilities)

--- a/python/metatensor-torch/tests/atomistic/neighbors.py
+++ b/python/metatensor-torch/tests/atomistic/neighbors.py
@@ -69,7 +69,7 @@ def test_neighbors_autograd():
             cell=cell.detach().numpy(),
             pbc=True,
         )
-        neighbors = _compute_ase_neighbors(atoms, options)
+        neighbors = _compute_ase_neighbors(atoms, options, dtype=torch.float64)
 
         system = System(
             torch.from_numpy(atoms.numbers).to(torch.int32), positions, cell
@@ -109,7 +109,7 @@ def test_neighbors_autograd_errors():
         pbc=True,
     )
     options = NeighborsListOptions(cutoff=2.0, full_list=False)
-    neighbors = _compute_ase_neighbors(atoms, options)
+    neighbors = _compute_ase_neighbors(atoms, options, dtype=torch.float64)
     system = System(torch.from_numpy(atoms.numbers).to(torch.int32), positions, cell)
     register_autograd_neighbors(system, neighbors)
 
@@ -126,12 +126,12 @@ def test_neighbors_autograd_errors():
         "\\[0.489917, 1.24926, 0.102936\\] but has a distance vector of "
         "\\[1.46975, 3.74777, 0.308807\\]"
     )
-    neighbors = _compute_ase_neighbors(atoms, options)
+    neighbors = _compute_ase_neighbors(atoms, options, dtype=torch.float64)
     neighbors.values[:] *= 3
     with pytest.raises(ValueError, match=message):
         register_autograd_neighbors(system, neighbors, check_consistency=True)
 
-    neighbors = _compute_ase_neighbors(atoms, options)
+    neighbors = _compute_ase_neighbors(atoms, options, dtype=torch.float64)
     message = (
         "`system` and `neighbors` must have the same dtype, "
         "got torch.float32 and torch.float64"


### PR DESCRIPTION
The dtype is picked by the model, and the engine has to convert data on input/output to whatever it needs (similar to how different devices are handled).


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--551.org.readthedocs.build/en/551/

<!-- readthedocs-preview metatensor end -->