### PR TITLE
Set CMAKE_INSTALL_LIBDIR in `setup.py` to match assumptions in `_c_lib.py`

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -19,6 +19,7 @@ concurrency:
 env:
   METATENSOR_NO_LOCAL_DEPS: "1"
 
+
 jobs:
   build-core-wheels:
     runs-on: ${{ matrix.os }}

--- a/python/metatensor-core/setup.py
+++ b/python/metatensor-core/setup.py
@@ -50,6 +50,7 @@ class cmake_ext(build_ext):
 
         cmake_options = [
             f"-DCMAKE_INSTALL_PREFIX={install_dir}",
+            "-DCMAKE_INSTALL_LIBDIR=lib",
             f"-DCMAKE_BUILD_TYPE={METATENSOR_BUILD_TYPE}",
             "-DBUILD_SHARED_LIBS=ON",
             "-DMETATENSOR_INSTALL_BOTH_STATIC_SHARED=OFF",

--- a/python/metatensor-torch/setup.py
+++ b/python/metatensor-torch/setup.py
@@ -62,6 +62,7 @@ class cmake_ext(build_ext):
         cmake_options = [
             "-DCMAKE_BUILD_TYPE=Release",
             f"-DCMAKE_INSTALL_PREFIX={cmake_install_prefix}",
+            "-DCMAKE_INSTALL_LIBDIR=lib",
             f"-DCMAKE_PREFIX_PATH={';'.join(cmake_prefix_path)}",
         ]
 


### PR DESCRIPTION
This fixes building wheels which depend on each other. Previously on some systems `CMAKE_INSTALL_LIBDIR` would be set to `lib64` instead of `lib`, and cmake could not find the configuration files in the expected `<site-packages>/metatensor/lib`.


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1497114260.zip)

<!-- download-section Documentation end -->

<!-- download-section Build Python wheels start -->
⚙️ [Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1497186724.zip)

<!-- download-section Build Python wheels end -->