### PR TITLE
Also set CMAKE_INSTALL_LIBDIR in metatensor-sys

### DIFF
--- a/metatensor-core/CHANGELOG.md
+++ b/metatensor-core/CHANGELOG.md
@@ -29,6 +29,12 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 - the Julia bindings to metatensor-core in the Metatensor.jl package
 
+## [Version 0.1.8](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-core-v0.1.8) - 2024-05-13
+
+### Fixed
+
+- fix the build when using metatensor from the Rust bindings
+
 ## [Version 0.1.7](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-core-v0.1.7) - 2024-05-13
 
 ### metatensor-core C/C++

--- a/metatensor-core/Cargo.toml
+++ b/metatensor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metatensor-core"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 publish = false
 rust-version = "1.65"

--- a/rust/metatensor-sys/Cargo.toml
+++ b/rust/metatensor-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metatensor-sys"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 
 description = "Bindings to the metatensor C library"

--- a/rust/metatensor-sys/build.rs
+++ b/rust/metatensor-sys/build.rs
@@ -47,6 +47,7 @@ fn main() {
         .define("CARGO_EXE", env!("CARGO"))
         .define("RUST_BUILD_TARGET", std::env::var("TARGET").unwrap())
         .define("BUILD_SHARED_LIBS", if cfg!(feature="static") { "OFF" } else { "ON" })
+        .define("CMAKE_INSTALL_LIBDIR", "lib")
         .define("METATENSOR_INSTALL_BOTH_STATIC_SHARED", "OFF")
         .build();
 


### PR DESCRIPTION
Same as #617 but when building the code to be used from Rust (i.e. rascaline)


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1497635853.zip)

<!-- download-section Documentation end -->