### PR TITLE
added len of a block

### DIFF
--- a/metatensor-core/CHANGELOG.md
+++ b/metatensor-core/CHANGELOG.md
@@ -23,6 +23,11 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 ### metatensor-core Python
 
+#### Added
+
+- `TensorBlock.__len__` and `TensorBlock.shape`, which return the length and
+  shape of the values in the block respectively
+
 ### metatensor-core Julia
 
 #### Added

--- a/metatensor-torch/CHANGELOG.md
+++ b/metatensor-torch/CHANGELOG.md
@@ -9,6 +9,8 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 ### Added
 
 - ``MetatensorAtomisticModel.save()`` to save a wrapped model to a file.
+- `TensorBlock.__len__` and `TensorBlock.shape`, which return the length and
+  shape of the values in the block respectively
 
 ### Deprecated
 

--- a/metatensor-torch/include/metatensor/torch/block.hpp
+++ b/metatensor-torch/include/metatensor/torch/block.hpp
@@ -59,7 +59,7 @@ public:
         return this->labels(0);
     }
 
-    // get the len of the samples
+    /// get the len of the samples
     int64_t len() const {
         return this->labels(0)->count();
     }

--- a/metatensor-torch/include/metatensor/torch/block.hpp
+++ b/metatensor-torch/include/metatensor/torch/block.hpp
@@ -61,7 +61,7 @@ public:
 
     // get the len of the samples
     int64_t len() const {
-        return this->labels(0).count();
+        return this->labels(0)->count();
     }
 
     /// Access the component `Labels` for this block.

--- a/metatensor-torch/include/metatensor/torch/block.hpp
+++ b/metatensor-torch/include/metatensor/torch/block.hpp
@@ -61,7 +61,7 @@ public:
 
     // get the len of the samples
     int64_t len() const {
-        return this->labels(0).size(0);
+        return this->labels.size(0);
     }
 
     /// Access the component `Labels` for this block.

--- a/metatensor-torch/include/metatensor/torch/block.hpp
+++ b/metatensor-torch/include/metatensor/torch/block.hpp
@@ -59,6 +59,11 @@ public:
         return this->labels(0);
     }
 
+    // get the len of the samples
+    int64_t len() const {
+        return this->labels(0).size(0);
+    }
+
     /// Access the component `Labels` for this block.
     ///
     /// The entries in these labels describe intermediate dimensions of the

--- a/metatensor-torch/include/metatensor/torch/block.hpp
+++ b/metatensor-torch/include/metatensor/torch/block.hpp
@@ -61,7 +61,7 @@ public:
 
     // get the len of the samples
     int64_t len() const {
-        return this->labels.size(0);
+        return this->labels(0).count();
     }
 
     /// Access the component `Labels` for this block.

--- a/metatensor-torch/include/metatensor/torch/block.hpp
+++ b/metatensor-torch/include/metatensor/torch/block.hpp
@@ -66,9 +66,7 @@ public:
 
     /// Get the shape of the values Tensor
     at::IntArrayRef shape() const{
-        auto _shape  = this->block_.values_shape();
-        std::vector<int64_t> shapei64(_shape.begin(), _shape.end());
-        at::IntArrayRef shape(shapei64);
+        at::IntArrayRef shape(this->shapei64);
         return shape ;
     }
 
@@ -183,6 +181,8 @@ private:
     /// If this TensorBlock contains gradients, these are gradients w.r.t. this
     /// parameter
     std::string parameter_;
+    /// Shape
+    std::vector<int64_t> shapei64 ;
 };
 
 }

--- a/metatensor-torch/include/metatensor/torch/block.hpp
+++ b/metatensor-torch/include/metatensor/torch/block.hpp
@@ -66,8 +66,7 @@ public:
 
     /// Get the shape of the values Tensor
     at::IntArrayRef shape() const{
-        at::IntArrayRef shape(this->shapei64);
-        return shape ;
+        return this->values().sizes() ;
     }
 
     /// Access the component `Labels` for this block.
@@ -181,8 +180,6 @@ private:
     /// If this TensorBlock contains gradients, these are gradients w.r.t. this
     /// parameter
     std::string parameter_;
-    /// Shape
-    std::vector<int64_t> shapei64 ;
 };
 
 }

--- a/metatensor-torch/include/metatensor/torch/block.hpp
+++ b/metatensor-torch/include/metatensor/torch/block.hpp
@@ -59,7 +59,7 @@ public:
         return this->labels(0);
     }
 
-    /// Get the len of the samples
+    /// Get the length of this block, i.e. the number of samples
     int64_t len() const {
         return this->labels(0)->count();
     }
@@ -69,8 +69,6 @@ public:
         auto _shape  = this->block_.values_shape();
         std::vector<int64_t> shapei64(_shape.begin(), _shape.end());
         at::IntArrayRef shape(shapei64);
-        //auto options = torch::TensorOptions().dtype(at::kLong);
-        //torch::Tensor t = torch::from_blob(shape.data(), {(int)shape.size()},options);
         return shape ;
     }
 

