### PR TITLE
Make sure the temporary directory is always created

### DIFF
--- a/metatensor-core/cmake/tempdir.cmake
+++ b/metatensor-core/cmake/tempdir.cmake
@@ -22,6 +22,7 @@ function(get_tempdir _outvar_)
         )
 
         if(_status_ EQUAL 0)
+            file(MAKE_DIRECTORY ${_output_})
             set(${_outvar_} ${_output_} PARENT_SCOPE)
             return()
         endif()


### PR DESCRIPTION
Some windows version of mktemp don't create it. This was required to get the code to build on conda-forge (https://github.com/conda-forge/staged-recipes/pull/25986)


# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--575.org.readthedocs.build/en/575/

<!-- readthedocs-preview metatensor end -->