### PR TITLE
Vectorized NeighborsAutograd::backward

### DIFF
--- a/metatensor-torch/src/atomistic/system.cpp
+++ b/metatensor-torch/src/atomistic/system.cpp
@@ -219,15 +219,15 @@ std::vector<torch::Tensor> NeighborsAutograd::backward(
             positions_grad,
             /*dim=*/0,
             /*index=*/samples.index({torch::indexing::Slice(), 1}),
-            /*source=*/distances_grad.squeeze(-1)
+            /*source=*/distances_grad.squeeze(-1),
+            /*alpha=*/1.0
         );
-        auto positions_grad_centers = torch::zeros_like(positions);
         positions_grad = torch::index_add(
             positions_grad,
             /*dim=*/0,
             /*index=*/samples.index({torch::indexing::Slice(), 0}),
             /*source=*/distances_grad.squeeze(-1),
-            /*alpha=*/-1
+            /*alpha=*/-1.0
         );
     }
 

--- a/metatensor-torch/src/atomistic/system.cpp
+++ b/metatensor-torch/src/atomistic/system.cpp
@@ -214,21 +214,21 @@ std::vector<torch::Tensor> NeighborsAutograd::backward(
 
     auto positions_grad = torch::Tensor();
     if (positions.requires_grad()) {
-        auto positions_grad_neighbors = torch::zeros_like(positions);
-        positions_grad_neighbors = torch::index_add(
-            positions_grad_neighbors,
+        positions_grad = torch::zeros_like(positions);
+        positions_grad = torch::index_add(
+            positions_grad,
             /*dim=*/0,
             /*index=*/samples.index({torch::indexing::Slice(), 1}),
             /*source=*/distances_grad.squeeze(-1)
         );
         auto positions_grad_centers = torch::zeros_like(positions);
-        positions_grad_centers = torch::index_add(
-            positions_grad_centers,
+        positions_grad = torch::index_add(
+            positions_grad,
             /*dim=*/0,
             /*index=*/samples.index({torch::indexing::Slice(), 0}),
-            /*source=*/distances_grad.squeeze(-1)
+            /*source=*/distances_grad.squeeze(-1),
+            /*alpha=*/-1
         );
-        positions_grad = positions_grad_neighbors - positions_grad_centers;
     }
 
     auto cell_grad = torch::Tensor();

--- a/python/metatensor-torch/tests/atomistic/neighbors.py
+++ b/python/metatensor-torch/tests/atomistic/neighbors.py
@@ -56,11 +56,14 @@ def test_neighbor_list_options():
 def test_neighbors_autograd():
     torch.manual_seed(0xDEADBEEF)
     n_atoms = 20
-    cell_size = 6.0
-    positions = cell_size * torch.rand(
+    approx_cell_size = 6.0
+    positions = approx_cell_size * torch.rand(
         n_atoms, 3, dtype=torch.float64, requires_grad=True
     )
-    cell = cell_size * torch.eye(3, dtype=torch.float64, requires_grad=True)
+    cell = approx_cell_size * (
+        torch.eye(3, dtype=torch.float64) + 0.1 * torch.rand(3, 3, dtype=torch.float64)
+    )
+    cell.requires_grad = True
 
     def compute(positions, cell, options):
         atoms = ase.Atoms(
@@ -125,10 +128,10 @@ def test_neighbor_autograd_errors():
         register_autograd_neighbors(system, neighbors)
 
     message = (
-        "one neighbor pair does not match its metadata: the pair between atom 0 and "
-        "atom 6 for the \\[0, 0, 0\\] cell shift should have a distance vector of "
-        "\\[-0.220464, -0.407372, 1.07291\\] but has a distance vector of "
-        "\\[-0.661392, -1.22212, 3.21872\\]"
+        "one neighbor pair does not match its metadata: the pair between atom 1 and "
+        "atom 4 for the \\[0, 0, 0\\] cell shift should have a distance vector of "
+        "\\[0.926094, -0.219122, 1.4382\\] but has a distance vector of "
+        "\\[2.77828, -0.657366, 4.31461\\]"
     )
     neighbors = _compute_ase_neighbors(
         atoms, options, dtype=torch.float64, device="cpu"


### PR DESCRIPTION
This small PR updated the way the `NeighborsAutograd::backward` computes the `positions_grad`. Now, instead of iterating over the samples (i.e. list of neighbors), the operation is vectorized with `torch::index_add`.



# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1549000929.zip)

<!-- download-section Documentation end -->