### PR TITLE
Fix device in atomistic model check

### DIFF
--- a/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
@@ -71,13 +71,14 @@ def _check_energy(
             for a in range(len(system)):
                 expected_values.append([s, a])
 
-        expected_samples = Labels(["system", "atom"], torch.tensor(expected_values))
+        expected_samples = Labels(
+            ["system", "atom"],
+            torch.tensor(expected_values, device=energy_block.samples.values.device),
+        )
         if selected_atoms is not None:
             expected_samples = expected_samples.intersection(selected_atoms)
 
-        if len(expected_samples.union(energy_block.samples.to(device="cpu"))) != len(
-            expected_samples
-        ):
+        if len(expected_samples.union(energy_block.samples)) != len(expected_samples):
             raise ValueError(
                 "invalid samples entries for 'energy' output, they do not match the "
                 f"`systems` and `selected_atoms`. Expected samples:\n{expected_samples}"
@@ -91,9 +92,7 @@ def _check_energy(
             )
             expected_samples = expected_samples.intersection(selected_systems)
 
-        if len(expected_samples.union(energy_block.samples.to(device="cpu"))) != len(
-            expected_samples
-        ):
+        if len(expected_samples.union(energy_block.samples)) != len(expected_samples):
             raise ValueError(
                 "invalid samples entries for 'energy' output, they do not match the "
                 f"`systems` and `selected_atoms`. Expected samples:\n{expected_samples}"

--- a/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
@@ -73,7 +73,7 @@ def _check_energy(
 
         expected_samples = Labels(
             ["system", "atom"],
-            torch.tensor(expected_values, device=energy_block.samples.values.device),
+            torch.tensor(expected_values, device=energy_block.values.device),
         )
         if selected_atoms is not None:
             expected_samples = expected_samples.intersection(selected_atoms)

--- a/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
@@ -75,7 +75,9 @@ def _check_energy(
         if selected_atoms is not None:
             expected_samples = expected_samples.intersection(selected_atoms)
 
-        if len(expected_samples.union(energy_block.samples)) != len(expected_samples):
+        if len(expected_samples.union(energy_block.samples.to(device="cpu"))) != len(
+            expected_samples
+        ):
             raise ValueError(
                 "invalid samples entries for 'energy' output, they do not match the "
                 f"`systems` and `selected_atoms`. Expected samples:\n{expected_samples}"
@@ -89,7 +91,9 @@ def _check_energy(
             )
             expected_samples = expected_samples.intersection(selected_systems)
 
-        if len(expected_samples.union(energy_block.samples)) != len(expected_samples):
+        if len(expected_samples.union(energy_block.samples.to(device="cpu"))) != len(
+            expected_samples
+        ):
             raise ValueError(
                 "invalid samples entries for 'energy' output, they do not match the "
                 f"`systems` and `selected_atoms`. Expected samples:\n{expected_samples}"


### PR DESCRIPTION
This fixes a small device bug in the atomistic model checks. The predictions can be on any device, but they were being compared to a CPU Labels object.
I am not sure how to test this however

# Contributor (creator of pull-request) checklist

 - [?] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--552.org.readthedocs.build/en/552/

<!-- readthedocs-preview metatensor end -->