### PR TITLE
Remove dependency on getrandom

### DIFF
--- a/metatensor-core/CMakeLists.txt
+++ b/metatensor-core/CMakeLists.txt
@@ -230,11 +230,6 @@ if (CARGO_VERSION_CHANGED)
             list(REMOVE_ITEM stripped_lib_list "System")
         endif()
 
-        if (MSVC)
-            # https://github.com/rust-lang/rust/issues/91974#issuecomment-2090604896
-            list(APPEND stripped_lib_list "bcrypt")
-        endif()
-
         list(REMOVE_DUPLICATES stripped_lib_list)
         set(CARGO_DEFAULT_LIBRARIES "${stripped_lib_list}" CACHE INTERNAL "list of implicitly linked libraries")
 

--- a/metatensor-core/Cargo.toml
+++ b/metatensor-core/Cargo.toml
@@ -14,7 +14,8 @@ name = "metatensor"
 bench = false
 
 [dependencies]
-ahash = "=0.8.7"  # last version supporting rustc 1.65
+# ahash 0.8.7 is the last version supporting rustc 1.65
+ahash = { version = "=0.8.7", default-features = false, features = ["std"]}
 hashbrown = "0.14"
 indexmap = "2"
 once_cell = "1"


### PR DESCRIPTION
It needs to link to BCrypt on Windows which is non trivial with our build system, and we don't actually need it.

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] I~ssue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatensor start -->
----
📚 Documentation preview 📚: https://metatensor--612.org.readthedocs.build/en/612/

<!-- readthedocs-preview metatensor end -->