### PR TITLE
Add support for torch v2.3

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -112,6 +112,8 @@ jobs:
           # arm64-macos is only supported for torch >= 2.0
           - {os: macos-14, arch: arm64, torch-version: '1.12'}
           - {os: macos-14, arch: arm64, torch-version: '1.13'}
+          # x86_64-macos is only supported for torch <2.3
+          - {os: macos-11, arch: x86_64, torch-version: '2.3'}
         include:
           # add `cibw-arch` and `rust-target` to the different configurations
           - name: x86_64 Linux

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -109,6 +109,8 @@ jobs:
           - {os: macos-11, arch: arm64}
           # no arm64-windows build
           - {os: windows-2019, arch: arm64}
+          # https://github.com/pytorch/pytorch/issues/125109
+          - {os: windows-2019, torch-version: '2.3'}
           # arm64-macos is only supported for torch >= 2.0
           - {os: macos-14, arch: arm64, torch-version: '1.12'}
           - {os: macos-14, arch: arm64, torch-version: '1.13'}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -100,7 +100,7 @@ jobs:
     name: ${{ matrix.name }} (torch v${{ matrix.torch-version }})
     strategy:
       matrix:
-        torch-version: ['1.12', '1.13', '2.0', '2.1', '2.2']
+        torch-version: ['1.12', '1.13', '2.0', '2.1', '2.2', '2.3']
         arch: ['arm64', 'x86_64']
         os: ['ubuntu-22.04', 'macos-11', 'macos-14', 'windows-2019']
         exclude:
@@ -145,6 +145,7 @@ jobs:
           - {torch-version: '2.0',  python-version: '3.11', cibw-python: 'cp311-*'}
           - {torch-version: '2.1',  python-version: '3.11', cibw-python: 'cp311-*'}
           - {torch-version: '2.2',  python-version: '3.12', cibw-python: 'cp312-*'}
+          - {torch-version: '2.3',  python-version: '3.12', cibw-python: 'cp312-*'}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/julia-tests.yml
+++ b/.github/workflows/julia-tests.yml
@@ -24,7 +24,7 @@ jobs:
           - os: ubuntu-20.04
             julia-version: "1.9"
 
-          - os: macos-11
+          - os: macos-14
             julia-version: "1.9"
 
           # TODO

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,16 +22,16 @@ jobs:
             torch-version: "1.12.*"
           - os: ubuntu-20.04
             python-version: "3.8"
-            torch-version: "2.2.*"
+            torch-version: "2.3.*"
           - os: ubuntu-20.04
             python-version: "3.12"
-            torch-version: "2.2.*"
+            torch-version: "2.3.*"
           - os: macos-11
             python-version: "3.12"
-            torch-version: "2.2.*"
+            torch-version: "2.3.*"
           - os: windows-2019
             python-version: "3.12"
-            torch-version: "2.2.*"
+            torch-version: "2.3.*"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -26,7 +26,7 @@ jobs:
           - os: ubuntu-20.04
             python-version: "3.12"
             torch-version: "2.3.*"
-          - os: macos-11
+          - os: macos-14
             python-version: "3.12"
             torch-version: "2.3.*"
           - os: windows-2019

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -41,9 +41,9 @@ jobs:
             cargo-build-flags: --features=rayon
             extra-name: ", cmake 3.16"
 
-          - os: macos-11
+          - os: macos-14
             rust-version: stable
-            rust-target: x86_64-apple-darwin
+            rust-target: aarch64-apple-darwin
             cargo-test-flags: --features=rayon
             extra-name: ""
 

--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -38,7 +38,7 @@ jobs:
             cargo-test-flags: --release
 
           - os: windows-2019
-            torch-version: 2.3.*
+            torch-version: 2.2.*
             python-version: "3.12"
             cargo-test-flags: --release
     steps:

--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -27,18 +27,18 @@ jobs:
           - os: ubuntu-20.04
             container: ubuntu:20.04
             extra-name: ", cmake 3.16"
-            torch-version: 2.2.*
+            torch-version: 2.3.*
             python-version: "3.12"
             cargo-test-flags: ""
             cxx-flags: -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -g
 
           - os: macos-11
-            torch-version: 2.2.*
+            torch-version: 2.3.*
             python-version: "3.12"
             cargo-test-flags: --release
 
           - os: windows-2019
