### PR TITLE
Allow non-identifiers as fields in Dataset

### DIFF
--- a/python/metatensor-learn/CHANGELOG.md
+++ b/python/metatensor-learn/CHANGELOG.md
@@ -17,6 +17,12 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
+### Changed
+
+- Dataset and DataLoader can now handle fields with a name which is not a valid
+  Python identifier.
+
+
 ## [Version 0.2.2](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-learn-v0.2.2) - 2024-05-16
 
 ### Added

--- a/python/metatensor-learn/metatensor/learn/data/_namedtuple.py
+++ b/python/metatensor-learn/metatensor/learn/data/_namedtuple.py
@@ -1,0 +1,148 @@
+"""
+This contains a custom version of `collections.namedtuple` that supports field names
+which are not valid Python identifiers.
+"""
+
+import keyword
+import sys
+from operator import itemgetter
+
+
+def _tuplegetter(index, doc):
+    return property(itemgetter(index), doc=doc)
+
+
+def namedtuple(typename, field_names):
+    field_names = list(map(str, field_names))
+    typename = sys.intern(str(typename))
+
+    if keyword.iskeyword(typename):
+        raise ValueError(f"Type names cannot be a keyword: {typename!r}")
+
+    arg_names = []
+    fmt_names = []
+    for index, name in enumerate(field_names):
+        if name.isidentifier() and not keyword.iskeyword(name):
+            arg_names.append(name)
+            fmt_names.append(name)
+        else:
+            arg_names.append(f"_{index}")
+            fmt_names.append(f"'{name}'")
+
+    seen = set()
+    for name in field_names:
+        if name in seen:
+            raise ValueError(f"Encountered duplicate field name: {name!r}")
+        seen.add(name)
+
+    # Variables used in the methods and docstrings
+    field_names = tuple(map(sys.intern, field_names))
+    num_fields = len(field_names)
+    arg_list = ", ".join(arg_names)
+    if num_fields == 1:
+        arg_list += ","
+    repr_fmt = "(" + ", ".join(f"{name}=%r" for name in fmt_names) + ")"
+    tuple_new = tuple.__new__
+    tuple_getitem = tuple.__getitem__
+    _dict, _tuple, _len, _map, _zip = dict, tuple, len, map, zip
+
+    # Create all the named tuple methods to be added to the class namespace
+
+    namespace = {
+        "_tuple_new": tuple_new,
+        "__builtins__": {},
+        "__name__": f"namedtuple_{typename}",
+    }
+    code = f"lambda _cls, {arg_list}: _tuple_new(_cls, ({arg_list}))"
+    __new__ = eval(code, namespace)
+    __new__.__name__ = "__new__"
+    __new__.__doc__ = f"Create new instance of {typename}({arg_list})"
+
+    @classmethod
+    def _make(cls, iterable):
+        result = tuple_new(cls, iterable)
+        if _len(result) != num_fields:
+            raise TypeError(f"Expected {num_fields} arguments, got {len(result)}")
+        return result
+
+    _make.__func__.__doc__ = (
+        f"Make a new {typename} object from a sequence " "or iterable"
+    )
+
+    def _replace(self, /, **kwds):
+        result = self._make(_map(kwds.pop, field_names, self))
+        if kwds:
+            raise TypeError(f"Got unexpected field names: {list(kwds)!r}")
+        return result
+
+    _replace.__doc__ = (
+        f"Return a new {typename} object replacing specified fields with new values"
+    )
+
+    def __repr__(self):
+        "Return a nicely formatted representation string"
+        return self.__class__.__name__ + repr_fmt % self
+
+    def _asdict(self):
+        "Return a new dict which maps field names to their values."
+        return _dict(_zip(self._fields, self))
+
+    def __getnewargs__(self):
+        "Return self as a plain tuple.  Used by copy and pickle."
+        return _tuple(self)
+
+    def __getitem__(self, key):
+        if isinstance(key, str):
+            return self._asdict()[key]
+        else:
+            return tuple_getitem(self, key)
+
+    # Modify function metadata to help with introspection and debugging
+    for method in (
+        __new__,
+        _make.__func__,
+        _replace,
+        __repr__,
+        _asdict,
+        __getnewargs__,
+        __getitem__,
+    ):
+        method.__qualname__ = f"{typename}.{method.__name__}"
+
+    # Build-up the class namespace dictionary
+    # and use type() to build the result class
+    class_namespace = {
+        "__doc__": f"{typename}({arg_list})",
+        "__slots__": (),
+        "_fields": field_names,
+        "__new__": __new__,
+        "_make": _make,
+        "__replace__": _replace,
+        "_replace": _replace,
+        "__repr__": __repr__,
+        "_asdict": _asdict,
+        "__getnewargs__": __getnewargs__,
+        "__getitem__": __getitem__,
+        "__match_args__": field_names,
+    }
+    for index, name in enumerate(field_names):
+        if name.isidentifier():
+            doc = sys.intern(f"Alias for field number {index}")
+            class_namespace[name] = _tuplegetter(index, doc)
+
+    result = type(typename, (tuple,), class_namespace)
+
+    # For pickling to work, the __module__ variable needs to be set to the frame
+    # where the named tuple is created.
+    try:
+        module = sys._getframemodulename(1) or "__main__"
+    except AttributeError:
+        try:
+            module = sys._getframe(1).f_globals.get("__name__", "__main__")
+        except (AttributeError, ValueError):
+            pass
+
+    if module is not None:
+        result.__module__ = module
+
+    return result

