### PR TITLE
Use a custom scraper in sphinx-gallery for animations

### DIFF
--- a/docs/generate_examples/conf.py
+++ b/docs/generate_examples/conf.py
@@ -2,6 +2,8 @@
 
 import os
 
+from matplotlib.animation import Animation, FFMpegWriter, ImageMagickWriter
+from sphinx_gallery.scrapers import figure_rst, matplotlib_scraper
 from sphinx_gallery.sorting import FileNameSortKey
 
 
@@ -11,6 +13,56 @@ extensions = [
 
 HERE = os.path.dirname(__file__)
 ROOT = os.path.realpath(os.path.join(HERE, "..", ".."))
+
+
+class AnimationScrapper:
+    """
+    Alternative image scrapper for sphinx-gallery, rendering the animation to GIF
+    instead of a base64-encoded HTML video.
+
+    This decreases the size of the documentation and the time taken to render the
+    documentation (sphinx-gallery with ``matplotlib_animations=True``) renders the GIF
+    and then re-render to create the HTML video.
+    """
+
+    def __init__(self):
+        # only process animations once by storing their `id()` here
+        self.seen = set()
+
+    def __call__(self, block, block_vars, gallery_conf):
+        animations = []
+        for variable in block_vars["example_globals"].values():
+            if isinstance(variable, Animation) and id(variable) not in self.seen:
+                self.seen.add(id(variable))
+                animations.append(variable)
+
+        if len(animations) == 0:
+            # just do the default scrapping
+            return matplotlib_scraper(block, block_vars, gallery_conf)
+        else:
+            # process matplotlib static preview of the animation, and ignore it
+            matplotlib_scraper(block, block_vars, gallery_conf)
+
+            image_names = []
+            for anim, image_path in zip(animations, block_vars["image_path_iterator"]):
+                image_path = str(image_path)[:-4] + ".gif"
+                image_names.append(image_path)
+
+                # this is strongly inspired by the code in sphinx-gallery
+                fig_size = anim._fig.get_size_inches()
+                thumb_size = gallery_conf["thumbnail_size"]
+                use_dpi = round(
+                    min(t_s / f_s for t_s, f_s in zip(thumb_size, fig_size))
+                )
+                if FFMpegWriter.isAvailable():
+                    writer = "ffmpeg"
+                elif ImageMagickWriter.isAvailable():
+                    writer = "imagemagick"
+                else:
+                    writer = None
+                anim.save(str(image_path), writer=writer, dpi=use_dpi)
+
+            return figure_rst(image_names, gallery_conf["src_dir"])
 
 
 sphinx_gallery_conf = {
@@ -26,7 +78,8 @@ sphinx_gallery_conf = {
         os.path.join(ROOT, "docs", "src", "examples", "learn"),
         os.path.join(ROOT, "docs", "src", "examples", "atomistic"),
     ],
-    "matplotlib_animations": True,
+    "matplotlib_animations": False,
+    "image_scrapers": (AnimationScrapper()),
     "remove_config_comments": True,
     "within_subsection_order": FileNameSortKey,
     "default_thumb_file": os.path.join(


### PR DESCRIPTION
This reduces the size of the docs by 10 MiB (there where two 5MiB copies of the base64-encoded HTML video), and the rendering time went from 20s to 10s for the ase-md example.


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--610.org.readthedocs.build/en/610/

<!-- readthedocs-preview metatensor end -->