--- a/metatensor-torch/include/metatensor/torch/block.hpp
+++ b/metatensor-torch/include/metatensor/torch/block.hpp
@@ -59,9 +59,17 @@ public:
         return this->labels(0);
     }
 
-    /// get the len of the samples
+    /// Get the len of the samples
     int64_t len() const {
         return this->labels(0)->count();
+    }
+
+    /// Get the shape of the values Tensor
+    torch::Tensor shape() const{
+        auto shape  = this->block_.values_shape();
+        auto options = torch::TensorOptions().dtype(at::kLong);
+        torch::Tensor t = torch::from_blob(shape.data(), {(int)shape.size()},options);
+        return t ;
     }
 
     /// Access the component `Labels` for this block.

--- a/metatensor-torch/include/metatensor/torch/block.hpp
+++ b/metatensor-torch/include/metatensor/torch/block.hpp
@@ -65,11 +65,13 @@ public:
     }
 
     /// Get the shape of the values Tensor
-    torch::Tensor shape() const{
-        auto shape  = this->block_.values_shape();
-        auto options = torch::TensorOptions().dtype(at::kLong);
-        torch::Tensor t = torch::from_blob(shape.data(), {(int)shape.size()},options);
-        return t ;
+    at::IntArrayRef shape() const{
+        auto _shape  = this->block_.values_shape();
+        std::vector<int64_t> shapei64(_shape.begin(), _shape.end());
+        at::IntArrayRef shape(shapei64);
+        //auto options = torch::TensorOptions().dtype(at::kLong);
+        //torch::Tensor t = torch::from_blob(shape.data(), {(int)shape.size()},options);
+        return shape ;
     }
 
     /// Access the component `Labels` for this block.

--- a/metatensor-torch/src/block.cpp
+++ b/metatensor-torch/src/block.cpp
@@ -36,6 +36,11 @@ TensorBlockHolder::TensorBlockHolder(
         /* parent */ torch::IValue()
     )
 {
+    auto _shape  = this->block_.values_shape();
+    for (auto i :_shape){
+        shapei64.push_back(i);
+    }
+    
     auto values_device = this->values().device();
     if (values_device != this->samples()->values().device()) {
         C10_THROW_ERROR(ValueError,

--- a/metatensor-torch/src/block.cpp
+++ b/metatensor-torch/src/block.cpp
@@ -36,10 +36,6 @@ TensorBlockHolder::TensorBlockHolder(
         /* parent */ torch::IValue()
     )
 {
-    auto _shape  = this->block_.values_shape();
-    for (auto i :_shape){
-        shapei64.push_back(i);
-    }
     
     auto values_device = this->values().device();
     if (values_device != this->samples()->values().device()) {

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -184,6 +184,7 @@ TORCH_LIBRARY(metatensor, m) {
         .def_property("samples", &TensorBlockHolder::samples)
         .def_property("components", &TensorBlockHolder::components)
         .def_property("properties", &TensorBlockHolder::properties)
+        .def_property("shape", &TensorBlockHolder::shape )
         .def("add_gradient", &TensorBlockHolder::add_gradient, DOCSTRING,
             {torch::arg("parameter"), torch::arg("gradient")}
         )

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -178,6 +178,7 @@ TORCH_LIBRARY(metatensor, m) {
         )
         .def("__repr__", &TensorBlockHolder::repr)
         .def("__str__", &TensorBlockHolder::repr)
+        .def("__len__", &TensorBlockHolder::len )
         .def("copy", &TensorBlockHolder::copy)
         .def_property("values", &TensorBlockHolder::values)
         .def_property("samples", &TensorBlockHolder::samples)

--- a/metatensor-torch/tests/block.cpp
+++ b/metatensor-torch/tests/block.cpp
@@ -14,6 +14,8 @@ TEST_CASE("Blocks") {
             LabelsHolder::create({"p"}, {{0}, {1}})
         );
 
+        CHECK((block.len == 2));
+        CHECK((block.shape() == block.values().sizes()));
         CHECK((block.values().sizes() == std::vector<int64_t>{3, 2}));
         CHECK(torch::all(block.values() == 11.0).item<bool>());
 

--- a/metatensor-torch/tests/block.cpp
+++ b/metatensor-torch/tests/block.cpp
@@ -1,5 +1,4 @@
 #include <torch/torch.h>
-#include <iostream>
 
 #include <metatensor/torch.hpp>
 using namespace metatensor_torch;

--- a/metatensor-torch/tests/block.cpp
+++ b/metatensor-torch/tests/block.cpp
@@ -1,4 +1,5 @@
 #include <torch/torch.h>
+#include <iostream>
 
 #include <metatensor/torch.hpp>
 using namespace metatensor_torch;
@@ -13,8 +14,7 @@ TEST_CASE("Blocks") {
             {},
             LabelsHolder::create({"p"}, {{0}, {1}})
         );
-
-        CHECK((block.len == 2));
+        CHECK((block.len() == 3));
         CHECK((block.shape() == block.values().sizes()));
         CHECK((block.values().sizes() == std::vector<int64_t>{3, 2}));
         CHECK(torch::all(block.values() == 11.0).item<bool>());

--- a/python/metatensor-core/metatensor/block.py
+++ b/python/metatensor-core/metatensor/block.py
@@ -192,9 +192,7 @@ class TensorBlock:
     @property
     def shape(self):
         """
-        Get the shape of the values stored in this block
-        (i.e. the number of samples, of components, of properties
-        in the block)
+        Get the shape of the values  array in this block.
         """
         return self.values.shape
 

--- a/python/metatensor-core/metatensor/block.py
+++ b/python/metatensor-core/metatensor/block.py
@@ -184,7 +184,8 @@ class TensorBlock:
 
     def __len__(self):
         """
-        Get the length of the values stored in this block (i.e. the number of samples in the block)
+        Get the length of the values stored in this block
+        (i.e. the number of samples in the block)
         """
         return len(self.values)
 

--- a/python/metatensor-core/metatensor/block.py
+++ b/python/metatensor-core/metatensor/block.py
@@ -182,6 +182,12 @@ class TensorBlock:
             "TensorMap first"
         )
 
+    def __len__(self):
+        """
+        get len of the values array
+        """
+        return len(self.values)
+
     def copy(self) -> "TensorBlock":
         """
         get a deep copy of this block, including all the data and metadata

--- a/python/metatensor-core/metatensor/block.py
+++ b/python/metatensor-core/metatensor/block.py
@@ -182,12 +182,21 @@ class TensorBlock:
             "TensorMap first"
         )
 
-    def __len__(self):
+    def __len__(self) -> int:
         """
         Get the length of the values stored in this block
         (i.e. the number of samples in the block)
         """
         return len(self.values)
+
+    @property
+    def shape(self):
+        """
+        Get the shape of the values stored in this block
+        (i.e. the number of samples, of components, of properties
+        in the block)
+        """
+        return self.values.shape
 
     def copy(self) -> "TensorBlock":
         """

--- a/python/metatensor-core/metatensor/block.py
+++ b/python/metatensor-core/metatensor/block.py
@@ -184,7 +184,7 @@ class TensorBlock:
 
     def __len__(self):
         """
-        get len of the values array
+        Get the length of the values stored in this block (i.e. the number of samples in the block)
         """
         return len(self.values)
 

--- a/python/metatensor-core/tests/blocks.py
+++ b/python/metatensor-core/tests/blocks.py
@@ -45,6 +45,10 @@ def test_len(block):
     assert len(block) == len(block.values)
 
 
+def test_shape(block):
+    assert block.shape == block.values.shape
+
+
 def test_constructor_errors():
     values = np.full((3, 3, 2, 2), -1.0)
     samples = Labels(["s"], np.array([[0], [2], [4]]))

--- a/python/metatensor-core/tests/blocks.py
+++ b/python/metatensor-core/tests/blocks.py
@@ -41,6 +41,10 @@ def block_components():
     )
 
 
+def test_len(block):
+    assert len(block) == len(block.values)
+
+
 def test_constructor_errors():
     values = np.full((3, 3, 2, 2), -1.0)
     samples = Labels(["s"], np.array([[0], [2], [4]]))

--- a/python/metatensor-torch/metatensor/torch/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/documentation.py
@@ -674,6 +674,16 @@ class TensorBlock:
             .. _pytorch-115639: https://github.com/pytorch/pytorch/issues/115639
         """
 
+    def __len__(self) -> int:
+        """Get the length of the values stored in this block
+        (i.e. the number of samples in the :py:class:`TensorBlock`)"""
+
+    @property
+    def shape(self):
+        """
+        Get the shape of the values  array in this block.
+        """
+
     @property
     def values(self) -> torch.Tensor:
         """get the values for this block"""

--- a/python/metatensor-torch/tests/block.py
+++ b/python/metatensor-torch/tests/block.py
@@ -343,6 +343,12 @@ class TensorBlockWrap:
     def __repr__(self) -> str:
         return self._c.__repr__()
 
+    def __len__(self) -> int:
+        return self._c.__len__()
+
+    def shape(self):
+        return self._c.shape
+
     def copy(self) -> TensorBlock:
         return self._c.copy()
 

--- a/python/metatensor-torch/tests/block.py
+++ b/python/metatensor-torch/tests/block.py
@@ -36,6 +36,8 @@ def test_constructor():
     assert block.samples.names == ["s"]
     assert block.components == []
     assert block.properties.names == ["p"]
+    assert len(block) == len(block.values)
+    assert block.shape == list(block.values.shape)
 
 
 def test_repr():


### PR DESCRIPTION
add a __len__ function to the block.
I found it annoying not to be able to do len(block). 
It is not revolutionary so if you do not like you can also not merge it.

<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1558537230.zip)

<!-- download-section Documentation end -->