### PR TITLE
Build wheels on CI whenever the build system code changes

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -5,8 +5,16 @@ on:
     tags: ["*"]
   pull_request:
     paths:
-      # run the build if this file was changed
+      # build wheels in PR if this file changed
       - '.github/workflows/build-wheels.yml'
+      # build wheels in PR if any of the build system files changed
+      - '**/VERSION'
+      - '**/setup.py'
+      - '**/pyproject.toml'
+      - '**/MANIFEST.in'
+      - '**/Cargo.toml'
+      - '**/CMakeLists.txt'
+      - '**/build.rs'
   schedule:
     # check the build once a week on mondays
     - cron: '0 10 * * 1'


### PR DESCRIPTION
This should allow to catch things like #617 earlier.


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1501781632.zip)

<!-- download-section Documentation end -->

<!-- download-section Build Python wheels start -->
⚙️ [Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1501861125.zip)

<!-- download-section Build Python wheels end -->