### PR TITLE
Also exclude torch patch version from find_package

### DIFF
--- a/metatensor-torch/cmake/metatensor_torch-config.in.cmake
+++ b/metatensor-torch/cmake/metatensor_torch-config.in.cmake
@@ -10,7 +10,7 @@ set(BUILD_TORCH_VERSION @Torch_VERSION@)
 set(BUILD_TORCH_MAJOR @Torch_VERSION_MAJOR@)
 set(BUILD_TORCH_MINOR @Torch_VERSION_MINOR@)
 
-find_package(Torch ${BUILD_TORCH_VERSION} REQUIRED)
+find_package(Torch "${BUILD_TORCH_MAJOR}.${BUILD_TORCH_MINOR}" REQUIRED)
 
 if (NOT "${BUILD_TORCH_MAJOR}" STREQUAL "${Torch_VERSION_MAJOR}")
     message(FATAL_ERROR "found incompatible torch version: metatensor-torch was built against v${BUILD_TORCH_VERSION} but we found v${Torch_VERSION}")


### PR DESCRIPTION
This is a follow up to #527, allowing to build metatensor-torch against torch x.y.z and then use it with x.y.0 (which would otherwise be disabled by `find_package(Torch)`

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--596.org.readthedocs.build/en/596/

<!-- readthedocs-preview metatensor end -->