### PR TITLE
Make `LayerNorm` sample independent

### DIFF
--- a/python/metatensor-learn/CHANGELOG.md
+++ b/python/metatensor-learn/CHANGELOG.md
@@ -29,6 +29,8 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `metatensor.learn.nn` modules `LayerNorm` and `InvariantLayerNorm` now applies
+  sample-independent transformations to input tensors.
 - Set correct device for output of when torch default device is different than input device (#595)
 
 ## [Version 0.2.1](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-learn-v0.2.1) - 2024-03-01

--- a/python/metatensor-learn/metatensor/learn/nn/layer_norm.py
+++ b/python/metatensor-learn/metatensor/learn/nn/layer_norm.py
@@ -326,7 +326,7 @@ def _layer_norm(
     :return: :py:class:`torch.Tensor` with layer normalization applied.
     """
     # Contract over all dimensions except samples
-    dim: List[int] = list(range(1, len(tensor.shape) - 1))
+    dim: List[int] = list(range(1, len(tensor.shape)))
 
     if mean:  # subtract mean over properties dimension
         tensor_out = tensor - torch.mean(tensor, dim=dim, keepdim=True)

--- a/python/metatensor-learn/metatensor/learn/nn/layer_norm.py
+++ b/python/metatensor-learn/metatensor/learn/nn/layer_norm.py
@@ -25,12 +25,11 @@ class LayerNorm(Module):
 
     The main difference from :py:class:`torch.nn.LayerNorm` is that there is no
     `normalized_shape` parameter. Instead, the standard deviation and mean (if
-    applicable) are calculated over the property dimension of each
-    :py:class:`TensorBlock`.
+    applicable) are calculated over all dimensions except the samples (first) dimension
+    of each :py:class:`TensorBlock`.
 
-    This module also has an extra parameter :param mean: that controls whether or not
-    the mean over the properties dimension is subtracted from the input tensor in the
-    transformation.
+    The extra parameter :param mean: controls whether or not the mean over these
+    dimensions is subtracted from the input tensor in the transformation.
 
     Refer to the :py:class`torch.nn.LayerNorm` documentation for a more detailed
     description of the other parameters.
@@ -47,8 +46,9 @@ class LayerNorm(Module):
     :param out_properties: list of :py:class`Labels` (optional), the properties labels
         of the output. By default (if none) the output properties are relabeled using
         Labels.range.
-    :mean bool: whether or not to subtract the mean over the properties (final)
-        dimension of each block of the input passed to :py:meth:`forward`.
+    :mean bool: whether or not to subtract the mean over all dimensions except the
+        samples (first) dimension of each block of the input passed to
+        :py:meth:`forward`.
     """
 
     def __init__(
@@ -119,12 +119,11 @@ class InvariantLayerNorm(Module):
 
     The main difference from :py:class:`torch.nn.LayerNorm` is that there is no
     `normalized_shape` parameter. Instead, the standard deviation and mean (if
-    applicable) are calculated over the property dimension of each
-    :py:class:`TensorBlock`.
+    applicable) are calculated over all dimensions except the samples (first) dimension
+    of each :py:class:`TensorBlock`.
 
-    This module also has an extra parameter :param mean: that controls whether or not
-    the mean over the properties dimension is subtracted from the input tensor in the
-    transformation.
+    The extra parameter :param mean: controls whether or not the mean over these
+    dimensions is subtracted from the input tensor in the transformation.
 
     Refer to the :py:class`torch.nn.LayerNorm` documentation for a more detailed
     description of the other parameters.
@@ -146,8 +145,8 @@ class InvariantLayerNorm(Module):
     :param out_properties: list of :py:class`Labels` (optional), the properties labels
         of the output. By default (if none) the output properties are relabeled using
         Labels.range.
-    :param mean: bool or list of bool. Whether or not to subtract the mean over the
-        properties (final) dimension of each invariant block of the input passed to
+    :mean bool: whether or not to subtract the mean over all dimensions except the
+        samples (first) dimension of each block of the input passed to
         :py:meth:`forward`. If passed as a list, must have the same length as :param
         invariant_key_idxs:.
     """
@@ -237,8 +236,8 @@ class _LayerNorm(Module):
     Custom :py:class:`Module` re-implementing :py:class:`torch.nn.LayerNorm`.
 
     In this case, `normalized_shape` is not provided as a parameter. Instead, the
-    standard deviation and mean (if applicable) are calculated over the final dimension
-    of the input tensor.
+    standard deviation and mean (if applicable) are calculated over all dimensions
+    except the samples of the input tensor.
 
     Subtraction of this mean can be switched on or off using the extra :param mean:
     parameter.
@@ -246,8 +245,8 @@ class _LayerNorm(Module):
     Refer to :py:class:`torch.nn.LayerNorm` documentation for more information on the
     other parameters.
 
-    :param mean: bool, whether or not to subtract the mean over the final dimension of
-        the input tensor passed to :py:meth:`forward`.
+    :param mean: bool, whether or not to subtract the mean over all dimension except the
+        samples of the input tensor passed to :py:meth:`forward`.
     """
 
     __constants__ = ["in_features", "eps", "elementwise_affine"]
@@ -314,23 +313,23 @@ def _layer_norm(
     """
     Apply layer normalization to the input `tensor`.
 
-    See :py:class:`torch.nn.functional.layer_norm` for more information on the
-    other parameters.
+    See :py:class:`torch.nn.functional.layer_norm` for more information on the other
+    parameters.
 
     In addition to base torch implementation, this function has the added control of
-    whether or not the mean over the properties (final) dimension is subtracted from the
-    input tensor.
+    whether or not the mean over all dimensions except the samples (first) dimension is
+    subtracted from the input tensor.
 
     :param mean: whether or not to subtract from the input :param tensor: the mean over
-        the dimensions not included in :param normalized_shape:.
+        all dimensions except the samples (first) dimension.
 
     :return: :py:class:`torch.Tensor` with layer normalization applied.
     """
-    # Contract over all dimensions except properties
-    dim: List[int] = list(range(0, len(tensor.shape) - 1))
+    # Contract over all dimensions except samples
+    dim: List[int] = list(range(1, len(tensor.shape) - 1))
 
     if mean:  # subtract mean over properties dimension
-        tensor_out = tensor - torch.mean(tensor, dim=dim)
+        tensor_out = tensor - torch.mean(tensor, dim=dim, keepdim=True)
     else:
         tensor_out = tensor
 

--- a/python/metatensor-learn/tests/layer_norm.py
+++ b/python/metatensor-learn/tests/layer_norm.py
@@ -83,3 +83,19 @@ def test_equivariance(tensor, wigner_d_real):
     fRx = f(Rx)  # f(R . x)
 
     assert metatensor.allclose(fRx, Rfx, atol=1e-10, rtol=1e-10)
+
+
+def test_layer_norm_indep_samples():
+    """
+    Tests that the LayerNorm is applied to each sample independently.
+    """
+    layer_norm_module = _LayerNorm(
+        in_features=10, elementwise_affine=True, dtype=torch.float64
+    )
+    tensor = torch.randn(5, 3, 10)
+    norm = layer_norm_module(tensor)
+
+    # Apply to each sample independently and check consistency
+    for i in range(tensor.shape[0]):
+        norm_i = layer_norm_module(tensor[i : i + 1])
+        assert torch.allclose(norm[i], norm_i, atol=1e-10, rtol=1e-10)

--- a/python/metatensor-learn/tests/layer_norm.py
+++ b/python/metatensor-learn/tests/layer_norm.py
@@ -45,16 +45,14 @@ def test_layer_norm_torch_mts_equivalence(tensor):
             dtype=torch.float64,
         )(array)
 
-        # Apply the native torch.nn.LayerNorm. This requires reshaping such that the
-        # properties are in the first dimension. This is because the `normalized_shape`
-        # parameter is defined over the *final* D dimensions of the array, and we want
-        # to reduce over samples and components.
-        array_T = array.transpose(0, 2)
+        # Apply the native torch.nn.LayerNorm. `normalized_shape` is defined over the
+        # last D dimensions of the array, and we want to reduce over components and
+        # properties
         norm_torch = torch.nn.LayerNorm(
-            normalized_shape=array_T.shape[1:],
+            normalized_shape=array.shape[1:],
             elementwise_affine=True,
             dtype=torch.float64,
-        )(array_T).transpose(0, 2)
+        )(array)
         assert torch.allclose(norm_mts, norm_torch, atol=1e-10, rtol=1e-10)
 
 
@@ -85,7 +83,7 @@ def test_equivariance(tensor, wigner_d_real):
     assert metatensor.allclose(fRx, Rfx, atol=1e-10, rtol=1e-10)
 
 
-def test_layer_norm_indep_samples():
+def test_layer_norm_independent_samples():
     """
     Tests that the LayerNorm is applied to each sample independently.
     """


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Fix the implementation of `LayerNorm` and `InvariantLayerNorm` to calculate the mean and variance of blocks over all dimensions except the samples, such that transformations are applied to samples independently. The current implementation calculates these statistics over the samples, thus applying a BatchNorm-esque transformation.



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1534277939.zip)

<!-- download-section Documentation end -->