### PR TITLE
Require cmake to build metatensor-torch wheels

### DIFF
--- a/python/metatensor-torch/build-backend/backend.py
+++ b/python/metatensor-torch/build-backend/backend.py
@@ -55,4 +55,4 @@ build_sdist = build_meta.build_sdist
 # Special dependencies to build the wheels
 def get_requires_for_build_wheel(config_settings=None):
     defaults = build_meta.get_requires_for_build_wheel(config_settings)
-    return defaults + ["cmake", TORCH_DEP, METATENSOR_CORE_DEP]
+    return defaults + [TORCH_DEP, METATENSOR_CORE_DEP]

--- a/python/metatensor-torch/pyproject.toml
+++ b/python/metatensor-torch/pyproject.toml
@@ -37,6 +37,7 @@ requires = [
     "setuptools >=68",
     "packaging >=23",
     "wheel >=0.41",
+    "cmake",
 ]
 
 # use a custom build backend to :

--- a/python/metatensor-torch/setup.py
+++ b/python/metatensor-torch/setup.py
@@ -261,15 +261,14 @@ def create_version_number(version):
 
 if __name__ == "__main__":
     if not os.path.exists(METATENSOR_TORCH):
-        # we are building from a sdist, which should include metatensor-core Rust
+        # we are building from a sdist, which should include metatensor-torch C++
         # sources as a tarball
-        tarballs = glob.glob(os.path.join(ROOT, "metatensor-torch-*.tar.gz"))
+        tarballs = glob.glob(os.path.join(ROOT, "metatensor-torch-cxx-*.tar.gz"))
 
         if not len(tarballs) == 1:
             raise RuntimeError(
-                "expected a single 'metatensor-torch-*.tar.gz' file containing "
-                "metatensor-torch C++ sources. remove all files and re-run "
-                "scripts/package-torch.sh"
+                "expected a single 'metatensor-torch-cxx-*.tar.gz' file containing "
+                "metatensor-torch C++ sources"
             )
 
         METATENSOR_TORCH = os.path.realpath(tarballs[0])


### PR DESCRIPTION
We need it early to be able to unpack the C++ sources tarball. 

Related to #626 

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1526907502.zip)

<!-- download-section Documentation end -->

<!-- download-section Build Python wheels start -->
⚙️ [Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1527154695.zip)

<!-- download-section Build Python wheels end -->