### PR TITLE
Enforce that the name of experimental outputs looks like `<domain>::<output>`

### DIFF
--- a/metatensor-torch/include/metatensor/torch/atomistic/model.hpp
+++ b/metatensor-torch/include/metatensor/torch/atomistic/model.hpp
@@ -103,18 +103,18 @@ public:
 
     /// Initialize `ModelCapabilities` with the given data
     ModelCapabilitiesHolder(
-        torch::Dict<std::string, ModelOutput> outputs_,
+        torch::Dict<std::string, ModelOutput> outputs,
         std::vector<int64_t> atomic_types_,
         double interaction_range_,
         std::string length_unit,
         std::vector<std::string> supported_devices_,
         std::string dtype
     ):
-        outputs(outputs_),
         atomic_types(std::move(atomic_types_)),
         interaction_range(interaction_range_),
         supported_devices(std::move(supported_devices_))
     {
+        this->set_outputs(outputs);
         this->set_length_unit(std::move(length_unit));
 
         if (!dtype.empty()) {
@@ -125,7 +125,11 @@ public:
     ~ModelCapabilitiesHolder() override = default;
 
     /// all possible outputs from this model and corresponding settings
-    torch::Dict<std::string, ModelOutput> outputs;
+    torch::Dict<std::string, ModelOutput> outputs() const {
+        return outputs_;
+    }
+    /// set the outputs for this model
+    void set_outputs(torch::Dict<std::string, ModelOutput> outputs);
 
     /// which types the model can handle
     std::vector<int64_t> atomic_types;
@@ -177,6 +181,7 @@ public:
     static ModelCapabilities from_json(std::string_view json);
 
 private:
+    torch::Dict<std::string, ModelOutput> outputs_;
     std::string length_unit_;
     std::string dtype_;
 };

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -437,7 +437,7 @@ TORCH_LIBRARY(metatensor, m) {
                 torch::arg("dtype") = "",
             }
         )
-        .def_readwrite("outputs", &ModelCapabilitiesHolder::outputs)
+        .def_property("outputs", &ModelCapabilitiesHolder::outputs, &ModelCapabilitiesHolder::set_outputs)
         .def_readwrite("atomic_types", &ModelCapabilitiesHolder::atomic_types)
         .def_readwrite("interaction_range", &ModelCapabilitiesHolder::interaction_range)
         .def("engine_interaction_range", &ModelCapabilitiesHolder::engine_interaction_range)

