### PR TITLE
Release metatensor-core v0.1.5

### DIFF
--- a/docs/src/core/reference/c/index.rst
+++ b/docs/src/core/reference/c/index.rst
@@ -11,6 +11,10 @@ C API reference
   .. grid::
     :margin: 0 0 0 0
 
+    .. grid-item-version:: 0.1.5
+      :tag-prefix: metatensor-core-v
+      :url-suffix: core/reference/c/index.html
+
     .. grid-item-version:: 0.1.4
       :tag-prefix: metatensor-core-v
       :url-suffix: core/reference/c/index.html

--- a/docs/src/core/reference/cxx/index.rst
+++ b/docs/src/core/reference/cxx/index.rst
@@ -11,6 +11,10 @@ C++ API reference
   .. grid::
     :margin: 0 0 0 0
 
+    .. grid-item-version:: 0.1.5
+      :tag-prefix: metatensor-core-v
+      :url-suffix: core/reference/cxx/index.html
+
     .. grid-item-version:: 0.1.4
       :tag-prefix: metatensor-core-v
       :url-suffix: core/reference/cxx/index.html

--- a/docs/src/core/reference/python/index.rst
+++ b/docs/src/core/reference/python/index.rst
@@ -11,6 +11,10 @@ Python API reference
   .. grid::
     :margin: 0 0 0 0
 
+    .. grid-item-version:: 0.1.5
+      :tag-prefix: metatensor-core-v
+      :url-suffix: core/reference/python/index.html
+
     .. grid-item-version:: 0.1.4
       :tag-prefix: metatensor-core-v
       :url-suffix: core/reference/python/index.html

--- a/metatensor-core/CHANGELOG.md
+++ b/metatensor-core/CHANGELOG.md
@@ -29,6 +29,21 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 - the Julia bindings to metatensor-core in the Metatensor.jl package
 
+## [Version 0.1.5](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-core-v0.1.5) - 2024-04-09
+
+### metatensor-core C++
+
+#### Fixed
+
+- fixed compilation with cmake 3.29.1 (#573)
+
+### metatensor-core Python
+
+### Changed
+
+-  allow positional arguments in `TensorMap.to`/`TensorBlock.to` (#556)
+
+
 ## [Version 0.1.4](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-core-v0.1.4) - 2024-03-01
 
 ### Fixed

--- a/metatensor-core/Cargo.toml
+++ b/metatensor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metatensor-core"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 publish = false
 rust-version = "1.65"

--- a/metatensor-core/src/tensor/mod.rs
+++ b/metatensor-core/src/tensor/mod.rs
@@ -66,7 +66,7 @@ fn check_labels_names(
     Ok(())
 }
 
-fn check_origin(blocks: &Vec<TensorBlock>) -> Result<(), Error> {
+fn check_origin(blocks: &[TensorBlock]) -> Result<(), Error> {
     if blocks.is_empty() {
         return Ok(());
     }

--- a/rust/metatensor-sys/Cargo.toml
+++ b/rust/metatensor-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metatensor-sys"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 
 description = "Bindings to the metatensor C library"

--- a/rust/metatensor/src/lib.rs
+++ b/rust/metatensor/src/lib.rs
@@ -28,6 +28,7 @@
 #![allow(clippy::unreadable_literal, clippy::option_if_let_else, clippy::module_name_repetitions)]
 #![allow(clippy::missing_errors_doc, clippy::missing_panics_doc, clippy::missing_safety_doc)]
 #![allow(clippy::similar_names, clippy::borrow_as_ptr, clippy::uninlined_format_args)]
+#![allow(clippy::thread_local_initializer_can_be_made_const)]
 
 pub use metatensor_sys as c_api;
 


### PR DESCRIPTION
This mainly includes #573, which we also need in rascaline.


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--574.org.readthedocs.build/en/574/

<!-- readthedocs-preview metatensor end -->