-            torch-version: 2.2.*
+            torch-version: 2.3.*
             python-version: "3.12"
             cargo-test-flags: --release
     steps:

--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -32,7 +32,7 @@ jobs:
             cargo-test-flags: ""
             cxx-flags: -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -g
 
-          - os: macos-11
+          - os: macos-14
             torch-version: 2.3.*
             python-version: "3.12"
             cargo-test-flags: --release

--- a/metatensor-torch/tests/utils/mod.rs
+++ b/metatensor-torch/tests/utils/mod.rs
@@ -84,7 +84,7 @@ pub fn setup_pytorch(build_dir: PathBuf) -> PathBuf {
         .expect("failed to run python");
     assert!(status.success(), "failed to run `python -m pip install --upgrade pip`");
 
-    let torch_version = std::env::var("METATENSOR_TESTS_TORCH_VERSION").unwrap_or("2.2.*".into());
+    let torch_version = std::env::var("METATENSOR_TESTS_TORCH_VERSION").unwrap_or("2.3.*".into());
     let status = Command::new(&python)
         .arg("-m")
         .arg("pip")

--- a/python/metatensor-core/tests/_tests_utils.py
+++ b/python/metatensor-core/tests/_tests_utils.py
@@ -1,7 +1,6 @@
-"""Utility functions to be used across all test files.
+"""Utility functions to be used across all test files"""
 
-These functions are by design no pytest fixtures to avoid a confusing global import.
-"""
+import os
 
 import numpy as np
 
@@ -143,4 +142,16 @@ def tensor_zero_len_block():
                 properties=Labels.single(),
             )
         ],
+    )
+
+
+def can_use_mps_backend():
+    import torch
+
+    return (
+        # Github Actions M1 runners don't have a GPU accessible
+        os.environ.get("GITHUB_ACTIONS") is None
+        and hasattr(torch.backends, "mps")
+        and torch.backends.mps.is_built()
+        and torch.backends.mps.is_available()
     )

--- a/python/metatensor-core/tests/blocks.py
+++ b/python/metatensor-core/tests/blocks.py
@@ -15,6 +15,8 @@ except ImportError:
 
 from metatensor import DeviceWarning, Labels, MetatensorError, TensorBlock
 
+from . import _tests_utils
+
 
 @pytest.fixture
 def block():
@@ -440,11 +442,7 @@ def test_to():
         assert isinstance(block.gradient("g").values, torch.Tensor)
 
         devices = ["meta", torch.device("meta")]
-        if (
-            hasattr(torch.backends, "mps")
-            and torch.backends.mps.is_built()
-            and torch.backends.mps.is_available()
-        ):
+        if _tests_utils.can_use_mps_backend():
             devices.append("mps")
             devices.append(torch.device("mps"))
 

--- a/python/metatensor-core/tests/tensor.py
+++ b/python/metatensor-core/tests/tensor.py
@@ -525,11 +525,7 @@ def test_to():
         assert isinstance(tensor.block(0).values, torch.Tensor)
 
         devices = ["meta", torch.device("meta")]
-        if (
-            hasattr(torch.backends, "mps")
-            and torch.backends.mps.is_built()
-            and torch.backends.mps.is_available()
-        ):
+        if _tests_utils.can_use_mps_backend():
             devices.append("mps")
             devices.append(torch.device("mps"))
 

--- a/python/metatensor-learn/tests/_tests_utils.py
+++ b/python/metatensor-learn/tests/_tests_utils.py
@@ -235,3 +235,13 @@ def indexed_dataset_mixed_mem_disk(sample_indices):
         output=outputs,
         auxiliary=partial(transform, filename="auxiliary"),
     )
+
+
+def can_use_mps_backend():
+    return (
+        # Github Actions M1 runners don't have a GPU accessible
+        os.environ.get("GITHUB_ACTIONS") is None
+        and hasattr(torch.backends, "mps")
+        and torch.backends.mps.is_built()
+        and torch.backends.mps.is_available()
+    )

--- a/python/metatensor-learn/tests/module_map.py
+++ b/python/metatensor-learn/tests/module_map.py
@@ -8,7 +8,7 @@ torch = pytest.importorskip("torch")
 
 from metatensor.learn.nn import ModuleMap  # noqa: E402
 