--- a/python/metatensor-learn/metatensor/learn/data/collate.py
+++ b/python/metatensor-learn/metatensor/learn/data/collate.py
@@ -2,13 +2,14 @@
 Module containing a collate function for use in a Dataloader.
 """
 
-from collections import namedtuple
 from typing import List, NamedTuple, Optional, Union
 
 import torch
 
 import metatensor
 from metatensor import TensorMap
+
+from ._namedtuple import namedtuple
 
 
 def group(batch: List[NamedTuple]) -> NamedTuple:

--- a/python/metatensor-learn/metatensor/learn/data/dataset.py
+++ b/python/metatensor-learn/metatensor/learn/data/dataset.py
@@ -109,6 +109,38 @@ class Dataset(_BaseDataset):
     ID. This data field for a given sample is then only lazily loaded into memory when
     the :py:meth:`Dataset.__getitem__` method is called.
 
+    >>> # create a Dataset with only lists
+    >>> dataset = Dataset(num=[1, 2, 3], string=["a", "b", "c"])
+    >>> dataset[0]
+    Sample(num=1, string='a')
+    >>> dataset[2]
+    Sample(num=3, string='c')
+
+    >>> # create a Dataset with callables for lazy loading of data
+    >>> def call_me(sample_id: int):
+    ...     # this could also read from a file
+    ...     return f"compute something with sample {sample_id}"
+    >>> dataset = Dataset(num=[1, 2, 3], call_me=call_me)
+    >>> dataset[0]
+    Sample(num=1, call_me='compute something with sample 0')
+    >>> dataset[2]
+    Sample(num=3, call_me='compute something with sample 2')
+
+    >>> # iterating over a dataset
+    >>> for num, called in dataset:
+    ...     print(num, " -- ", called)
+    ...
+    1  --  compute something with sample 0
+    2  --  compute something with sample 1
+    3  --  compute something with sample 2
+    >>> for sample in dataset:
+    ...     print(sample.num, " -- ", sample.call_me)
+    ...
+    1  --  compute something with sample 0
+    2  --  compute something with sample 1
+    3  --  compute something with sample 2
+
+
     :param size: Optional, an integer indicating the size of the dataset, i.e. the
         number of samples. This only needs to be specified if all data
     :param kwargs: List or Callable. Keyword arguments specifying the data fields for
@@ -178,6 +210,25 @@ class IndexedDataset(_BaseDataset):
     return the data object for that sample ID. This data field for a given sample is
     then only lazily loaded into memory when :py:meth:`IndexedDataset.__getitem__` or
     :py:meth:`IndexedDataset.get_sample` methods are called.
+
+    >>> # create an IndexedDataset with lists
+    >>> dataset = IndexedDataset(sample_id=["cat", "bird", "dog"], y=[11, 22, 33])
+    >>> dataset[0]
+    Sample(sample_id='cat', y=11)
+    >>> dataset[2]
+    Sample(sample_id='dog', y=33)
+
+    >>> # create an IndexedDataset with callables for lazy loading of data
+    >>> def call_me(sample_id: int):
+    ...     # this could also read from a file
+    ...     return f"compute something with sample {sample_id}"
+    >>> dataset = IndexedDataset(sample_id=["cat", "bird", "dog"], call_me=call_me)
+    >>> dataset[0]
+    Sample(sample_id='cat', call_me='compute something with sample cat')
+    >>> dataset[2]
+    Sample(sample_id='dog', call_me='compute something with sample dog')
+    >>> dataset.get_sample("bird")
+    Sample(sample_id='bird', call_me='compute something with sample bird')
 
     :param sample_id: A list of unique IDs for each sample in the dataset.
     :param kwargs: Keyword arguments specifying the data fields for the dataset.

--- a/python/metatensor-learn/tests/_tests_utils.py
+++ b/python/metatensor-learn/tests/_tests_utils.py
@@ -15,14 +15,11 @@ torch = pytest.importorskip("torch")
 from metatensor.learn.data import Dataset, IndexedDataset  # noqa E402
 
 
-TORCH_KWARGS = {"device": "cpu", "dtype": torch.float32}
-
-
 def random_single_block_no_components_tensor_map(use_torch):
     """Create a dummy tensor map to be used in tests."""
 
     if use_torch:
-        create_random_array = partial(torch.rand, **TORCH_KWARGS)
+        create_random_array = partial(torch.rand, device="cpu", dtype=torch.float32)
     else:
         create_random_array = np.random.rand
 
@@ -154,7 +151,7 @@ def generate_data(sample_indices):
     return inputs, outputs, auxiliaries
 
 
-def transform(sample_index: int, filename: str):
+def load_tensor_map(sample_index: int, filename: str):
     """
     Loads a TensorMap for a given sample indexed by `sample_index` from disk and
     converts it to a torch tensor.
