### PR TITLE
Use the right link for preview wheels in PR

### DIFF
--- a/.github/workflows/comment-wheels-pr.yml
+++ b/.github/workflows/comment-wheels-pr.yml
@@ -59,7 +59,7 @@ jobs:
 
             for (const artifact of artifacts) {
                 if (artifact.name == "wheels") {
-                    const link = `https://nightly.link/${owner}/${repo}/actions/artifacts/${artifacts[0].id}.zip`
+                    const link = `https://nightly.link/${owner}/${repo}/actions/artifacts/${artifact.id}.zip`
 
                     let body = `Here is a pre-built version of the code in this pull request: [wheels.zip](${link}), `;
                     body += 'you can install it locally by unzipping `wheels.zip` and using `pip` to install the file matching your system';


### PR DESCRIPTION
There was a typo using the first artifact instead of the current one

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--582.org.readthedocs.build/en/582/

<!-- readthedocs-preview metatensor end -->