### PR TITLE
Load TorchScript extensions used by a model

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -100,7 +100,7 @@ jobs:
     name: ${{ matrix.name }} (torch v${{ matrix.torch-version }})
     strategy:
       matrix:
-        torch-version: ['1.11', '1.12', '1.13', '2.0', '2.1', '2.2']
+        torch-version: ['1.12', '1.13', '2.0', '2.1', '2.2']
         arch: ['arm64', 'x86_64']
         os: ['ubuntu-22.04', 'macos-11', 'macos-14', 'windows-2019']
         exclude:
@@ -110,7 +110,6 @@ jobs:
           # no arm64-windows build
           - {os: windows-2019, arch: arm64}
           # arm64-macos is only supported for torch >= 2.0
-          - {os: macos-14, arch: arm64, torch-version: '1.11'}
           - {os: macos-14, arch: arm64, torch-version: '1.12'}
           - {os: macos-14, arch: arm64, torch-version: '1.13'}
         include:
@@ -141,7 +140,6 @@ jobs:
             rust-target: x86_64-pc-windows-msvc
             cibw-arch: AMD64
           # add the right python version for each torch version
-          - {torch-version: '1.11', python-version: '3.10', cibw-python: 'cp310-*'}
           - {torch-version: '1.12', python-version: '3.10', cibw-python: 'cp310-*'}
           - {torch-version: '1.13', python-version: '3.10', cibw-python: 'cp310-*'}
           - {torch-version: '2.0',  python-version: '3.11', cibw-python: 'cp311-*'}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - os: ubuntu-20.04
             python-version: "3.8"
-            torch-version: "1.11.*"
+            torch-version: "1.12.*"
           - os: ubuntu-20.04
             python-version: "3.8"
             torch-version: "2.2.*"

--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            torch-version: 1.11.*
+            torch-version: 1.12.*
             python-version: "3.10"
             cargo-test-flags: --release
             do-valgrind: true

--- a/docs/src/atomistic/reference/cxx/models.rst
+++ b/docs/src/atomistic/reference/cxx/models.rst
@@ -5,6 +5,8 @@ Models
 
 .. doxygenfunction:: metatensor_torch::check_atomistic_model
 
+.. doxygenfunction:: metatensor_torch::load_model_extensions
+
 .. doxygenfunction:: metatensor_torch::unit_conversion_factor
 
 .. doxygentypedef:: metatensor_torch::ModelOutput

--- a/docs/src/atomistic/reference/models/index.rst
+++ b/docs/src/atomistic/reference/models/index.rst
@@ -15,6 +15,8 @@ We also provide a couple of functions to work with the models:
 
 .. autofunction:: metatensor.torch.atomistic.check_atomistic_model
 
+.. autofunction:: metatensor.torch.atomistic.load_model_extensions
+
 .. autofunction:: metatensor.torch.atomistic.unit_conversion_factor
 
 .. _known-quantities-units:

--- a/docs/src/atomistic/reference/models/index.rst
+++ b/docs/src/atomistic/reference/models/index.rst
@@ -13,6 +13,8 @@ below:
 
 We also provide a couple of functions to work with the models:
 
+.. autofunction:: metatensor.torch.atomistic.load_atomistic_model
+
 .. autofunction:: metatensor.torch.atomistic.check_atomistic_model
 
 .. autofunction:: metatensor.torch.atomistic.load_model_extensions

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -152,11 +152,20 @@ and use it will depend on the programming language you are using.
 
             pip install metatensor-torch
 
-        Due to the way PyTorch itself is structured and distributed, we can not
-        provide pre-compiled versions of metatensor-torch on `PyPI
-        <https://pypi.org/>`_, but only a source distribution that will be
-        compiled on your machine. This local compilation will require a couple
-        of additional dependencies.
+        We provide pre-compiled wheels on PyPI that are compatible with all the
+        supported torch versions at the time of metatensor-torch release.
+        Currently PyTorch version 1.12 and above is supported.
+
+        If you want to use the code with an unsupported PyTorch version, or a
+        new release of PyTorch which did not exist yet when we released
+        metatensor-torch; you'll need to compile the code on your local machine
+        with
+
+        .. code-block:: bash
+
+            pip install metatensor-torch --no-binary=metatensor-torch
+
+        This local compilation will require a couple of additional dependencies:
 
         - a modern C++ compiler, able to handle C++17, such as:
             - gcc version 7 or above;