@@ -164,7 +161,7 @@ def transform(sample_index: int, filename: str):
     tensor = metatensor.io.load_custom_array(
         path, create_array=metatensor.io.create_torch_array
     )
-    return tensor.to(**TORCH_KWARGS)
+    return tensor
 
 
 def dataset_in_mem(sample_indices):
@@ -183,9 +180,9 @@ def dataset_on_disk(sample_indices):
     _ = generate_data(range(len(sample_indices)))
     return Dataset(
         size=len(sample_indices),
-        input=partial(transform, filename="input"),
-        output=partial(transform, filename="output"),
-        auxiliary=partial(transform, filename="auxiliary"),
+        input=partial(load_tensor_map, filename="input"),
+        output=partial(load_tensor_map, filename="output"),
+        auxiliary=partial(load_tensor_map, filename="auxiliary"),
     )
 
 
@@ -197,7 +194,7 @@ def dataset_mixed_mem_disk(sample_indices):
         size=len(sample_indices),
         input=inputs,
         output=outputs,
-        auxiliary=partial(transform, filename="auxiliary"),
+        auxiliary=partial(load_tensor_map, filename="auxiliary"),
     )
 
 
@@ -217,9 +214,9 @@ def indexed_dataset_on_disk(sample_indices):
     _ = generate_data(sample_indices)
     return IndexedDataset(
         sample_id=sample_indices,
-        input=partial(transform, filename="input"),
-        output=partial(transform, filename="output"),
-        auxiliary=partial(transform, filename="auxiliary"),
+        input=partial(load_tensor_map, filename="input"),
+        output=partial(load_tensor_map, filename="output"),
+        auxiliary=partial(load_tensor_map, filename="auxiliary"),
     )
 
 
@@ -233,7 +230,7 @@ def indexed_dataset_mixed_mem_disk(sample_indices):
         sample_id=sample_indices,
         input=inputs,
         output=outputs,
-        auxiliary=partial(transform, filename="auxiliary"),
+        auxiliary=partial(load_tensor_map, filename="auxiliary"),
     )
 
 

--- a/python/metatensor-learn/tests/dataloader.py
+++ b/python/metatensor-learn/tests/dataloader.py
@@ -9,7 +9,7 @@ torch = pytest.importorskip("torch")
 
 import metatensor  # noqa: E402
 from metatensor import TensorMap  # noqa: E402
-from metatensor.learn.data import DataLoader, group  # noqa: E402
+from metatensor.learn.data import DataLoader, Dataset, group  # noqa: E402
 
 from . import _tests_utils  # noqa: E402
 
