### PR TITLE
Deploy documentation on a separate repository

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,9 +46,9 @@ jobs:
 
       - name: put documentation in the website
         run: |
-          git clone https://github.com/$GITHUB_REPOSITORY --branch gh-pages gh-pages
-          rm -rf gh-pages/.git
-          cd gh-pages
+          git clone https://github.com/lab-cosmo/metatensor-docs metatensor-docs
+          rm -rf metatensor-docs/.git
+          cd metatensor-docs
 
           REF_KIND=$(echo $GITHUB_REF | cut -d / -f2)
           if [[ "$REF_KIND" == "tags" ]]; then
@@ -59,10 +59,12 @@ jobs:
               mv ../docs/build/html latest
           fi
 
-      - name: deploy to gh-pages
+      - name: deploy to metatensor-docs
         if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./gh-pages/
+          external_repository: lab-cosmo/metatensor-docs
+          deploy_key: ${{ secrets.METATENSOR_DOCS_SSH_KEY }}
+          publish_branch: main
+          publish_dir: ./metatensor-docs/
           force_orphan: true

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Metatensor
 
 [![tests status](https://img.shields.io/github/checks-status/lab-cosmo/metatensor/master)](https://github.com/lab-cosmo/metatensor/actions?query=branch%3Amaster)
-[![documentation](https://img.shields.io/badge/documentation-latest-sucess)](https://lab-cosmo.github.io/metatensor/latest/)
-[![coverage](https://codecov.io/gh/lab-cosmo/metatensor/branch/master/graph/badge.svg)]( https://codecov.io/gh/lab-cosmo/metatensor)
+[![documentation](https://img.shields.io/badge/documentation-latest-sucess)](https://docs.metatensor.org/latest/)
+[![coverage](https://codecov.io/gh/lab-cosmo/metatensor/branch/master/graph/badge.svg)](https://codecov.io/gh/lab-cosmo/metatensor)
 
 Metatensor is a self-describing sparse tensor data format for atomistic machine
 learning and beyond; storing values and gradients of these values together.
@@ -17,7 +17,7 @@ operations to make working with TensorMaps more convenient.
 
 ## Documentation
 
-For details, tutorials, and examples, please have a look at our [documentation](https://lab-cosmo.github.io/metatensor/latest/).
+For details, tutorials, and examples, please have a look at our [documentation](https://docs.metatensor.org/).
 
 ## Contributors
 

--- a/docs/extensions/versions_list.py
+++ b/docs/extensions/versions_list.py
@@ -1,7 +1,7 @@
 from sphinx_design.grids import GridItemCardDirective
 
 
-DOC_ROOT = "https://doc.metatensor.org/"
+DOC_ROOT = "https://docs.metatensor.org/"
 
 
 class GridItemVersion(GridItemCardDirective):

--- a/docs/extensions/versions_list.py
+++ b/docs/extensions/versions_list.py
@@ -1,7 +1,7 @@
 from sphinx_design.grids import GridItemCardDirective
 
 
-DOC_ROOT = "https://lab-cosmo.github.io/metatensor"
+DOC_ROOT = "https://doc.metatensor.org/"
 
 
 class GridItemVersion(GridItemCardDirective):

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -223,4 +223,10 @@ html_title = "Metatensor"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["../static"]
 
-html_js_files = [os.path.join("js", "custom.js")]
+html_js_files = [
+    os.path.join("js", "custom.js"),
+    (
+        "https://plausible.io/js/script.js",
+        {"data-domain": "docs.metatensor.org", "defer": "defer"},
+    ),
+]

--- a/metatensor-torch/README.md
+++ b/metatensor-torch/README.md
@@ -6,8 +6,8 @@ a custom language defined inside of the C++ version of [PyTorch](PyTorch.org/)
 ## Installation
 
 See the overall documentation for the [installation
-instructions](https://lab-cosmo.github.io/metatensor/latest/get-started/installation.html#installing-the-torchscript-bindings).
+instructions](https://docs.metatensor.org/latest/get-started/installation.html#installing-the-torchscript-bindings).
 
 ## Documentation
 
-The API documentation is available [online](https://lab-cosmo.github.io/metatensor/latest/reference/torch/cxx/index.html).
+The API documentation is available [online](https://docs.metatensor.org/latest/reference/torch/cxx/index.html).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,10 @@ classifiers = [
 ]
 
 [project.urls]
-homepage = "https://lab-cosmo.github.io/metatensor/latest/"
-documentation = "https://lab-cosmo.github.io/metatensor/latest/"
+homepage = "https://docs.metatensor.org/"
+documentation = "https://docs.metatensor.org/"
 repository = "https://github.com/lab-cosmo/metatensor"
-changelog = "https://lab-cosmo.github.io/metatensor/latest/core/CHANGELOG.html"
+changelog = "https://docs.metatensor.org/latest/core/CHANGELOG.html"
 
 ### ======================================================================== ###
 

--- a/python/metatensor-core/pyproject.toml
+++ b/python/metatensor-core/pyproject.toml
@@ -28,10 +28,10 @@ classifiers = [
 ]
 
 [project.urls]
-homepage = "https://lab-cosmo.github.io/metatensor/latest/"
-documentation = "https://lab-cosmo.github.io/metatensor/latest/"
+homepage = "https://docs.metatensor.org/latest/"
+documentation = "https://docs.metatensor.org/latest/"
 repository = "https://github.com/lab-cosmo/metatensor"
-changelog = "https://lab-cosmo.github.io/metatensor/latest/core/CHANGELOG.html"
+changelog = "https://docs.metatensor.org/latest/core/CHANGELOG.html"
 
 ### ======================================================================== ###
 [build-system]

--- a/python/metatensor-learn/pyproject.toml
+++ b/python/metatensor-learn/pyproject.toml
@@ -26,10 +26,10 @@ classifiers = [
 ]
 
 [project.urls]
-homepage = "https://lab-cosmo.github.io/metatensor/latest/"
-documentation = "https://lab-cosmo.github.io/metatensor/latest/"
+homepage = "https://docs.metatensor.org/latest/"
+documentation = "https://docs.metatensor.org/latest/"
 repository = "https://github.com/lab-cosmo/metatensor"
-changelog = "https://lab-cosmo.github.io/metatensor/latest/learn/CHANGELOG.html"
+changelog = "https://docs.metatensor.org/latest/learn/CHANGELOG.html"
 
 ### ======================================================================== ###
 [build-system]

--- a/python/metatensor-operations/pyproject.toml
+++ b/python/metatensor-operations/pyproject.toml
@@ -26,10 +26,10 @@ classifiers = [
 ]
 
 [project.urls]
-homepage = "https://lab-cosmo.github.io/metatensor/latest/"
-documentation = "https://lab-cosmo.github.io/metatensor/latest/"
+homepage = "https://docs.metatensor.org/latest/"
+documentation = "https://docs.metatensor.org/latest/"
 repository = "https://github.com/lab-cosmo/metatensor"
-changelog = "https://lab-cosmo.github.io/metatensor/latest/operations/CHANGELOG.html"
+changelog = "https://docs.metatensor.org/latest/operations/CHANGELOG.html"
 
 ### ======================================================================== ###
 [build-system]

--- a/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
@@ -18,7 +18,7 @@ def _check_outputs(
     atomistic models.
 
     This function checks conformance with the reference documentation in
-    https://lab-cosmo.github.io/metatensor/latest/atomistic/outputs.html
+    https://docs.metatensor.org/latest/atomistic/outputs.html
     """
 
     for name, output in outputs.items():

--- a/python/metatensor-torch/pyproject.toml
+++ b/python/metatensor-torch/pyproject.toml
@@ -26,10 +26,10 @@ classifiers = [
 ]
 
 [project.urls]
-homepage = "https://lab-cosmo.github.io/metatensor/latest/"
-documentation = "https://lab-cosmo.github.io/metatensor/latest/"
+homepage = "https://docs.metatensor.org/latest/"
+documentation = "https://docs.metatensor.org/latest/"
 repository = "https://github.com/lab-cosmo/metatensor"
-changelog = "https://lab-cosmo.github.io/metatensor/latest/torch/CHANGELOG.html"
+changelog = "https://docs.metatensor.org/latest/torch/CHANGELOG.html"
 
 ### ======================================================================== ###
 [build-system]

--- a/rust/metatensor-sys/Cargo.toml
+++ b/rust/metatensor-sys/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 description = "Bindings to the metatensor C library"
 readme = "README.md"
-homepage = "https://lab-cosmo.github.io/metatensor/latest/"
+homepage = "https://docs.metatensor.org/latest/"
 repository = "https://github.com/lab-cosmo/metatensor"
 license = "BSD-3-Clause"
 

--- a/rust/metatensor/Cargo.toml
+++ b/rust/metatensor/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.65"
 
 description = "Self-describing sparse tensor data format for atomistic machine learning and beyond"
 readme = "../../README.md"
-homepage = "https://lab-cosmo.github.io/metatensor/latest/"
+homepage = "https://docs.metatensor.org/latest/"
 repository = "https://github.com/lab-cosmo/metatensor"
 license = "BSD-3-Clause"
 


### PR DESCRIPTION
This will help keeping the size of this repository under control. The documentation will be deployed to https://github.com/lab-cosmo/metatensor-docs, which is then served at https://docs.metatensor.org/

This does not change how developers write the documentation or build it locally, only how we create the public documentation website.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--609.org.readthedocs.build/en/609/

<!-- readthedocs-preview metatensor end -->