### PR TITLE
Pin cmake dependency used to build wheels

### DIFF
--- a/python/metatensor-core/pyproject.toml
+++ b/python/metatensor-core/pyproject.toml
@@ -39,7 +39,7 @@ requires = [
     "setuptools >=68",
     "packaging >=23",
     "wheel >=0.41",
-    "cmake",
+    "cmake ==3.28.4",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/python/metatensor-torch/build-backend/backend.py
+++ b/python/metatensor-torch/build-backend/backend.py
@@ -40,7 +40,7 @@ build_sdist = build_meta.build_sdist
 
 def get_requires_for_build_wheel(config_settings=None):
     defaults = build_meta.get_requires_for_build_wheel(config_settings)
-    return defaults + ["cmake", "torch >=1.11", METATENSOR_CORE_DEP]
+    return defaults + ["cmake ==3.28.4", "torch >=1.11", METATENSOR_CORE_DEP]
 
 
 get_requires_for_build_sdist = build_meta.get_requires_for_build_sdist

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ packaging_deps =
     setuptools
     packaging
     wheel
-    cmake
+    cmake ==3.28.4
 
 testing_deps =
     pytest
@@ -241,7 +241,6 @@ description = build the documentation with sphinx
 deps =
     -r docs/requirements.txt
     {[testenv]packaging_deps}
-    cmake
 
 allowlist_externals = bash
 commands =


### PR DESCRIPTION
The latest release of cmake 3.29.0 is broken with Python 3.8. Since this is not the first time that a cmake release is broken, we should pin the dependency and manually update when needed.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--559.org.readthedocs.build/en/559/

<!-- readthedocs-preview metatensor end -->