### PR TITLE
Much faster adapter from ASE NL to metatensor NL

### DIFF
--- a/python/metatensor-torch/tests/atomistic/neighbors.py
+++ b/python/metatensor-torch/tests/atomistic/neighbors.py
@@ -76,9 +76,9 @@ def test_neighbors_autograd():
         system = System(
             torch.from_numpy(atoms.numbers).to(torch.int32), positions, cell
         )
-        register_autograd_neighbors(system, neighbors)
+        register_autograd_neighbors(system, neighbors, check_consistency=True)
 
-        return neighbors.values
+        return neighbors.values.sum()
 
     options = NeighborsListOptions(cutoff=2.0, full_list=False)
     torch.autograd.gradcheck(
@@ -126,9 +126,9 @@ def test_neighbors_autograd_errors():
 
     message = (
         "one neighbor pair does not match its metadata: the pair between atom 0 and "
-        "atom 4 for the \\[0, 0, 0\\] cell shift should have a distance vector of "
-        "\\[0.489917, 1.24926, 0.102936\\] but has a distance vector of "
-        "\\[1.46975, 3.74777, 0.308807\\]"
+        "atom 6 for the \\[0, 0, 0\\] cell shift should have a distance vector of "
+        "\\[-0.220464, -0.407372, 1.07291\\] but has a distance vector of "
+        "\\[-0.661392, -1.22212, 3.21872\\]"
     )
     neighbors = _compute_ase_neighbors(
         atoms, options, dtype=torch.float64, device="cpu"

--- a/python/metatensor-torch/tests/atomistic/systems.py
+++ b/python/metatensor-torch/tests/atomistic/systems.py
@@ -293,11 +293,7 @@ def test_neighbors_validation(system):
                     "cell_shift_a",
                     "cell_shift_b",
                 ],
-                torch.tensor(
-                    [
-                        (0, 1, 0, 0),
-                    ]
-                ),
+                torch.tensor([(0, 1, 0, 0)]),
             ),
             components=[Labels.range("xyz", 3)],
             properties=Labels.range("distance", 1),
@@ -320,11 +316,7 @@ def test_neighbors_validation(system):
                     "cell_shift_b",
                     "cell_shift_c",
                 ],
-                torch.tensor(
-                    [
-                        (0, 1, 0, 0, 0),
-                    ]
-                ),
+                torch.tensor([(0, 1, 0, 0, 0)]),
             ),
             components=[Labels.range("a", 3)],
             properties=Labels.range("distance", 1),
@@ -347,11 +339,7 @@ def test_neighbors_validation(system):
                     "cell_shift_b",
                     "cell_shift_c",
                 ],
-                torch.tensor(
-                    [
-                        (0, 1, 0, 0, 0),
-                    ]
-                ),
+                torch.tensor([(0, 1, 0, 0, 0)]),
             ),
             components=[Labels.range("xyz", 3)],
             properties=Labels.range("distance", 2),
@@ -371,11 +359,7 @@ def test_neighbors_validation(system):
                     "cell_shift_b",
                     "cell_shift_c",
                 ],
-                torch.tensor(
-                    [
-                        (0, 1, 0, 0, 0),
-                    ]
-                ),
+                torch.tensor([(0, 1, 0, 0, 0)]),
             ),
             components=[Labels.range("xyz", 3)],
             properties=Labels.range("distance", 1),
@@ -407,11 +391,7 @@ def test_neighbors_validation(system):
                     "cell_shift_b",
                     "cell_shift_c",
                 ],
-                torch.tensor(
-                    [
-                        (0, 1, 0, 0, 0),
-                    ]
-                ),
+                torch.tensor([(0, 1, 0, 0, 0)]),
             ).to(device="meta"),
             components=[Labels.range("xyz", 3).to(device="meta")],
             properties=Labels.range("distance", 1).to(device="meta"),
@@ -434,11 +414,7 @@ def test_neighbors_validation(system):
                     "cell_shift_b",
                     "cell_shift_c",
                 ],
-                torch.tensor(
-                    [
-                        (0, 1, 0, 0, 0),
-                    ]
-                ),
+                torch.tensor([(0, 1, 0, 0, 0)]),
             ),
             components=[Labels.range("xyz", 3)],
             properties=Labels.range("distance", 1),

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ test_options =
 
 packaging_deps =
     setuptools
+    setuptools-scm
     packaging
     wheel
     cmake
@@ -170,7 +171,7 @@ commands =
     pip install ../metatensor-learn {[testenv]build_single_wheel} --force-reinstall
 
     # use the reference LJ implementation for tests
-    pip install {[testenv]build_single_wheel} --force-reinstall git+https://github.com/Luthaf/metatensor-lj-test@78087b9
+    pip install {[testenv]build_single_wheel} git+https://github.com/Luthaf/metatensor-lj-test@acbf4b0
 
     # Make torch.autograd.gradcheck works with pytest
     python {toxinidir}/scripts/pytest-dont-rewrite-torch.py


### PR DESCRIPTION
The previous code was doing too many Python loops, and computing the neighbors took ~1s for only 40 atoms. It is now down to 20ms.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--586.org.readthedocs.build/en/586/

<!-- readthedocs-preview metatensor end -->