### PR TITLE
Parallelize compilation with cmake

### DIFF
--- a/julia/deps/build_local.jl
+++ b/julia/deps/build_local.jl
@@ -33,7 +33,7 @@ cmake() do cmake_path
     @info "Configuring CMake" cmd
     run(cmd)
 
-    cmd = `$cmake_path --build $(build_dir) --target install`
+    cmd = `$cmake_path --build $(build_dir) --parallel --target install`
     @info "Building with CMake" cmd
     run(cmd)
 end

--- a/metatensor-core/tests/utils/mod.rs
+++ b/metatensor-core/tests/utils/mod.rs
@@ -37,6 +37,7 @@ pub fn cmake_build(build_dir: &Path) -> Command {
     cmake_build.current_dir(build_dir);
     cmake_build.arg("--build");
     cmake_build.arg(".");
+    cmake_build.arg("--parallel");
     cmake_build.arg("--config");
     cmake_build.arg(build_type());
 

--- a/python/metatensor-core/setup.py
+++ b/python/metatensor-core/setup.py
@@ -102,7 +102,7 @@ class cmake_ext(build_ext):
             check=True,
         )
         subprocess.run(
-            ["cmake", "--build", build_dir, "--target", "install"],
+            ["cmake", "--build", build_dir, "--parallel", "--target", "install"],
             check=True,
         )
 

--- a/python/metatensor-torch/setup.py
+++ b/python/metatensor-torch/setup.py
@@ -85,6 +85,7 @@ class cmake_ext(build_ext):
                 "cmake",
                 "--build",
                 build_dir,
+                "--parallel",
                 "--config",
                 "Release",
                 "--target",


### PR DESCRIPTION
We use cmake's `--parallel` flag to speed up compilation for Python builds



# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--557.org.readthedocs.build/en/557/

<!-- readthedocs-preview metatensor end -->