@@ -33,13 +33,13 @@ def test_dataloader_indices(create_dataset, tmpdir):
     """
     with tmpdir.as_cwd():
         batch_size = 3
-        dset = create_dataset(SAMPLE_INDICES)
+        dataset = create_dataset(SAMPLE_INDICES)
         expected_indices = np.arange(len(SAMPLE_INDICES)).reshape(-1, batch_size)
 
         # Build dataloader from a random subset of sample indices
-        dloader = DataLoader(dset, batch_size=batch_size, shuffle=False)
+        dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=False)
 
-        for exp_idxs, batch in zip(expected_indices, dloader):
+        for exp_idxs, batch in zip(expected_indices, dataloader):
             assert (
                 np.sort(
                     metatensor.unique_metadata(
@@ -66,13 +66,13 @@ def test_dataloader_indices_indexed(create_dataset, tmpdir):
     """
     with tmpdir.as_cwd():
         batch_size = 3
-        dset = create_dataset(SAMPLE_INDICES)
+        dataset = create_dataset(SAMPLE_INDICES)
         expected_indices = np.array(SAMPLE_INDICES).reshape(-1, batch_size)
 
         # Build dataloader from a random subset of sample indices
-        dloader = DataLoader(dset, batch_size=batch_size, shuffle=False)
+        dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=False)
 
