### PR TITLE
Move data to the right device in ModuleMap::forward

### DIFF
--- a/python/metatensor-learn/CHANGELOG.md
+++ b/python/metatensor-learn/CHANGELOG.md
@@ -23,6 +23,9 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `LayerNorm`, `InvariantLayerNorm`, `EquivariantLinear`, `Sequential`, `Tanh`,
   and `InvariantTanh` (#513)
 
+### Fixed
+- Set correct device for output of when torch default device is different than input device (#595)
+
 ## [Version 0.2.1](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-learn-v0.2.1) - 2024-03-01
 
 ### Changed

--- a/python/metatensor-learn/metatensor/learn/nn/module_map.py
+++ b/python/metatensor-learn/metatensor/learn/nn/module_map.py
@@ -256,6 +256,12 @@ class ModuleMap(ModuleList):
         :param tensor:
             input tensor map
         """
+        self._in_keys = self._in_keys.to(tensor.device)
+        if self._out_properties is not None:
+            self._out_properties = [
+                label.to(tensor.device) for label in self._out_properties
+            ]
+
         out_blocks: List[TensorBlock] = []
         for key, block in tensor.items():
             out_block = self.forward_block(key, block)

--- a/python/metatensor-torch/tests/learn/module_map.py
+++ b/python/metatensor-torch/tests/learn/module_map.py
@@ -2,7 +2,6 @@ import io
 
 import pytest
 import torch
-from torch.nn import Module, Sigmoid
 
 from metatensor.torch import Labels, allclose_raise
 from metatensor.torch.learn.nn import ModuleMap
@@ -11,50 +10,47 @@ from ._tests_utils import random_single_block_no_components_tensor_map
 
 
 @pytest.fixture
-def single_block_tensor():
+def tensor():
     return random_single_block_no_components_tensor_map()
 
 
-class MockModule(Module):
+try:
+    if torch.cuda.is_available():
+        HAS_CUDA = True
+    else:
+        HAS_CUDA = False
+except ImportError:
+    HAS_CUDA = False
+
+
+class MockModule(torch.nn.Module):
     def __init__(self, in_features, out_features):
         super().__init__()
         self._linear = torch.nn.Linear(in_features, out_features)
-        self._activation = Sigmoid()
+        self._activation = torch.nn.Sigmoid()
         self._last_layer = torch.nn.Linear(out_features, 1)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         return self._last_layer(self._activation(self._linear(input)))
 
 
-@pytest.fixture(scope="module", autouse=True)
-def set_random_generator():
-    """Set the random generator to same seed before each test is run.
-    Otherwise test behaviour is dependent on the order of the tests
-    in this file and the number of parameters of the test.
-    """
-    torch.random.manual_seed(122578741812)
-
-
 @pytest.mark.parametrize(
     "out_properties", [None, [Labels(["a", "b"], torch.tensor([[1, 1]]))]]
 )
-def test_module_map_single_block_tensor(single_block_tensor, out_properties):
+def test_module_map(tensor, out_properties):
     modules = []
-    for key in single_block_tensor.keys:
+    for key in tensor.keys:
         modules.append(
             MockModule(
-                in_features=len(single_block_tensor.block(key).properties),
+                in_features=len(tensor.block(key).properties),
                 out_features=5,
             )
         )
 
-    tensor_module = ModuleMap(
-        single_block_tensor.keys, modules, out_properties=out_properties
-    )
-    with torch.no_grad():
-        out_tensor = tensor_module(single_block_tensor)
+    tensor_module = ModuleMap(tensor.keys, modules, out_properties=out_properties)
+    output = tensor_module(tensor)
 
-    for i, item in enumerate(single_block_tensor.items()):
+    for i, item in enumerate(tensor.items()):
         key, block = item
         module = modules[i]
         assert (
@@ -63,7 +59,7 @@ def test_module_map_single_block_tensor(single_block_tensor, out_properties):
 
         with torch.no_grad():
             ref_values = module(block.values)
-        out_block = out_tensor.block(key)
+        out_block = output.block(key)
         assert torch.allclose(ref_values, out_block.values)
         if out_properties is None:
             assert out_block.properties == Labels.range("_", len(out_block.properties))
@@ -76,38 +72,88 @@ def test_module_map_single_block_tensor(single_block_tensor, out_properties):
             assert torch.allclose(
                 ref_gradient_values, out_block.gradient(parameter).values
             )
-            if out_properties is None:
-                assert out_block.gradient(parameter).properties == Labels.range(
-                    "_", len(out_block.gradient(parameter).properties)
+
+
+@pytest.mark.parametrize("torch_script", [True, False])
+def test_to_device(tensor, torch_script):
+    devices = ["cpu"]
+    if (
+        hasattr(torch.backends, "mps")
+        and torch.backends.mps.is_built()
+        and torch.backends.mps.is_available()
+    ):
+        devices.append("mps")
+
+    if torch.cuda.is_available():
+        devices.append("cuda")
+
+    for device in devices:
+        modules = []
+        for key in tensor.keys:
+            modules.append(
+                MockModule(
+                    in_features=len(tensor.block(key).properties),
+                    out_features=5,
                 )
-            else:
-                assert out_block.gradient(parameter).properties == out_properties[0]
+            )
+        module = ModuleMap(
+            tensor.keys,
+            modules,
+            out_properties=[Labels(["a", "b"], torch.tensor([[1, 1]]))],
+        )
+
+        if torch_script:
+            module = torch.jit.script(module)
+
+        assert module._in_keys.device.type == "cpu"
+        for label in module._out_properties:
+            assert label.device.type == "cpu"
+
+        module.to(device=device)
+
+        # at this point, the parameters should have been moved,
+        # but the input keys and output properties should still be on cpu
+        assert len(list(module.parameters())) > 0
+        for parameter in module.parameters():
+            assert parameter.device.type == device
+
+        assert module._in_keys.device.type == "cpu"
+        for label in module._out_properties:
+            assert label.device.type == "cpu"
+
+        device_tensor = tensor.to(device=device)
+        output = module(device_tensor)
+        assert output.device.type == device
+
+        # the input keys and output properties should now be on device
+        assert module._in_keys.device.type == device
+        for label in module._out_properties:
+            assert label.device.type == device
 
 
-def test_torchscript_module_map(single_block_tensor):
+def test_torchscript(tensor):
     modules = []
-    for key in single_block_tensor.keys:
+    for key in tensor.keys:
         modules.append(
             MockModule(
-                in_features=len(single_block_tensor.block(key).properties),
+                in_features=len(tensor.block(key).properties),
                 out_features=5,
             )
         )
-    tensor_module = ModuleMap(single_block_tensor.keys, modules)
-    ref_tensor = tensor_module(single_block_tensor)
+    tensor_module = ModuleMap(tensor.keys, modules)
+    ref_tensor = tensor_module(tensor)
 
     tensor_module_script = torch.jit.script(tensor_module)
-    out_tensor = tensor_module_script(single_block_tensor)
+    out_tensor = tensor_module_script(tensor)
 
     allclose_raise(ref_tensor, out_tensor)
 
     # tests if member functions work that do not appear in forward
-    tensor_module_script.get_module(single_block_tensor.keys[0])
+    tensor_module_script.get_module(tensor.keys[0])
 
     # test save load
     scripted = torch.jit.script(tensor_module_script)
-    buffer = io.BytesIO()
-    torch.jit.save(scripted, buffer)
-    buffer.seek(0)
-    torch.jit.load(buffer)
-    buffer.close()
+    with io.BytesIO() as buffer:
+        torch.jit.save(scripted, buffer)
+        buffer.seek(0)
+        torch.jit.load(buffer)


### PR DESCRIPTION
Fix #554

This moves metatensor data to a new device when running forward(), ensuring `ModuleMap` can be used on non-cpu devices.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--595.org.readthedocs.build/en/595/

<!-- readthedocs-preview metatensor end -->