### PR TITLE
Record the compatible torch version in wheel METADATA

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -359,9 +359,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            wheels/metatensor-core-*.tar.gz
             wheels/cxx/metatensor-core-cxx-*.tar.gz
-            wheels/metatensor_core-*.whl
+            wheels/metatensor_core-*
           prerelease: ${{ contains(github.ref, '-rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -371,9 +370,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            wheels/metatensor-torch-*.tar.gz
             wheels/cxx/metatensor-torch-cxx-*.tar.gz
-            wheels/metatensor_torch-*.whl
+            wheels/metatensor_torch-*
           prerelease: ${{ contains(github.ref, '-rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -383,8 +381,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            wheels/metatensor-operations-*.tar.gz
-            wheels/metatensor_operations-*.whl
+            wheels/metatensor_operations-*
           prerelease: ${{ contains(github.ref, '-rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -394,26 +391,17 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            wheels/metatensor-learn-*.tar.gz
-            wheels/metatensor_learn-*.whl
+            wheels/metatensor_learn-*
           prerelease: ${{ contains(github.ref, '-rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: remove all sdist except metatensor
-        run: |
-          rm wheels/metatensor-core-*.tar.gz
-          rm wheels/metatensor-torch-*.tar.gz
-          rm wheels/metatensor-learn-*.tar.gz
-          rm wheels/metatensor-operations-*.tar.gz
 
       - name: upload to GitHub release (metatensor-python)
         if: startsWith(github.ref, 'refs/tags/metatensor-python-v')
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            wheels/metatensor-*.tar.gz
-            wheels/metatensor-*.whl
+            wheels/metatensor-*
           prerelease: ${{ contains(github.ref, '-rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -228,11 +228,14 @@ jobs:
             os: windows-2019
             arch: x86_64
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download wheels
         uses: actions/download-artifact@v4
         with:
           pattern: torch-single-version-wheel-*-${{ matrix.os }}-${{ matrix.arch }}
           merge-multiple: false
+          path: dist
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -244,14 +247,24 @@ jobs:
 
       - name: merge wheels
         run: |
-          # unpack all single torch versions wheels in the same directory,
-          # and repack the directory as a new wheel
+          # collect all torch versions used for the build
+          REQUIRES_TORCH=$(find dist -name "*.whl" -exec unzip -p {} "metatensor_torch-*.dist-info/METADATA" \; | grep "Requires-Dist: torch")
+          MERGED_TORCH_REQUIRE=$(python scripts/create-torch-versions-range.py "$REQUIRES_TORCH")
 
-          mkdir unpacked
-          find . -name "*.whl" -print -exec python -m wheel unpack --dest unpacked/ {} ';'
+          echo MERGED_TORCH_REQUIRE=$MERGED_TORCH_REQUIRE
 
+          # unpack all single torch versions wheels in the same directory
+          mkdir dist/unpacked
+          find dist -name "*.whl" -print -exec python -m wheel unpack --dest dist/unpacked/ {} ';'
+
+          sed -i "s/Requires-Dist: torch ==.*/$MERGED_TORCH_REQUIRE/" dist/unpacked/metatensor_torch-*/metatensor_torch-*.dist-info/METADATA
+
+          echo "\n\n METADATA = \n\n"
+          cat dist/unpacked/metatensor_torch-*/metatensor_torch-*.dist-info/METADATA
+
+          # repack the directory as a new wheel
           mkdir wheelhouse
-          python -m wheel pack --dest wheelhouse/ unpacked/*
+          python -m wheel pack --dest wheelhouse/ dist/unpacked/*
 
       - name: check wheels with twine
         run: twine check wheelhouse/*

--- a/python/metatensor-torch/setup.py
+++ b/python/metatensor-torch/setup.py
@@ -291,7 +291,18 @@ if __name__ == "__main__":
         with open(os.path.join(ROOT, authors[0])) as fd:
             authors = fd.read().splitlines()
 
-    install_requires = ["torch >= 1.12"]
+    try:
+        import torch
+
+        # if we have torch, we are building a wheel, which will only be compatible with
+        # a single torch version
+        torch_v_major, torch_v_minor, *_ = torch.__version__.split(".")
+        torch_version = f"== {torch_v_major}.{torch_v_minor}.*"
+    except ImportError:
+        # otherwise we are building a sdist
+        torch_version = ">= 1.12"
+
+    install_requires = [f"torch {torch_version}"]
 
     # when packaging a sdist for release, we should never use local dependencies
     METATENSOR_NO_LOCAL_DEPS = os.environ.get("METATENSOR_NO_LOCAL_DEPS", "0") == "1"

--- a/scripts/create-torch-versions-range.py
+++ b/scripts/create-torch-versions-range.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+This script updates the `Requires-Dist` information in metatensor-torch wheel METADATA
+to contain the range of compatible torch versions. It expects newline separated
+`Requires-Dist: torch ==...` information (corresponding to wheels built against a single
+torch version) and will print `Requires-Dist: torch >=$MIN_VERSION,<${MAX_VERSION+1}` on
+the standard output.
+
+This output can the be used in the merged wheel containing the build against all torch
+versions.
+"""
+import re
+import sys
+
+
+if __name__ == "__main__":
+    torch_versions_raw = sys.argv[1]
+
+    torch_versions = []
+    for version in torch_versions_raw.split("\n"):
+        if version.strip() == "":
+            continue
+
+        match = re.match(r"Requires-Dist: torch ==(\d+)\.(\d+)\.\*", version)
+        if match is None:
+            raise ValueError(f"unexpected Requires-Dist format: {version}")
+
+        major, minor = match.groups()
+        major = int(major)
+        minor = int(minor)
+
+        version = (major, minor)
+
+        if version in torch_versions:
+            raise ValueError(f"duplicate torch version: {version}")
+
+        torch_versions.append(version)
+
+    torch_versions = list(sorted(torch_versions))
+
+    min_version = f"{torch_versions[0][0]}.{torch_versions[0][1]}"
+    max_version = f"{torch_versions[-1][0]}.{torch_versions[-1][1] + 1}"
+
+    print(f"Requires-Dist: torch >={min_version},<{max_version}")


### PR DESCRIPTION
We now set `install_requires`/`Requires-Dist:` fields to the specific set of torch version a given metatensor-torch wheel is compatible with. This happen both when building a wheel locally (we set `torch == x.y.*`) and when merging wheels on CI (we merge the individual requirements above into `torch >=1.12,<2.4`)

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--592.org.readthedocs.build/en/592/

<!-- readthedocs-preview metatensor end -->