### PR TITLE
Re-enabled builds for PyTorch 2.3 and 2.4 on Windows

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -89,7 +89,7 @@ jobs:
           CIBW_BUILD: cp311-*
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: ${{ matrix.cibw-arch }}
-          CIBW_BUILD_VERBOSITY: 2
+          CIBW_BUILD_VERBOSITY: 1
           CIBW_MANYLINUX_X86_64_IMAGE: rustc-manylinux2014_x86_64
           CIBW_MANYLINUX_AARCH64_IMAGE: rustc-manylinux2014_aarch64
           CIBW_ENVIRONMENT: >
@@ -109,7 +109,7 @@ jobs:
     name: ${{ matrix.name }} (torch v${{ matrix.torch-version }})
     strategy:
       matrix:
-        torch-version: ['1.12', '1.13', '2.0', '2.1', '2.2', '2.3']
+        torch-version: ['1.12', '1.13', '2.0', '2.1', '2.2', '2.3', '2.4']
         arch: ['arm64', 'x86_64']
         os: ['ubuntu-22.04', 'macos-13', 'macos-14', 'windows-2019']
         exclude:
@@ -118,13 +118,12 @@ jobs:
           - {os: macos-13, arch: arm64}
           # no arm64-windows build
           - {os: windows-2019, arch: arm64}
-          # https://github.com/pytorch/pytorch/issues/125109
-          - {os: windows-2019, torch-version: '2.3'}
-          # arm64-macos is only supported for torch >= 2.0
+          # arch arm64 on macos is only supported for torch >= 2.0
           - {os: macos-14, arch: arm64, torch-version: '1.12'}
           - {os: macos-14, arch: arm64, torch-version: '1.13'}
-          # x86_64-macos is only supported for torch <2.3
+          # arch x86_64 on macos is only supported for torch <2.3
           - {os: macos-13, arch: x86_64, torch-version: '2.3'}
+          - {os: macos-13, arch: x86_64, torch-version: '2.4'}
         include:
           # add `cibw-arch` and `rust-target` to the different configurations
           - name: x86_64 Linux
@@ -192,7 +191,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.cibw-python}}
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: ${{ matrix.cibw-arch }}
-          CIBW_BUILD_VERBOSITY: 2
+          CIBW_BUILD_VERBOSITY: 1
           CIBW_MANYLINUX_X86_64_IMAGE: rustc-manylinux2014_x86_64
           CIBW_MANYLINUX_AARCH64_IMAGE: rustc-manylinux2014_aarch64
           # METATENSOR_NO_LOCAL_DEPS is set to 1 when building a tag of

--- a/scripts/create-torch-versions-range.py
+++ b/scripts/create-torch-versions-range.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
         if version.strip() == "":
             continue
 
-        match = re.match(r"Requires-Dist: torch ==(\d+)\.(\d+)\.\*", version)
+        match = re.match(r"Requires-Dist: torch[ ]?==(\d+)\.(\d+)\.\*", version)
         if match is None:
             raise ValueError(f"unexpected Requires-Dist format: {version}")
 


### PR DESCRIPTION
As it says on the tin! PyTorch 2.3.1 should have fixed the previous issue on Windows.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1815147920.zip)

<!-- download-section Documentation end -->

<!-- download-section Build Python wheels start -->
⚙️ [Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1815206759.zip)

<!-- download-section Build Python wheels end -->