@@ -174,7 +183,7 @@ and use it will depend on the programming language you are using.
 
         .. code-block:: bash
 
-            pip install --extra-index-url https://download.pytorch.org/whl/cpu metatensor[torch]
+            pip install --extra-index-url https://download.pytorch.org/whl/cpu metatensor-torch  --no-binary=metatensor-torch
 
         A similar index URL can be used to install the ROCm (AMD GPU) version of
         PyTorch, please refer to the `corresponding documentation
@@ -220,9 +229,10 @@ and use it will depend on the programming language you are using.
 
         - :ref:`the C++ interface <install-c>` of metatensor.
         - the C++ part of PyTorch, which you can install `on it's own
-          <https://pytorch.org/get-started/locally/>`_. You can also use the
-          same library as the Python version of torch by adding the output of
-          the command below to ``CMAKE_PREFIX_PATH``:
+          <https://pytorch.org/get-started/locally/>`_. We are compatible with
+          libtorch version 1.12 or above. You can also use the same library as
+          the Python version of torch by adding the output of the command below
+          to ``CMAKE_PREFIX_PATH``:
 
           .. code-block:: bash
 

--- a/metatensor-torch/CHANGELOG.md
+++ b/metatensor-torch/CHANGELOG.md
@@ -23,6 +23,8 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 - `ModelCapabilities::dtype`, used by the model to communicate the dtype it
   wants to use for inputs and outputs.
+- The `load_model_extensions()` function to facilitate loading a model using
+  TorchScript extensions
 
 ### metatensor-torch Python
 
@@ -30,10 +32,10 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 - `ModelCapabilities.dtype`, used by the model to communicate the dtype it
   wants to use for inputs and outputs.
-
 - The `device` that should be used by a model inside the ASE's
   `MetatensorCalculator` can now be specified by the user.
-
+- The `load_model_extensions()` and `load_atomistic_model` functions to
+  facilitate loading a model using TorchScript extensions
 
 ## [Version 0.3.0](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-torch-v0.3.0) - 2024-03-01
 

--- a/metatensor-torch/CMakeLists.txt
+++ b/metatensor-torch/CMakeLists.txt
@@ -93,7 +93,7 @@ endif()
 # fixed version in `cmake/FindCUDNN.cmake`
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
 
