### PR TITLE
More tweaks for loading extensions

### DIFF
--- a/metatensor-torch/src/atomistic/model.cpp
+++ b/metatensor-torch/src/atomistic/model.cpp
@@ -897,8 +897,8 @@ torch::jit::Module metatensor_torch::load_atomistic_model(
     std::string path,
     c10::optional<std::string> extensions_directory
 ) {
-    check_atomistic_model(path);
     load_model_extensions(path, extensions_directory);
+    check_atomistic_model(path);
     return torch::jit::load(path);
 }
 

--- a/python/metatensor-torch/metatensor/torch/atomistic/_extensions.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/_extensions.py
@@ -5,6 +5,11 @@ import site
 
 import torch
 
+from .. import _c_lib
+
+
+METATENSOR_TORCH_LIB_PATH = _c_lib._lib_path()
+
 
 def _rascaline_lib_path():
     import rascaline
@@ -36,6 +41,9 @@ def _collect_extensions(extensions_path):
     extensions = []
     extensions_deps = []
     for library in torch.ops.loaded_libraries:
+        if library == METATENSOR_TORCH_LIB_PATH:
+            continue
+
         path = _copy_extension(library, extensions_path)
         info = _extension_info(library)
         info["path"] = path

--- a/python/metatensor-torch/metatensor/torch/atomistic/model.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/model.py
@@ -615,7 +615,7 @@ def _check_inputs(
 
         possible_atoms = Labels(
             ["system", "atom"],
-            torch.tensor(possible_atoms_values),
+            torch.tensor(possible_atoms_values, device=global_device),
         )
 
         intersection = selected_atoms.intersection(possible_atoms)

--- a/python/metatensor-torch/metatensor/torch/atomistic/model.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/model.py
@@ -38,8 +38,8 @@ def load_atomistic_model(path, extensions_directory=None) -> "MetatensorAtomisti
     :param extensions_directory: path to a directory containing all extensions required
         by the exported model
     """
-    check_atomistic_model(path)
     load_model_extensions(path, extensions_directory)
+    check_atomistic_model(path)
     return torch.jit.load(path)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -170,7 +170,7 @@ commands =
     pip install ../metatensor-learn {[testenv]build_single_wheel} --force-reinstall
 
     # use the reference LJ implementation for tests
-    pip install {[testenv]build_single_wheel} --force-reinstall git+https://github.com/Luthaf/metatensor-lj-test@875c807
+    pip install {[testenv]build_single_wheel} --force-reinstall git+https://github.com/Luthaf/metatensor-lj-test@78087b9
 
     # Make torch.autograd.gradcheck works with pytest
     python {toxinidir}/scripts/pytest-dont-rewrite-torch.py


### PR DESCRIPTION
The main change is the order of operations when loading a model: first try to load extensions, THEN complain if extensions are not loaded.

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--584.org.readthedocs.build/en/584/

<!-- readthedocs-preview metatensor end -->