### PR TITLE
Pin tox version in tox.ini

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,9 +25,7 @@ jobs:
       - name: install python dependencies
         run: |
           python -m pip install --upgrade pip
-          # https://github.com/tox-dev/tox/issues/3238
-          python -m pip install tox==4.14.0
-          python -m pip install coverage
+          python -m pip install tox coverage
 
       - name: cache tox environments
         uses: actions/cache@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,8 +28,7 @@ jobs:
           python-version: "3.12"
       - name: install dependencies
         run: |
-          # https://github.com/tox-dev/tox/issues/3238
-          python -m pip install tox==4.14.0
+          python -m pip install tox
           sudo apt install doxygen
       - name: build documentation
         env:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -65,9 +65,7 @@ jobs:
       - name: install tests dependencies
         run: |
           python -m pip install --upgrade pip
-
-          # https://github.com/tox-dev/tox/issues/3238
-          python -m pip install tox==4.14.0
+          python -m pip install tox
 
       - name: run tests
         run: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-min_version = 4.9.0
+# https://github.com/tox-dev/tox/issues/3238
+requires = tox==4.14.0
+
 # these are the default environments, i.e. the list of tests running when you
 # execute `tox` in the command-line without anything else
 envlist =


### PR DESCRIPTION
This way it will work automatically regardless of the version installed locally



# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1566011521.zip)

<!-- download-section Documentation end -->