### PR TITLE
Allow to override custom data inside a System

### DIFF
--- a/metatensor-torch/CHANGELOG.md
+++ b/metatensor-torch/CHANGELOG.md
@@ -24,7 +24,12 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 - `ModelCapabilities::dtype`, used by the model to communicate the dtype it
   wants to use for inputs and outputs.
 - The `load_model_extensions()` function to facilitate loading a model using
-  TorchScript extensions
+  TorchScript extensions.
+
+#### Changed
+
+- `System::add_data` now has an `override` parameter to replace custom data with
+  a new value.
 
 ### metatensor-torch Python
 

--- a/metatensor-torch/include/metatensor/torch/atomistic/system.hpp
+++ b/metatensor-torch/include/metatensor/torch/atomistic/system.hpp
@@ -243,7 +243,9 @@ public:
     ///
     /// @param name name of the data
     /// @param values values of the data
-    void add_data(std::string name, TorchTensorBlock values);
+    /// @param override if true, allow this function to override existing data
+    ///                 with the same name
+    void add_data(std::string name, TorchTensorBlock values, bool override=false);
 
     /// Retrieve custom data stored in this System, or throw an error.
     TorchTensorBlock get_data(std::string name) const;

--- a/metatensor-torch/src/atomistic/system.cpp
+++ b/metatensor-torch/src/atomistic/system.cpp
@@ -676,7 +676,7 @@ static auto INVALID_DATA_NAMES = std::unordered_set<std::string>{
     "neighbors", "neighbor"
 };
 
-void SystemHolder::add_data(std::string name, TorchTensorBlock values) {
+void SystemHolder::add_data(std::string name, TorchTensorBlock values, bool override) {
     if (!valid_ident(name)) {
         C10_THROW_ERROR(ValueError,
             "custom data name '" + name + "' is invalid: only [a-z A-Z 0-9 _-] are accepted"
@@ -689,7 +689,7 @@ void SystemHolder::add_data(std::string name, TorchTensorBlock values) {
         );
     }
 
-    if (data_.find(name) != data_.end()) {
+    if (!override && data_.find(name) != data_.end()) {
         C10_THROW_ERROR(ValueError,
             "custom data '" + name + "' is already present in this system"
         );
@@ -711,7 +711,7 @@ void SystemHolder::add_data(std::string name, TorchTensorBlock values) {
         );
     }
 
-    data_.emplace(std::move(name), std::move(values));
+    data_.insert_or_assign(std::move(name), std::move(values));
 }
 
 TorchTensorBlock SystemHolder::get_data(std::string name) const {

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -354,7 +354,7 @@ TORCH_LIBRARY(metatensor, m) {
         )
         .def("known_neighbors_lists", &SystemHolder::known_neighbors_lists)
         .def("add_data", &SystemHolder::add_data, DOCSTRING,
-            {torch::arg("name"), torch::arg("data")}
+            {torch::arg("name"), torch::arg("data"), torch::arg("override") = false}
         )
         .def("get_data", &SystemHolder::get_data, DOCSTRING,
             {torch::arg("name")}

--- a/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
@@ -135,7 +135,7 @@ class System:
         Get all the neighbors lists options registered with this :py:class:`System`
         """
 
-    def add_data(self, name: str, data: TensorBlock):
+    def add_data(self, name: str, data: TensorBlock, override: bool = False):
         """
         Add custom data to this system, stored as :py:class:`TensorBlock`.
 
@@ -144,6 +144,8 @@ class System:
 
         :param name: name of the custom data
         :param data: values of the custom data
+        :param override: if ``True``, allow this function to override existing data with
+            the same name
         """
 
     def get_data(self, name: str) -> TensorBlock:

--- a/python/metatensor-torch/tests/atomistic/systems.py
+++ b/python/metatensor-torch/tests/atomistic/systems.py
@@ -132,6 +132,13 @@ def test_custom_data(system):
     with pytest.raises(ValueError, match=message):
         system.add_data("data-name", data)
 
+    new_data = data.copy()
+    new_data.values[:] = 12
+    # this should work
+    system.add_data("data-name", new_data, override=True)
+
+    assert metatensor.torch.equal_block(system.get_data("data-name"), new_data)
+
 
 def test_data_validation(types, positions, cell):
     # this should run without error:


### PR DESCRIPTION
This enable workflows where a first part of the calculation generates some data that will be used as input in a second part of the calculations (e.g. soap model to generate charges then used by lode)

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--578.org.readthedocs.build/en/578/

<!-- readthedocs-preview metatensor end -->