### PR TITLE
Re-enable grouping for GitHub action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: daily # Temporarily set to daily to test
     open-pull-requests-limit: 1
-    # groups:
-    #   action-dependencies:
-    #     patterns:
-    #       - "*" # A wildcard to create one PR for all dependencies in the ecosystem
+    groups:
+      action-dependencies:
+        patterns:
+          - "*" # A wildcard to create one PR for all dependencies in the ecosystem

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: deploy to gh-pages
         if: github.event_name == 'push'
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./gh-pages/


### PR DESCRIPTION
This should tell the bot to open one PR for ALL GitHub action dependencies and not one per package as in #601.

Let's see if this is working. To test I revert the change of #601. 🤞

<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--602.org.readthedocs.build/en/602/

<!-- readthedocs-preview metatensor end -->