-from ._tests_utils import random_single_block_no_components_tensor_map  # noqa: E402
+from . import _tests_utils  # noqa: E402
 
 
 @pytest.fixture
@@ -16,7 +16,7 @@ def tensor():
     """
     random tensor map with no components using torch as array backend
     """
-    return random_single_block_no_components_tensor_map(use_torch=True)
+    return _tests_utils.random_single_block_no_components_tensor_map(use_torch=True)
 
 
 class MockModule(torch.nn.Module):
@@ -75,11 +75,7 @@ def test_to_device(tensor):
     checking that the output tensor is on this device.
     """
     devices = ["meta"]
-    if (
-        hasattr(torch.backends, "mps")
-        and torch.backends.mps.is_built()
-        and torch.backends.mps.is_available()
-    ):
+    if _tests_utils.can_use_mps_backend():
         devices.append("mps")
 
     if torch.cuda.is_available():

--- a/python/metatensor-torch/tests/_tests_utils.py
+++ b/python/metatensor-torch/tests/_tests_utils.py
@@ -1,3 +1,5 @@
+import os
+
 import torch
 
 from metatensor.torch import Labels, TensorBlock, TensorMap
@@ -137,4 +139,14 @@ def tensor_zero_len_block():
                 properties=Labels.single(),
             )
         ],
+    )
+
+
+def can_use_mps_backend():
+    return (
+        # Github Actions M1 runners don't have a GPU accessible
+        os.environ.get("GITHUB_ACTIONS") is None
+        and hasattr(torch.backends, "mps")
+        and torch.backends.mps.is_built()
+        and torch.backends.mps.is_available()
     )

--- a/python/metatensor-torch/tests/atomistic/ase_calculator.py
+++ b/python/metatensor-torch/tests/atomistic/ase_calculator.py
@@ -25,6 +25,8 @@ from metatensor.torch.atomistic.ase_calculator import (
     _compute_ase_neighbors,
 )
 
+from .. import _tests_utils
+
 
 STR_TO_DTYPE = {
     "float32": torch.float32,
@@ -222,11 +224,7 @@ def test_dtype_device(tmpdir, model, atoms):
         ("float32", "cpu"),
     ]
 
-    if (
-        hasattr(torch.backends, "mps")
-        and torch.backends.mps.is_built()
-        and torch.backends.mps.is_available()
-    ):
+    if _tests_utils.can_use_mps_backend():
         dtype_device.append(("float32", "mps"))
 
     if torch.cuda.is_available():

--- a/python/metatensor-torch/tests/atomistic/systems.py
+++ b/python/metatensor-torch/tests/atomistic/systems.py
@@ -6,6 +6,8 @@ import metatensor.torch
 from metatensor.torch import Labels, TensorBlock
 from metatensor.torch.atomistic import NeighborListOptions, System
 
+from .. import _tests_utils
+
 
 @pytest.fixture
 def types():
@@ -437,11 +439,7 @@ def test_to(system, neighbors):
         check_dtype(converted, torch.float64)
 
     devices = ["meta", torch.device("meta")]
-    if (
-        hasattr(torch.backends, "mps")
-        and torch.backends.mps.is_built()
-        and torch.backends.mps.is_available()
-    ):
+    if _tests_utils.can_use_mps_backend():
         devices.append("mps")
         devices.append(torch.device("mps"))
 

--- a/python/metatensor-torch/tests/block.py
+++ b/python/metatensor-torch/tests/block.py
@@ -7,6 +7,8 @@ from torch import Tensor
 
 from metatensor.torch import Labels, TensorBlock
 
+from . import _tests_utils
+
 
 def test_constructor():
     # keyword arguments
@@ -194,11 +196,7 @@ def test_different_device():
     )
 
     devices = []
-    if (
-        hasattr(torch.backends, "mps")
-        and torch.backends.mps.is_built()
-        and torch.backends.mps.is_available()
-    ):
+    if _tests_utils.can_use_mps_backend():
         devices.append("mps")
 
     if torch.cuda.is_available():
@@ -271,11 +269,7 @@ def test_to():
         check_dtype(converted.gradient("g"), torch.float64)
 
     devices = ["meta", torch.device("meta")]
-    if (
-        hasattr(torch.backends, "mps")
-        and torch.backends.mps.is_built()
-        and torch.backends.mps.is_available()
-    ):
+    if _tests_utils.can_use_mps_backend():
         devices.append("mps")
         devices.append(torch.device("mps"))
 

--- a/python/metatensor-torch/tests/labels.py
+++ b/python/metatensor-torch/tests/labels.py
@@ -7,6 +7,8 @@ from torch import Tensor
 
 from metatensor.torch import Labels, LabelsEntry
 
+from . import _tests_utils
+
 
 def test_constructor():
     # keyword arguments + name is a tuple
@@ -293,11 +295,7 @@ def test_eq():
 
 def test_to():
     devices = ["meta", torch.device("meta")]
-    if (
-        hasattr(torch.backends, "mps")
-        and torch.backends.mps.is_built()
-        and torch.backends.mps.is_available()
-    ):
+    if _tests_utils.can_use_mps_backend():
         devices.append("mps")
         devices.append(torch.device("mps"))
 

--- a/python/metatensor-torch/tests/learn/_tests_utils.py
+++ b/python/metatensor-torch/tests/learn/_tests_utils.py
@@ -2,6 +2,9 @@ import torch
 
 from metatensor.torch import Labels, TensorBlock, TensorMap
 
+# re-export can_use_mps_backend
+from .._tests_utils import can_use_mps_backend  # noqa F401
+
 
 TORCH_KWARGS = {"device": "cpu", "dtype": torch.float32}
 

--- a/python/metatensor-torch/tests/learn/module_map.py
+++ b/python/metatensor-torch/tests/learn/module_map.py
@@ -6,12 +6,12 @@ import torch
 from metatensor.torch import Labels, allclose_raise
 from metatensor.torch.learn.nn import ModuleMap
 
-from ._tests_utils import random_single_block_no_components_tensor_map
+from . import _tests_utils
 
 
 @pytest.fixture
 def tensor():
-    return random_single_block_no_components_tensor_map()
+    return _tests_utils.random_single_block_no_components_tensor_map()
 
 
 try:
@@ -77,11 +77,7 @@ def test_module_map(tensor, out_properties):
 @pytest.mark.parametrize("torch_script", [True, False])
 def test_to_device(tensor, torch_script):
     devices = ["cpu"]
-    if (
-        hasattr(torch.backends, "mps")
-        and torch.backends.mps.is_built()
-        and torch.backends.mps.is_available()
-    ):
+    if _tests_utils.can_use_mps_backend():
         devices.append("mps")
 
     if torch.cuda.is_available():

--- a/python/metatensor-torch/tests/tensor.py
+++ b/python/metatensor-torch/tests/tensor.py
@@ -518,11 +518,7 @@ def test_to(tensor):
         check_dtype(converted, torch.float64)
 
     devices = ["meta", torch.device("meta")]
-    if (
-        hasattr(torch.backends, "mps")
-        and torch.backends.mps.is_built()
-        and torch.backends.mps.is_available()
-    ):
+    if _tests_utils.can_use_mps_backend():
         devices.append("mps")
         devices.append(torch.device("mps"))
 

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ description = Run the tests of the metatensor-core Python package
 deps =
     numpy <2.0
     {[testenv]testing_deps}
-    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.2.*}
+    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.3.*}
 
 changedir = python/metatensor-core
 commands =
@@ -99,7 +99,7 @@ deps =
     {[testenv]packaging_deps}
     {[testenv]testing_deps}
     numpy <2.0
-    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.2.*}
+    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.3.*}
 
 changedir = python/metatensor-operations
 commands =
@@ -136,7 +136,7 @@ description =
 deps =
     {[testenv]packaging_deps}
     {[testenv]testing_deps}
-    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.2.*}
+    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.3.*}
 
     ; used for checking equivariance
     scipy
@@ -162,7 +162,7 @@ deps =
     {[testenv]testing_deps}
 
     numpy <2.0
-    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.2.*}
+    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.3.*}
     ase
 
 changedir = python/metatensor-torch
@@ -191,7 +191,7 @@ deps =
     {[testenv]testing_deps}
 
     numpy <2.0
-    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.2.*}
+    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.3.*}
     ase
 
 setenv =


### PR DESCRIPTION
This is not doing much, just build wheels for torch v2.3 and using it for tests on CI

<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--590.org.readthedocs.build/en/590/

<!-- readthedocs-preview metatensor end -->