### PR TITLE
Also consider user site prefix when collecting extensions

### DIFF
--- a/python/metatensor-torch/metatensor/torch/atomistic/_extensions.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/_extensions.py
@@ -59,11 +59,15 @@ def _collect_extensions(extensions_path):
 
 
 def _copy_extension(full_path, extensions_path):
+    site_packages = site.getsitepackages()
+    if site.ENABLE_USER_SITE:
+        site_packages.append(site.getusersitepackages())
+
     path = full_path
-    for site_packages in site.getsitepackages():
+    for prefix in site_packages:
         # Remove any site-package prefix
-        if path.startswith(site_packages):
-            path = os.path.relpath(path, site_packages)
+        if path.startswith(prefix):
+            path = os.path.relpath(path, prefix)
             break
 
     if extensions_path is not None:


### PR DESCRIPTION
If someone is using a global python installation (like the one from their Linux distribution), most of the packages will be installed in the user site prefix. If it is enabled, we also consider it when copying extensions out of the site-packages.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1543467487.zip)

<!-- download-section Documentation end -->