--- a/metatensor-torch/tests/atomistic.cpp
+++ b/metatensor-torch/tests/atomistic.cpp
@@ -201,7 +201,10 @@ TEST_CASE("Models metadata") {
         output->per_atom = true;
         output->set_quantity("length");
         output->explicit_gradients.emplace_back("µ-λ");
-        capabilities->outputs.insert("bar", output);
+
+        auto outputs = torch::Dict<std::string, ModelOutput>();
+        outputs.insert("tests::bar", output);
+        capabilities->set_outputs(outputs);
 
         const auto* expected = R"({
     "atomic_types": [
@@ -214,7 +217,7 @@ TEST_CASE("Models metadata") {
     "interaction_range": 4608983858650965606,
     "length_unit": "nm",
     "outputs": {
-        "bar": {
+        "tests::bar": {
             "class": "ModelOutput",
             "explicit_gradients": [
                 "\u00b5-\u03bb"
@@ -237,7 +240,7 @@ TEST_CASE("Models metadata") {
         std::string json =R"({
     "length_unit": "nm",
     "outputs": {
-        "foo": {
+        "tests::foo": {
             "explicit_gradients": ["\u00b5-test"],
             "class": "ModelOutput"
         }
@@ -254,7 +257,7 @@ TEST_CASE("Models metadata") {
         CHECK(capabilities->dtype().empty());
         CHECK(capabilities->atomic_types == std::vector<int64_t>{1, -2});
 
-        output = capabilities->outputs.at("foo");
+        output = capabilities->outputs().at("tests::foo");
         CHECK(output->quantity().empty());
         CHECK(output->unit().empty());
         CHECK(output->per_atom == false);

--- a/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
@@ -278,13 +278,21 @@ class ModelCapabilities:
     ):
         pass
 
-    outputs: Dict[str, ModelOutput]
-    """
-    All possible outputs from this model and corresponding settings.
+    @property
+    def outputs(self) -> Dict[str, ModelOutput]:
+        """
+        All possible outputs from this model and corresponding settings.
 
-    During a specific run, a model might be asked to only compute a subset of these
-    outputs.
-    """
+        During a specific run, a model might be asked to only compute a subset of these
+        outputs. Some outputs are standardized, and have additional constrains on how
+        the associated metadata should look like, documented in the
+        :ref:`atomistic-models-outputs` section.
+
+        If you want to define a new output for your own usage, it name should looks like
+        ``"<domain>::<output>"``, where ``<domain>`` indicates who defines this new
+        output and ``<output>`` describes the output itself. For example,
+        ``"my-package::foobar"`` for a ``foobar`` output defined in ``my-package``.
+        """
 
     atomic_types: List[int]
     """which atomic types the model can handle"""

--- a/python/metatensor-torch/metatensor/torch/atomistic/model.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/model.py
@@ -67,9 +67,13 @@ class ModelInterface(torch.nn.Module):
 
         The returned dictionary should have the same keys as ``outputs``, and the values
         should contains the corresponding properties of the ``systems``, as computed for
-        the subset of atoms defined in ``selected_atoms``. For some specific outputs,
-        there are additional constrains on how the associated metadata should look like,
-        documented in the :ref:`atomistic-models-outputs` section.
+        the subset of atoms defined in ``selected_atoms``. Some outputs are
+        standardized, and have additional constrains on how the associated metadata
+        should look like, documented in the :ref:`atomistic-models-outputs` section. If
+        you want to define a new output for your own usage, it name should looks like
+        ``"<domain>::<output>"``, where ``<domain>`` indicates who defines this new
+        output and ``<output>`` describes the output itself. For example,
+        ``"my-package::foobar"`` for a ``foobar`` output defined in ``my-package``.
 
         The main use case for ``selected_atoms`` is domain decomposition, where the
         :py:class:`System` given to a model might contain both atoms in the current

--- a/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
@@ -46,6 +46,7 @@ def _check_outputs(
         if name == "energy":
             _check_energy(systems, request, selected_atoms, energy=value)
         else:
+            # this is a non-standard output, there is nothing to check
             continue
 
 

--- a/python/metatensor-torch/tests/atomistic/model.py
+++ b/python/metatensor-torch/tests/atomistic/model.py
@@ -57,7 +57,7 @@ def model():
         atomic_types=[1, 2, 3],
         interaction_range=4.3,
         outputs={
-            "dummy": ModelOutput(
+            "tests::dummy::long": ModelOutput(
                 quantity="",
                 unit="",
                 per_atom=False,
@@ -211,3 +211,24 @@ def test_bad_capabilities():
     message = "`capabilities.dtype` was not set, but it is required to run simulations"
     with pytest.raises(ValueError, match=message):
         MetatensorAtomisticModel(model, ModelMetadata(), capabilities)
+
+    message = (
+        "Invalid name for model output: 'not-a-standard'. "
+        "Non-standard names should have the form '<domain>::<output>'."
+    )
+    with pytest.raises(ValueError, match=message):
+        ModelCapabilities(outputs={"not-a-standard": ModelOutput()})
+
+    message = (
+        "Invalid name for model output: '::not-a-standard'. "
+        "Non-standard names should have the form '<domain>::<output>'."
+    )
+    with pytest.raises(ValueError, match=message):
+        ModelCapabilities(outputs={"::not-a-standard": ModelOutput()})
+
+    message = (
+        "Invalid name for model output: 'not-a-standard::'. "
+        "Non-standard names should have the form '<domain>::<output>'."
+    )
+    with pytest.raises(ValueError, match=message):
+        ModelCapabilities(outputs={"not-a-standard::": ModelOutput()})


### PR DESCRIPTION
This makes it clearer what is part of the standard and what is not, and allow code to check for either `my-code::custom-output` or `custom-output` to stay compatible with models before and after a new standard is defined.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--565.org.readthedocs.build/en/565/

<!-- readthedocs-preview metatensor end -->