### PR TITLE
Force the inclusion of bcrypt in Cargo default link libraries

### DIFF
--- a/metatensor-core/CMakeLists.txt
+++ b/metatensor-core/CMakeLists.txt
@@ -230,6 +230,11 @@ if (CARGO_VERSION_CHANGED)
             list(REMOVE_ITEM stripped_lib_list "System")
         endif()
 
+        if (MSVC)
+            # https://github.com/rust-lang/rust/issues/91974#issuecomment-2090604896
+            list(APPEND stripped_lib_list "bcrypt")
+        endif()
+
         list(REMOVE_DUPLICATES stripped_lib_list)
         set(CARGO_DEFAULT_LIBRARIES "${stripped_lib_list}" CACHE INTERNAL "list of implicitly linked libraries")
 


### PR DESCRIPTION
This should fix the build on MSVC with rustc 1.78. I'm hotfixing this for now, the issue is also reported on the rust repository to see if there is a better way.


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--605.org.readthedocs.build/en/605/

<!-- readthedocs-preview metatensor end -->