-find_package(Torch 1.11 REQUIRED)
+find_package(Torch 1.12 REQUIRED)
 
 set(METATENSOR_TORCH_HEADERS
     "include/metatensor/torch/array.hpp"

--- a/metatensor-torch/CMakeLists.txt
+++ b/metatensor-torch/CMakeLists.txt
@@ -129,7 +129,7 @@ target_compile_definitions(metatensor_torch PRIVATE
     METATENSOR_TORCH_VERSION="${METATENSOR_TORCH_FULL_VERSION}"
 )
 
-target_link_libraries(metatensor_torch PUBLIC torch metatensor::shared)
+target_link_libraries(metatensor_torch PUBLIC torch metatensor::shared ${CMAKE_DL_LIBS})
 target_compile_features(metatensor_torch PUBLIC cxx_std_17)
 target_include_directories(metatensor_torch PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/metatensor-torch/include/metatensor/torch/atomistic/model.hpp
+++ b/metatensor-torch/include/metatensor/torch/atomistic/model.hpp
@@ -289,12 +289,28 @@ private:
 };
 
 /// Check the exported metatensor atomistic model at the given `path`, and
-/// warn/error as required.
+/// warn/error as required. This should be called after `load_model_extensions`
 METATENSOR_TORCH_EXPORT void check_atomistic_model(std::string path);
 
+/// Load all extensions and extensions dependencies for the model at the given
+/// `path`, trying to find extensions and dependencies in the given
+/// `extensions`. Users can set the `METATENSOR_DEBUG_EXTENSIONS_LOADING`
+/// environment variable to get more information when loading fails.
+METATENSOR_TORCH_EXPORT void load_model_extensions(
+    std::string path,
+    c10::optional<std::string> extensions_directory
+);
+
 /// Check and then load the metatensor atomistic model at the given `path`.
+///
+/// The model is returned on the given `device`.
+///
+/// This function calls `check_atomistic_model(path)` and
+/// `load_model_extensions(path, extension_directory)` before attempting to load
+/// the model.
 METATENSOR_TORCH_EXPORT torch::jit::Module load_atomistic_model(
     std::string path,
+    c10::optional<std::string> extensions_directory,
     c10::optional<c10::Device> device = c10::nullopt
 );
 

--- a/metatensor-torch/include/metatensor/torch/atomistic/model.hpp
+++ b/metatensor-torch/include/metatensor/torch/atomistic/model.hpp
@@ -303,15 +303,12 @@ METATENSOR_TORCH_EXPORT void load_model_extensions(
 
 /// Check and then load the metatensor atomistic model at the given `path`.
 ///
-/// The model is returned on the given `device`.
-///
 /// This function calls `check_atomistic_model(path)` and
 /// `load_model_extensions(path, extension_directory)` before attempting to load
 /// the model.
 METATENSOR_TORCH_EXPORT torch::jit::Module load_atomistic_model(
     std::string path,
-    c10::optional<std::string> extensions_directory,
-    c10::optional<c10::Device> device = c10::nullopt
+    c10::optional<std::string> extensions_directory = c10::nullopt
 );
 
 /// Get the multiplicative conversion factor to use to convert from unit `from`

--- a/metatensor-torch/src/atomistic/model.cpp
+++ b/metatensor-torch/src/atomistic/model.cpp
@@ -868,12 +868,11 @@ void metatensor_torch::check_atomistic_model(std::string path) {
 
 torch::jit::Module metatensor_torch::load_atomistic_model(
     std::string path,
-    c10::optional<std::string> extensions_directory,
-    c10::optional<c10::Device> device
+    c10::optional<std::string> extensions_directory
 ) {
     check_atomistic_model(path);
     load_model_extensions(path, extensions_directory);
-    return torch::jit::load(path, device);
+    return torch::jit::load(path);
 }
 
 /******************************************************************************/

--- a/metatensor-torch/src/internal/shared_libraries.cpp
+++ b/metatensor-torch/src/internal/shared_libraries.cpp
@@ -1,4 +1,7 @@
 #include <mutex>
+#include <cstdlib>
+#include <iostream>
+#include <filesystem>
 
 #include "shared_libraries.hpp"
 
@@ -11,6 +14,7 @@ static std::mutex MUTEX;
 #endif
 
 #include <link.h>
+#include <dlfcn.h>
 
 
 static int phdr_callback(struct dl_phdr_info *info, size_t, void *data) {
@@ -30,10 +34,21 @@ std::vector<std::string> metatensor_torch::details::get_loaded_libraries() {
     return result;
 }
 
+static bool try_load(const std::string& path, bool debug) {
+    auto* lib = dlopen(path.c_str(), RTLD_LAZY);
+
+    if (debug && lib == nullptr) {
+        std::cerr << dlerror() << std::endl;
+    }
+
+    return lib != nullptr;
+}
+
 
 #elif defined(__APPLE__)
 
 #include <mach-o/dyld.h>
+#include <dlfcn.h>
 
 std::vector<std::string> metatensor_torch::details::get_loaded_libraries() {
     // prevent simultaneous calls to this function
@@ -49,6 +64,20 @@ std::vector<std::string> metatensor_torch::details::get_loaded_libraries() {
     return result;
 }
 
+static bool try_load(const std::string& path, bool debug) {
+    auto* lib = dlopen(path.c_str(), RTLD_LAZY);
+
+    if (debug) {
+        if (lib == nullptr) {
+            std::cerr << "failed: " << dlerror() << std::endl;
+        } else {
+            std::cerr << " … success!" << std::endl;
+        }
+    }
+
+    return lib != nullptr;
+}
+
 #elif defined(_WIN32)
 
 #include <Windows.h>
@@ -57,6 +86,9 @@ std::vector<std::string> metatensor_torch::details::get_loaded_libraries() {
 #include <cstring>
 
 std::vector<std::string> metatensor_torch::details::get_loaded_libraries() {
+    // prevent simultaneous calls to this function
+    auto guard = std::lock_guard<std::mutex>(MUTEX);
+
     auto handle = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32, 0);
 
     if (handle == INVALID_HANDLE_VALUE) {
@@ -87,8 +119,83 @@ std::vector<std::string> metatensor_torch::details::get_loaded_libraries() {
     return result;
 }
 
+static bool try_load(const std::string& path, bool debug) {
+    // do not open a dialog window if the DLL fails to load
+    auto previous_error_mode = GetErrorMode();
+    SetErrorMode(previous_error_mode | SEM_FAILCRITICALERRORS);
+
+    HMODULE library = nullptr;
+    // convert file path to absolute path, but leave file name alone
+    if (path.find('/') != std::string::npos || path.find('\\') != std::string::npos) {
+        auto full_path = std::string(4096, '\0');
+        auto size = GetFullPathNameA(path.c_str(), full_path.size(), &full_path[0], nullptr);
+        full_path.resize(size);
+
+        library = LoadLibraryA(full_path.c_str());
+    } else {
+        library = LoadLibraryA(path.c_str());
+    }
+
+    if (debug) {
+        if (library == nullptr) {
+            auto status = GetLastError();
+
+            LPTSTR message = nullptr;
+            FormatMessage(
+                FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS,
+                /* language */ nullptr,
+                status,
+                /* language */0,
+                reinterpret_cast<LPTSTR>(&message),
+                /* buffer size */0,
+                /* format arguments */nullptr
+            );
+
+            if (message != nullptr) {
+                std::cerr << "failed: " << message << std::endl;
+                LocalFree(message);
+            }
+        } else {
+            std::cerr << " … success!" << std::endl;
+        }
+    }
+
+    // reset error mode
+    SetErrorMode(previous_error_mode);
+
+    return library != nullptr;
+}
+
 #else
 
 #error "Unsupported OS, please add it to this file!"
 
 #endif
+
+bool metatensor_torch::details::load_library(
+    const std::string& name,
+    const std::vector<std::string>& candidates
+) {
+    auto debug = getenv("METATENSOR_DEBUG_EXTENSIONS_LOADING") != nullptr;
+
+    for (const auto& path: candidates) {
+        if (std::filesystem::exists(path)) {
+            if (debug) {
+                std::cerr << "trying to load '" << path << "' …" << std::endl;
+            }
+            auto loaded = try_load(path, debug);
+            if (loaded) {
+                return true;
+            }
+        } else {
+            if (debug) {
+                std::cerr << "skipping '" << path << "', the file does not exists" << std::endl;
+            }
+        }
+    }
+
+    if (debug) {
+        std::cerr << "trying to load by name '" << name << "' …" << std::endl;
+    }
+    return try_load(name, debug);
+}

--- a/metatensor-torch/src/internal/shared_libraries.hpp
+++ b/metatensor-torch/src/internal/shared_libraries.hpp
@@ -6,9 +6,14 @@
 
 namespace metatensor_torch::details {
 
-/// Get the full list of shared libraries loaded by the current module. Shared
-/// libraries are returned with their path.
+/// Get the full list of shared libraries loaded by the current executable.
+/// This function returns the path to the libraries.
 std::vector<std::string> get_loaded_libraries();
+
+/// Try to load a shared library, trying the candidates in order, and if they
+/// all fail trying to load by name. This function returns if it managed to find
+/// and load the library.
+bool load_library(const std::string& name, const std::vector<std::string>& candidates);
 
 }
 

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -482,9 +482,10 @@ TORCH_LIBRARY(metatensor, m) {
             }
         );
 
+    m.def("check_atomistic_model(str path) -> ()", check_atomistic_model);
+    m.def("load_model_extensions(str path, str? extensions_directory) -> ()", load_model_extensions);
 
     m.def("unit_conversion_factor(str quantity, str from_unit, str to_unit) -> float", unit_conversion_factor);
-    m.def("check_atomistic_model(str path) -> ()", check_atomistic_model);
     m.def(
         "register_autograd_neighbors("
             "__torch__.torch.classes.metatensor.System system, "

--- a/python/metatensor-torch/build-backend/backend.py
+++ b/python/metatensor-torch/build-backend/backend.py
@@ -37,7 +37,7 @@ FORCED_TORCH_VERSION = os.environ.get("METATENSOR_TORCH_BUILD_WITH_TORCH_VERSION
 if FORCED_TORCH_VERSION is not None:
     TORCH_DEP = f"torch =={FORCED_TORCH_VERSION}"
 else:
-    TORCH_DEP = "torch >=1.11"
+    TORCH_DEP = "torch >=1.12"
 
 # ==================================================================================== #
 #                   Build backend functions definition                                 #

--- a/python/metatensor-torch/metatensor/torch/atomistic/__init__.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/__init__.py
@@ -33,4 +33,5 @@ else:
     unit_conversion_factor = torch.ops.metatensor.unit_conversion_factor
 
 from .model import MetatensorAtomisticModel, ModelInterface  # noqa: F401
+from .model import load_atomistic_model  # noqa: F401
 from .systems_to_torch import systems_to_torch  # noqa: F401

--- a/python/metatensor-torch/metatensor/torch/atomistic/__init__.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/__init__.py
@@ -12,6 +12,7 @@ if os.environ.get("METATENSOR_IMPORT_FOR_SPHINX", "0") != "0":
 
     from .documentation import (
         check_atomistic_model,
+        load_model_extensions,
         register_autograd_neighbors,
         unit_conversion_factor,
     )
@@ -25,7 +26,9 @@ else:
     ModelCapabilities = torch.classes.metatensor.ModelCapabilities
     ModelMetadata = torch.classes.metatensor.ModelMetadata
 
+    load_model_extensions = torch.ops.metatensor.load_model_extensions
     check_atomistic_model = torch.ops.metatensor.check_atomistic_model
+
     register_autograd_neighbors = torch.ops.metatensor.register_autograd_neighbors
     unit_conversion_factor = torch.ops.metatensor.unit_conversion_factor
 

--- a/python/metatensor-torch/metatensor/torch/atomistic/_extensions.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/_extensions.py
@@ -1,0 +1,94 @@
+import hashlib
+import os
+import shutil
+import site
+
+import torch
+
+
+def _rascaline_lib_path():
+    import rascaline
+
+    return [rascaline._c_lib._lib_path()]
+
+
+# Manual definition of which TorchScript extensions have their own dependencies. The
+# dependencies should be returned in the order they need to be loaded.
+EXTENSIONS_WITH_DEPENDENCIES = {
+    "rascaline_torch": _rascaline_lib_path,
+}
+
+
+def _collect_extensions(extensions_path):
+    """
+    Record the list of loaded TorchScript extensions (and their dependencies), to check
+    that they are also loaded when executing the model.
+    """
+    if extensions_path is not None:
+        if os.path.exists(extensions_path):
+            shutil.rmtree(extensions_path)
+        os.makedirs(extensions_path)
+        # TODO: the extensions are currently collected in a separate directory,
+        # should we store the files directly inside the model file? This would makes
+        # the model platform-specific but much more convenient (since the end user
+        # does not have to move a model around)
+
+    extensions = []
+    extensions_deps = []
+    for library in torch.ops.loaded_libraries:
+        path = _copy_extension(library, extensions_path)
+        info = _extension_info(library)
+        info["path"] = path
+        extensions.append(info)
+
+        for extra in EXTENSIONS_WITH_DEPENDENCIES.get(info["name"], lambda: [])():
+            path = _copy_extension(extra, extensions_path)
+            info = _extension_info(extra)
+            info["path"] = path
+            extensions_deps.append(info)
+
+    return extensions, extensions_deps
+
+
+def _copy_extension(full_path, extensions_path):
+    path = full_path
+    for site_packages in site.getsitepackages():
+        # Remove any site-package prefix
+        if path.startswith(site_packages):
+            path = os.path.relpath(path, site_packages)
+            break
+
+    if extensions_path is not None:
+        collect_path = os.path.join(extensions_path, path)
+        if os.path.exists(collect_path):
+            raise RuntimeError(
+                f"more than one extension would be collected at {collect_path}"
+            )
+
+        os.makedirs(os.path.dirname(collect_path), exist_ok=True)
+        shutil.copyfile(full_path, collect_path)
+
+    return path
+
+
+def _extension_info(path):
+    # get the name of the library, excluding any shared object prefix/suffix
+    name = os.path.basename(path)
+    if name.startswith("lib"):
+        name = name[3:]
+
+    if name.endswith(".so"):
+        name = name[:-3]
+
+    if name.endswith(".dll"):
+        name = name[:-4]
+
+    if name.endswith(".dylib"):
+        name = name[:-6]
+
+    # Collect the hash of the extension shared library. We don't currently use
+    # this, but it would allow for binary-level reproducibility later.
+    with open(path, "rb") as fd:
+        sha256 = hashlib.sha256(fd.read()).hexdigest()
+
+    return {"name": name, "sha256": sha256}

--- a/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
@@ -433,6 +433,25 @@ def check_atomistic_model(path: str):
     """
 
 
+def load_model_extensions(path: str, extensions_directory: Optional[str] = None):
+    """
+    Load the TorchScript extensions (and their dependencies) that the model at ``path``
+    uses.
+
+    If ``extensions_directory`` is provided, we look for the extensions and their
+    dependencies in there first. If this function fails to load some library, it will
+    produce a warning using Torch's warnings infrastructure. Users can set the
+    ``METATENSOR_DEBUG_EXTENSIONS_LOADING`` environment variable to get more
+    informations about a failure in the standard error output.
+
+    :param path: path to the exported model file
+    :param extensions_directory: path to a directory containing the extensions. This
+        directory will typically be created by calling
+        :py:meth:`MetatensorAtomisticModel.export` with
+        ``collect_extensions=extensions_directory``.
+    """
+
+
 def register_autograd_neighbors(
     system: System, neighbors: TensorBlock, check_consistency: bool
 ):

--- a/python/metatensor-torch/metatensor/torch/atomistic/model.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/model.py
@@ -18,10 +18,29 @@ from . import (
     ModelOutput,
     NeighborsListOptions,
     System,
+    check_atomistic_model,
+    load_model_extensions,
     unit_conversion_factor,
 )
 from ._extensions import _collect_extensions
 from .outputs import _check_outputs
+
+
+def load_atomistic_model(path, extensions_directory=None) -> "MetatensorAtomisticModel":
+    """
+    Check and then load the metatensor atomistic model at the given `path`.
+
+    This function calls :py:func:`metatensor.torch.atomistic.check_atomistic_model()`
+    and :py:func:`metatensor.torch.atomistic.load_model_extensions()` before attempting
+    to load the model.
+
+    :param path: path to an exported metatensor model
+    :param extensions_directory: path to a directory containing all extensions required
+        by the exported model
+    """
+    check_atomistic_model(path)
+    load_model_extensions(path, extensions_directory)
+    return torch.jit.load(path)
 
 
 class ModelInterface(torch.nn.Module):

--- a/python/metatensor-torch/setup.py
+++ b/python/metatensor-torch/setup.py
@@ -291,7 +291,7 @@ if __name__ == "__main__":
         with open(os.path.join(ROOT, authors[0])) as fd:
             authors = fd.read().splitlines()
 
-    install_requires = ["torch >= 1.11"]
+    install_requires = ["torch >= 1.12"]
 
     # when packaging a sdist for release, we should never use local dependencies
     METATENSOR_NO_LOCAL_DEPS = os.environ.get("METATENSOR_NO_LOCAL_DEPS", "0") == "1"

--- a/tox.ini
+++ b/tox.ini
@@ -169,7 +169,10 @@ commands =
     # install metatensor-learn
     pip install ../metatensor-learn {[testenv]build_single_wheel} --force-reinstall
 
-    # Make torch.autograd.gradcheck work with pytest
+    # use the reference LJ implementation for tests
+    pip install {[testenv]build_single_wheel} --force-reinstall git+https://github.com/Luthaf/metatensor-lj-test@875c807
+
+    # Make torch.autograd.gradcheck works with pytest
     python {toxinidir}/scripts/pytest-dont-rewrite-torch.py
 
     # run the unit tests


### PR DESCRIPTION
Fix #512 

This PR adds functionality to load the extensions a model uses (in practise defined as the extensions that where loaded when exporting a model) after the fact. This will enable using a model using rascaline without doing an `import rascaline.torch` before; or in LAMMPS.

An extensions loaded from `<site-package>/some/path.so` will be recorded as `some/path.so`, and we will try to load it from `<extensions_directory>/some/path.so`, `<current_directory>/some/path.so` and just as `path` (letting the OS try to find this lib, which enables stuff like `LD_LIBRARY_PATH` to work).

### Unresolved

Should we allow for multiple `extensions_directory`? So a user could add a Python's `<site-packages>` with the right set of packages to the list, allowing to use some newer versions of the extensions together with the files that where collected during the model export?


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--569.org.readthedocs.build/en/569/

<!-- readthedocs-preview metatensor end -->