-        for exp_idxs, batch in zip(expected_indices, dloader):
+        for exp_idxs, batch in zip(expected_indices, dataloader):
             assert (
                 np.sort(
                     metatensor.unique_metadata(
@@ -97,13 +97,13 @@ def test_indexed_dataloader_indices_shuffle(create_dataset, tmpdir):
     function.
     """
     with tmpdir.as_cwd():
-        dset = create_dataset(SAMPLE_INDICES)
-        dloader = DataLoader(dset, collate_fn=group, batch_size=2, shuffle=False)
+        dataset = create_dataset(SAMPLE_INDICES)
+        dataloader = DataLoader(dataset, collate_fn=group, batch_size=2, shuffle=False)
 
         batched_indices = np.array(SAMPLE_INDICES).reshape(-1, 2)
 
         matching = []
-        for batch_i, batch in enumerate(dloader):
+        for batch_i, batch in enumerate(dataloader):
             matching.append(np.all(batch.sample_id == batched_indices[batch_i]))
 
         assert np.all(matching)
@@ -114,12 +114,12 @@ def test_dataloader_collate_fn_group_and_join(tmpdir):
     Tests the output using the default "group_and_join" collate function.
     """
     with tmpdir.as_cwd():
-        dset = _tests_utils.indexed_dataset_on_disk(SAMPLE_INDICES)
+        dataset = _tests_utils.indexed_dataset_on_disk(SAMPLE_INDICES)
 
         # Build dataloader using default collate function "group_and_join"
-        dloader = DataLoader(dset, batch_size=6)
+        dataloader = DataLoader(dataset, batch_size=6)
 
-        for batch in dloader:
+        for batch in dataloader:
             for field in [batch.input, batch.output, batch.auxiliary]:
                 assert isinstance(field, TensorMap)
                 assert all(
@@ -138,10 +138,10 @@ def test_dataloader_collate_fn_group(tmpdir):
     Tests the output using the default "group_and_join" collate function.
     """
     with tmpdir.as_cwd():
-        dset = _tests_utils.indexed_dataset_mixed_mem_disk(SAMPLE_INDICES)
-        dloader = DataLoader(dset, collate_fn=group, batch_size=5)
+        dataset = _tests_utils.indexed_dataset_mixed_mem_disk(SAMPLE_INDICES)
+        dataloader = DataLoader(dataset, collate_fn=group, batch_size=5)
 
-        for batch in dloader:
+        for batch in dataloader:
             for field in [batch.input, batch.output, batch.auxiliary]:
                 assert isinstance(field, tuple)
                 for i, A in enumerate(batch.sample_id):
@@ -152,3 +152,19 @@ def test_dataloader_collate_fn_group(tmpdir):
                             field[i], "samples", "sample_index"
                         ).values[0]
                     )
+
+
+def test_dataloader_non_ident_names():
+    dataset = Dataset.from_dict(
+        {
+            "foo bar": [1, 2, 3],
+            "__underscore": [0, 2, 4],
+            "class": [-1, -2, -3],
+        },
+    )
+
+    dataloader = DataLoader(dataset, batch_size=3)
+    for batch in dataloader:
+        assert "foo bar" in batch._asdict()
+        assert "__underscore" in batch._asdict()
+        assert "class" in batch._asdict()

--- a/python/metatensor-learn/tests/dataset.py
+++ b/python/metatensor-learn/tests/dataset.py
@@ -218,14 +218,13 @@ def test_indexed_dataset_invalid_callable():
     Tests that passing a data fields as a callable that is invalid with a
     specific sample ID raises the appropriate error.
     """
-    message = "Error loading data field 'c' for sample ID cat"
-    with pytest.raises(IOError) as excinfo:
+    message = "Error loading data field 'c' for sample 'cat'"
+    with pytest.raises(ValueError, match=message):
         dset = IndexedDataset(
             c=lambda y: metatensor.load(f"path/to/{y}"),
             sample_id=["cat", "dog"],
         )
         dset.get_sample("cat")
-    assert message in str(excinfo.value)
 
 
 def test_dataset_inconsistent_lengths():
@@ -235,7 +234,7 @@ def test_dataset_inconsistent_lengths():
     """
     message = (
         "Number of samples inconsistent between argument 'size' (5) "
-        "and data fields in kwargs: ([10])"
+        "and data fields: ([10])"
     )
     with pytest.raises(ValueError, match=re.escape(message)):
         Dataset(
@@ -257,7 +256,7 @@ def test_indexed_dataset_inconsistent_lengths():
     """
     message = (
         "Number of samples inconsistent between argument 'sample_id' (9) "
-        "and data fields in kwargs: ([10])"
+        "and data fields: ([9, 10])"
     )
     with pytest.raises(ValueError, match=re.escape(message)):
         IndexedDataset(
@@ -297,7 +296,7 @@ def test_iterate_over_dataset():
         assert sample.b == torch.zeros((1, 1))
 
 
-def test_iterate_over_indexeddataset():
+def test_iterate_over_indexed_dataset():
     """
     Tests iterating over the IndexedDataset object.
     """

--- a/python/metatensor-learn/tests/dataset.py
+++ b/python/metatensor-learn/tests/dataset.py
@@ -26,20 +26,20 @@ def test_dataset_all_in_memory(indexed, tmpdir):
     """Tests dataset that all data is in memory"""
     with tmpdir.as_cwd():
         if indexed:
-            dset = _tests_utils.indexed_dataset_in_mem(SAMPLE_INDICES)
+            dataset = _tests_utils.indexed_dataset_in_mem(SAMPLE_INDICES)
         else:
-            dset = _tests_utils.dataset_in_mem(SAMPLE_INDICES)
+            dataset = _tests_utils.dataset_in_mem(SAMPLE_INDICES)
 
         for idx, A in enumerate(SAMPLE_INDICES):
             # Check successful loading into memory upon calling __getitem__
             if indexed:
-                assert isinstance(dset.get_sample(A).input, TensorMap)
-                assert isinstance(dset.get_sample(A).output, TensorMap)
-                assert isinstance(dset.get_sample(A).auxiliary, TensorMap)
+                assert isinstance(dataset.get_sample(A).input, TensorMap)
+                assert isinstance(dataset.get_sample(A).output, TensorMap)
+                assert isinstance(dataset.get_sample(A).auxiliary, TensorMap)
             else:
-                assert isinstance(dset[idx].input, TensorMap)
-                assert isinstance(dset[idx].output, TensorMap)
-                assert isinstance(dset[idx].auxiliary, TensorMap)
+                assert isinstance(dataset[idx].input, TensorMap)
+                assert isinstance(dataset[idx].output, TensorMap)
+                assert isinstance(dataset[idx].auxiliary, TensorMap)
 
 
 @pytest.mark.parametrize("indexed", [False, True])
@@ -48,24 +48,24 @@ def test_dataset_all_on_disk(indexed, tmpdir):
     and not yet loaded into memory"""
     with tmpdir.as_cwd():
         if indexed:
-            dset = _tests_utils.indexed_dataset_on_disk(SAMPLE_INDICES)
+            dataset = _tests_utils.indexed_dataset_on_disk(SAMPLE_INDICES)
         else:
-            dset = _tests_utils.dataset_on_disk(SAMPLE_INDICES)
+            dataset = _tests_utils.dataset_on_disk(SAMPLE_INDICES)
         for idx, A in enumerate(SAMPLE_INDICES):
             # Check that callables are stored internally
-            assert callable(dset._data["input"])
-            assert callable(dset._data["output"])
-            assert callable(dset._data["auxiliary"])
+            assert callable(dataset._data["input"])
+            assert callable(dataset._data["output"])
+            assert callable(dataset._data["auxiliary"])
 
             # Check successful loading into memory upon calling __getitem__
             if indexed:
-                assert isinstance(dset.get_sample(A).input, TensorMap)
-                assert isinstance(dset.get_sample(A).output, TensorMap)
-                assert isinstance(dset.get_sample(A).auxiliary, TensorMap)
+                assert isinstance(dataset.get_sample(A).input, TensorMap)
+                assert isinstance(dataset.get_sample(A).output, TensorMap)
+                assert isinstance(dataset.get_sample(A).auxiliary, TensorMap)
             else:
-                assert isinstance(dset[idx].input, TensorMap)
-                assert isinstance(dset[idx].output, TensorMap)
-                assert isinstance(dset[idx].auxiliary, TensorMap)
+                assert isinstance(dataset[idx].input, TensorMap)
+                assert isinstance(dataset[idx].output, TensorMap)
+                assert isinstance(dataset[idx].auxiliary, TensorMap)
 
 
 @pytest.mark.parametrize("indexed", [False, True])
@@ -74,26 +74,26 @@ def test_dataset_mixed_mem_disk(indexed, tmpdir):
     and not yet loaded into memory, or in memeory."""
     with tmpdir.as_cwd():
         if indexed:
-            dset = _tests_utils.indexed_dataset_mixed_mem_disk(SAMPLE_INDICES)
+            dataset = _tests_utils.indexed_dataset_mixed_mem_disk(SAMPLE_INDICES)
         else:
-            dset = _tests_utils.dataset_mixed_mem_disk(SAMPLE_INDICES)
+            dataset = _tests_utils.dataset_mixed_mem_disk(SAMPLE_INDICES)
         for idx, A in enumerate(SAMPLE_INDICES):
             # Check input/output data are stored as TensorMaps internally
-            assert isinstance(dset._data["input"][idx], TensorMap)
-            assert isinstance(dset._data["output"][idx], TensorMap)
+            assert isinstance(dataset._data["input"][idx], TensorMap)
+            assert isinstance(dataset._data["output"][idx], TensorMap)
 
             # Check auxiliary data is stored as a callable internally
-            assert callable(dset._data["auxiliary"])
+            assert callable(dataset._data["auxiliary"])
 
             # Check successful loading into memory upon calling __getitem__
             if indexed:
-                assert isinstance(dset.get_sample(A).input, TensorMap)
-                assert isinstance(dset.get_sample(A).output, TensorMap)
-                assert isinstance(dset.get_sample(A).auxiliary, TensorMap)
+                assert isinstance(dataset.get_sample(A).input, TensorMap)
+                assert isinstance(dataset.get_sample(A).output, TensorMap)
+                assert isinstance(dataset.get_sample(A).auxiliary, TensorMap)
             else:
-                assert isinstance(dset[idx].input, TensorMap)
-                assert isinstance(dset[idx].output, TensorMap)
-                assert isinstance(dset[idx].auxiliary, TensorMap)
+                assert isinstance(dataset[idx].input, TensorMap)
+                assert isinstance(dataset[idx].output, TensorMap)
+                assert isinstance(dataset[idx].auxiliary, TensorMap)
 
 
 def test_dataset_fields():
@@ -101,12 +101,12 @@ def test_dataset_fields():
     Tests that the dataset fields passed as kwargs are correctly set and
     returned in the correct order.
     """
-    dset = Dataset(
+    dataset = Dataset(
         a=[torch.zeros((1, 1)) for _ in range(10)],
         c=[torch.zeros((1, 1)) for _ in range(10)],
         b=[torch.zeros((1, 1)) for _ in range(10)],
     )
-    assert np.all(dset[5]._fields == ("a", "c", "b"))
+    assert np.all(dataset[5]._fields == ("a", "c", "b"))
 
 
 def test_indexed_dataset_fields():
@@ -114,13 +114,13 @@ def test_indexed_dataset_fields():
     Tests that the indexed dataset fields passed as kwargs are correctly set and
     returned in the correct order.
     """
-    dset = IndexedDataset(
+    dataset = IndexedDataset(
         a=[torch.zeros((1, 1)) for _ in range(10)],
         c=[torch.zeros((1, 1)) for _ in range(10)],
         sample_id=list(range(10)),
         b=[torch.zeros((1, 1)) for _ in range(10)],
     )
-    assert np.all(dset[5]._fields == ("sample_id", "a", "c", "b"))
+    assert np.all(dataset[5]._fields == ("sample_id", "a", "c", "b"))
 
 
 def test_dataset_fields_arbitrary_types():
@@ -128,15 +128,15 @@ def test_dataset_fields_arbitrary_types():
     Tests that the dataset fields passed as arbitrary objects are correctly set
     and stored.
     """
-    dset = Dataset(
+    dataset = Dataset(
         a=["hello" for _ in range(10)],
         c=[(3, 4, 7) for _ in range(10)],
         b=[0 for _ in range(10)],
     )
-    assert dset[5].a == "hello"
-    assert dset[5].c == (3, 4, 7)
-    assert dset[5].b == 0
-    assert np.all(dset[5]._fields == ("a", "c", "b"))
+    assert dataset[5].a == "hello"
+    assert dataset[5].c == (3, 4, 7)
+    assert dataset[5].b == 0
+    assert np.all(dataset[5]._fields == ("a", "c", "b"))
 
 
 def test_indexed_dataset_fields_arbitrary_types():
@@ -144,16 +144,16 @@ def test_indexed_dataset_fields_arbitrary_types():
     Tests that the dataset fields passed as arbitrary objects are correctly set
     and stored.
     """
-    dset = IndexedDataset(
+    dataset = IndexedDataset(
         a=["hello" for _ in range(10)],
         c=[(3, 4, 7) for _ in range(10)],
         sample_id=list(range(10)),
         b=[0 for _ in range(10)],
     )
-    assert dset[5].a == "hello"
-    assert dset[5].c == (3, 4, 7)
-    assert dset[5].b == 0
-    assert np.all(dset[5]._fields == ("sample_id", "a", "c", "b"))
+    assert dataset[5].a == "hello"
+    assert dataset[5].c == (3, 4, 7)
+    assert dataset[5].b == 0
+    assert np.all(dataset[5]._fields == ("sample_id", "a", "c", "b"))
 
 
 @pytest.mark.parametrize(
@@ -169,10 +169,10 @@ def test_dataset_nonexistant_index_error(create_dataset, tmpdir):
     Tests that calling __getitem__ for a non-existant index raises an error.
     """
     with tmpdir.as_cwd():
-        dset = create_dataset(SAMPLE_INDICES)
+        dataset = create_dataset(SAMPLE_INDICES)
         message = "Index 1000 not in dataset"
         with pytest.raises(ValueError, match=message):
-            dset[1000]
+            dataset[1000]
 
 
 @pytest.mark.parametrize(
@@ -188,29 +188,29 @@ def test_indexed_dataset_nonexistant_index_error(create_dataset, tmpdir):
     Tests that calling __getitem__ for a non-existant index raises an error.
     """
     with tmpdir.as_cwd():
-        dset = create_dataset(SAMPLE_INDICES)
+        dataset = create_dataset(SAMPLE_INDICES)
         message = "Index 1000 not in dataset"
         with pytest.raises(ValueError, match=message):
-            dset[1000]
+            dataset[1000]
 
         message = "Sample ID 'foo' not in dataset"
         with pytest.raises(ValueError, match=message):
-            dset.get_sample("foo")
+            dataset.get_sample("foo")
 
 
 def test_dataset_callable_invalid_callable():
     """
     Tests that passing a data fields as a callable that is invalid with a
-    specific numeric sample idx raises the appropriate error.
+    specific sample idx raises the appropriate error.
     """
-    message = "Error loading data field 'c' at numeric sample index 0"
-    with pytest.raises(IOError) as excinfo:
-        dset = Dataset(
-            c=lambda y: metatensor.load(f"path/to/{y}"),
-            size=1,
-        )
-        dset[0]
-    assert message in str(excinfo.value)
+    dataset = Dataset(
+        c=lambda y: metatensor.load(f"path/to/{y}"),
+        size=1,
+    )
+
+    message = "Error loading data field 'c' at sample index 0"
+    with pytest.raises(ValueError, match=message):
+        dataset[0]
 
 
 def test_indexed_dataset_invalid_callable():
@@ -218,13 +218,14 @@ def test_indexed_dataset_invalid_callable():
     Tests that passing a data fields as a callable that is invalid with a
     specific sample ID raises the appropriate error.
     """
+    dataset = IndexedDataset(
+        c=lambda y: metatensor.load(f"path/to/{y}"),
+        sample_id=["cat", "dog"],
+    )
+
     message = "Error loading data field 'c' for sample 'cat'"
     with pytest.raises(ValueError, match=message):
-        dset = IndexedDataset(
-            c=lambda y: metatensor.load(f"path/to/{y}"),
-            sample_id=["cat", "dog"],
-        )
-        dset.get_sample("cat")
+        dataset.get_sample("cat")
 
 
 def test_dataset_inconsistent_lengths():
@@ -272,7 +273,7 @@ def test_indexed_dataset_nonunique_sample_id():
     Tests the appropriate error is raised when non-unique sample IDs are
     passed.
     """
-    message = "Sample IDs must be unique. Found duplicate sample IDs."
+    message = "Sample IDs must be unique, found some duplicate"
     with pytest.raises(ValueError, match=message):
         IndexedDataset(
             a=[1, 2, 3],
@@ -284,13 +285,13 @@ def test_iterate_over_dataset():
     """
     Tests iterating over the Dataset object.
     """
-    dset = Dataset(
+    dataset = Dataset(
         a=[torch.ones((1, 1)) * i for i in range(5)],
         c=[torch.zeros((1, 1)) * 10 for _ in range(5)],
         b=[torch.zeros((1, 1)) for _ in range(5)],
     )
 
-    for i, sample in enumerate(dset):
+    for i, sample in enumerate(dataset):
         assert sample.a == torch.ones((1, 1)) * i
         assert sample.c == torch.zeros((1, 1))
         assert sample.b == torch.zeros((1, 1))
@@ -301,15 +302,58 @@ def test_iterate_over_indexed_dataset():
     Tests iterating over the IndexedDataset object.
     """
     sample_ids = ["dog", "cat", "fish", "bird", "mouse"]
-    dset = IndexedDataset(
+    dataset = IndexedDataset(
         a=[torch.ones((1, 1)) * i for i in range(5)],
         c=[torch.zeros((1, 1)) * 10 for _ in range(5)],
         b=[torch.zeros((1, 1)) for _ in range(5)],
         sample_id=sample_ids,
     )
 
-    for i, sample in enumerate(dset):
+    for i, sample in enumerate(dataset):
         assert sample.sample_id == sample_ids[i]
         assert sample.a == torch.ones((1, 1)) * i
         assert sample.c == torch.zeros((1, 1))
         assert sample.b == torch.zeros((1, 1))
+
+
+def test_dataset_non_ident_names():
+    dataset = Dataset.from_dict(
+        {
+            "foo bar": [1, 2, 3],
+            "__underscore": [0, 2, 4],
+            "class": [-1, -2, -3],
+        },
+    )
+
+    for i, sample in enumerate(dataset):
+        assert sample["foo bar"] == i + 1
+        assert sample.__underscore == 2 * i
+        assert sample["__underscore"] == 2 * i
+        assert sample["class"] == -(i + 1)
+
+    assert str(sample) == "Sample('foo bar'=3, __underscore=4, 'class'=-3)"
+    assert sample._asdict() == {"foo bar": 3, "__underscore": 4, "class": -3}
+
+    dataset = IndexedDataset.from_dict(
+        {
+            "foo bar": [1, 2, 3],
+            "__underscore": [0, 2, 4],
+            "class": [-1, -2, -3],
+        },
+        sample_id=[0, 1, 2],
+    )
+
+    for i, sample in enumerate(dataset):
+        assert sample.sample_id == i
+        assert sample["foo bar"] == i + 1
+        assert sample.__underscore == 2 * i
+        assert sample["__underscore"] == 2 * i
+        assert sample["class"] == -(i + 1)
+
+    assert str(sample) == "Sample(sample_id=2, 'foo bar'=3, __underscore=4, 'class'=-3)"
+    assert sample._asdict() == {
+        "sample_id": 2,
+        "foo bar": 3,
+        "__underscore": 4,
+        "class": -3,
+    }


### PR DESCRIPTION
Fix #621 

We use a custom `namedtuple` function to allow storing data where the name is not a python identifier. These fields can be accessed by their numeric index `sample[3]` or using a string name `sample["some weird name"]`. Previous code should work in the exact same way.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1543863592.zip)

<!-- download-section Documentation end -->