### PR TITLE
Allow to access `wrapped_module` of exported models

### DIFF
--- a/python/metatensor-torch/metatensor/torch/atomistic/model.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/model.py
@@ -233,6 +233,14 @@ class MetatensorAtomisticModel(torch.nn.Module):
     >>> with tempfile.TemporaryDirectory() as directory:
     ...     wrapped.save(os.path.join(directory, "constant-energy-model.pt"))
     ...
+
+    .. py:attribute:: module
+        :type: ModelInterface
+
+    The torch module wrapped by this :py:class:`MetatensorAtomisticModel`.
+
+    Reading from this attribute is safe, but modifying it is not recommended,
+    unless you are familiar with the implementation of the model.
     """
 
     # Some annotation to make the TorchScript compiler happy
@@ -260,15 +268,15 @@ class MetatensorAtomisticModel(torch.nn.Module):
             raise ValueError("module should not be in training mode")
 
         _check_annotation(module)
-        self._module = module
+        self.module = module
 
         # ============================================================================ #
 
         # recursively explore `module` to get all the requested_neighbor_lists
         self._requested_neighbor_lists = []
         _get_requested_neighbor_lists(
-            self._module,
-            self._module.__class__.__name__,
+            self.module,
+            self.module.__class__.__name__,
             self._requested_neighbor_lists,
             capabilities.length_unit,
         )
@@ -308,10 +316,6 @@ class MetatensorAtomisticModel(torch.nn.Module):
             self._model_dtype = torch.float64
         else:
             raise ValueError(f"unknown dtype in capabilities: {capabilities.dtype}")
-
-    def wrapped_module(self) -> torch.nn.Module:
-        """Get the module wrapped in this :py:class:`MetatensorAtomisticModel`"""
-        return self._module
 
     @torch.jit.export
     def capabilities(self) -> ModelCapabilities:
@@ -384,7 +388,7 @@ class MetatensorAtomisticModel(torch.nn.Module):
 
         # run the actual calculations
         with record_function("Model::forward"):
-            outputs = self._module(
+            outputs = self.module(
                 systems=systems,
                 outputs=options.outputs,
                 selected_atoms=options.selected_atoms,

--- a/python/metatensor-torch/metatensor/torch/atomistic/model.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/model.py
@@ -4,7 +4,8 @@ import math
 import os
 import platform
 import warnings
-from typing import Dict, List, Optional
+from pathlib import Path
+from typing import Dict, List, Optional, Union
 
 import torch
 from torch.profiler import record_function
@@ -39,7 +40,8 @@ def load_atomistic_model(path, extensions_directory=None) -> "MetatensorAtomisti
     :param extensions_directory: path to a directory containing all extensions required
         by the exported model
     """
-    load_model_extensions(path, extensions_directory)
+    path = str(path)
+    load_model_extensions(path, str(extensions_directory))
     check_atomistic_model(path)
     return torch.jit.load(path)
 
@@ -451,7 +453,7 @@ class MetatensorAtomisticModel(torch.nn.Module):
         )
         return self.save(file, collect_extensions)
 
-    def save(self, file: str, collect_extensions: Optional[str] = None):
+    def save(self, file: Union[str, Path], collect_extensions: Optional[str] = None):
         """Save this model to a file that can then be loaded by simulation engine.
 
         :param file: where to save the model. This can be a path or a file-like object.
@@ -488,7 +490,7 @@ class MetatensorAtomisticModel(torch.nn.Module):
 
         torch.jit.save(
             module.to("cpu"),  # this allows to torch.jit.load without devices
-            file,
+            str(file),
             _extra_files={
                 "torch-version": torch.__version__,
                 "metatensor-version": metatensor_version,

--- a/python/metatensor-torch/tests/atomistic/ase_calculator.py
+++ b/python/metatensor-torch/tests/atomistic/ase_calculator.py
@@ -237,7 +237,7 @@ def test_dtype_device(tmpdir, model, atoms):
 
         # re-create the model with a different dtype
         dtype_model = MetatensorAtomisticModel(
-            model._module.to(STR_TO_DTYPE[dtype]),
+            model.module.to(STR_TO_DTYPE[dtype]),
             model.metadata(),
             capabilities,
         )

--- a/python/metatensor-torch/tests/atomistic/model.py
+++ b/python/metatensor-torch/tests/atomistic/model.py
@@ -257,8 +257,8 @@ def test_access_module(tmpdir):
     # Access wrapped module
     assert atomistic.module is model
 
-    atomistic.save(str(tmpdir / "export.pt"))
-    loaded_atomistic = load_atomistic_model(str(tmpdir / "export.pt"))
+    atomistic.save(tmpdir / "export.pt")
+    loaded_atomistic = load_atomistic_model(tmpdir / "export.pt")
 
     # Access wrapped module after loading
     loaded_atomistic.module


### PR DESCRIPTION
This feature would be very useful to access information about the underlying model



# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1760815821.zip)

<!-- download-section Documentation end -->