### PR TITLE
Add `energy_ensemble` as a new standard output for atomistic models

### DIFF
--- a/docs/src/atomistic/outputs.rst
+++ b/docs/src/atomistic/outputs.rst
@@ -15,6 +15,8 @@ encouraged to come together, define the metadata they need and add a new section
 to this page.
 
 
+.. _energy:
+
 Energy
 ^^^^^^
 
@@ -54,6 +56,8 @@ have the following metadata:
     - ``"energy"``
     - the energy must have a single property dimension named ``"energy"``, with
       a single entry set to ``0``.
+
+.. _energy-gradients:
 
 Energy gradients
 ----------------
@@ -119,3 +123,43 @@ The following gradients can be defined and requested with
     - ``["xyz_1", "xyz_2"]``
     - Both ``"xyz_1"`` and ``"xyz_2"`` have values ``[0, 1, 2]``, and correspond
       to the two axes of the 3x3 strain matrix :math:`\epsilon`.
+
+
+Energy ensemble
+^^^^^^^^^^^^^^^
+
+An ensemble of energies is associated with the ``"energy_ensemble"`` key in the
+model outputs, and must have the following metadata:
+
+.. list-table:: Metadata for energy ensemble output
+  :widths: 2 3 7
+  :header-rows: 1
+
+  * - Metadata
+    - Names
+    - Description
+
+  * - keys
+    - same as `Energy`_
+    - same as `Energy`_
+
+  * - samples
+    - same as `Energy`_
+    - same as `Energy`_
+
+  * - components
+    - same as `Energy`_
+    - same as `Energy`_
+
+  * - properties
+    - ``"ensemble_member"``
+    - the energy ensemble must have a single property dimension named
+      ``"ensemble_member"``, with entries ranging from 0 to the number of
+      members of the ensemble minus one.
+
+
+Energy ensemble gradients
+-------------------------
+
+The gradient metadata for energy ensemble is the same as for the ``energy``
+output (see `Energy gradients`_).

--- a/docs/src/atomistic/outputs.rst
+++ b/docs/src/atomistic/outputs.rst
@@ -129,7 +129,11 @@ Energy ensemble
 ^^^^^^^^^^^^^^^
 
 An ensemble of energies is associated with the ``"energy_ensemble"`` key in the
-model outputs, and must have the following metadata:
+model outputs. Such ensembles are sometimes used to perform uncertainty
+quantification, using multiple prediction to estimate an error on the mean
+prediction.
+
+Energy ensembles must have the following metadata:
 
 .. list-table:: Metadata for energy ensemble output
   :widths: 2 3 7
@@ -152,10 +156,10 @@ model outputs, and must have the following metadata:
     - same as `Energy`_
 
   * - properties
-    - ``"ensemble_member"``
+    - ``"energy"``
     - the energy ensemble must have a single property dimension named
-      ``"ensemble_member"``, with entries ranging from 0 to the number of
-      members of the ensemble minus one.
+      ``"energy"``, with entries ranging from 0 to the number of members of the
+      ensemble minus one.
 
 
 Energy ensemble gradients

--- a/metatensor-torch/src/atomistic/model.cpp
+++ b/metatensor-torch/src/atomistic/model.cpp
@@ -136,7 +136,8 @@ ModelOutput ModelOutputHolder::from_json(std::string_view json) {
 /******************************************************************************/
 
 std::unordered_set<std::string> KNOWN_OUTPUTS = {
-    "energy"
+    "energy",
+    "energy_ensemble"
 };
 
 void ModelCapabilitiesHolder::set_outputs(torch::Dict<std::string, ModelOutput> outputs) {

--- a/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
@@ -44,30 +44,46 @@ def _check_outputs(
             )
 
         if name == "energy":
-            _check_energy(systems, request, selected_atoms, energy=value)
+            _check_energy_like(
+                "energy",
+                value,
+                systems,
+                request,
+                selected_atoms,
+            )
         elif name == "energy_ensemble":
-            _check_energy_ensemble(
-                systems, request, selected_atoms, energy_ensemble=value
+            _check_energy_like(
+                "energy_ensemble",
+                value,
+                systems,
+                request,
+                selected_atoms,
             )
         else:
             # this is a non-standard output, there is nothing to check
             continue
 
 
-def _check_energy(
+def _check_energy_like(
+    name: str,
+    value: TensorMap,
     systems: List[System],
     request: ModelOutput,
     selected_atoms: Optional[Labels],
-    energy: TensorMap,
 ):
-    """Check the "energy" output metadata"""
-    if energy.keys != Labels("_", torch.tensor([[0]])):
+    """
+    Check either "energy" or "energy_ensemble" output metadata
+    """
+
+    assert name in ["energy", "energy_ensemble"]
+
+    if value.keys != Labels("_", torch.tensor([[0]])):
         raise ValueError(
-            "invalid keys for 'energy' output: expected `Labels('_', [[0]])`"
+            f"invalid keys for '{name}' output: expected `Labels('_', [[0]])`"
         )
 
-    device = energy.device
-    energy_block = energy.block_by_id(0)
+    device = value.device
+    energy_block = value.block_by_id(0)
 
     if request.per_atom:
         expected_samples_names = ["system", "atom"]
@@ -76,7 +92,7 @@ def _check_energy(
 
     if energy_block.samples.names != expected_samples_names:
         raise ValueError(
-            "invalid sample names for 'energy' output: "
+            f"invalid sample names for '{name}' output: "
             f"expected {expected_samples_names}, got {energy_block.samples.names}"
         )
 
@@ -95,7 +111,7 @@ def _check_energy(
 
         if len(expected_samples.union(energy_block.samples)) != len(expected_samples):
             raise ValueError(
-                "invalid samples entries for 'energy' output, they do not match the "
+                f"invalid samples entries for '{name}' output, they do not match the "
                 f"`systems` and `selected_atoms`. Expected samples:\n{expected_samples}"
             )
 
@@ -111,48 +127,58 @@ def _check_energy(
 
         if len(expected_samples.union(energy_block.samples)) != len(expected_samples):
             raise ValueError(
-                "invalid samples entries for 'energy' output, they do not match the "
+                f"invalid samples entries for '{name}' output, they do not match the "
                 f"`systems` and `selected_atoms`. Expected samples:\n{expected_samples}"
             )
 
     if len(energy_block.components) != 0:
         raise ValueError(
-            "invalid components for 'energy' output: components should be empty"
+            f"invalid components for '{name}' output: components should be empty"
         )
 
-    if energy_block.properties != Labels("energy", torch.tensor([[0]], device=device)):
-        raise ValueError(
-            "invalid properties for 'energy' output: expected `Labels('energy', [[0]])`"
+    # the only difference between energy & energy_ensemble is in the properties
+    if name == "energy":
+        expected_properties = Labels("energy", torch.tensor([[0]], device=device))
+        message = "`Labels('energy', [[0]])`"
+    else:
+        assert name == "energy_ensemble"
+        n_ensemble_members = energy_block.values.shape[-1]
+        expected_properties = Labels(
+            "energy", torch.arange(n_ensemble_members, device=device).reshape(-1, 1)
         )
+        message = "`Labels('energy', [[0], ..., [n]])`"
+
+    if energy_block.properties != expected_properties:
+        raise ValueError(f"invalid properties for '{name}' output: expected {message}")
 
     for parameter, gradient in energy_block.gradients():
         if parameter not in ["strain", "positions"]:
-            raise ValueError(f"invalid gradient for 'energy' output: {parameter}")
+            raise ValueError(f"invalid gradient for '{name}' output: {parameter}")
 
         xyz = torch.tensor([[0], [1], [2]], device=device)
         # strain gradient checks
         if parameter == "strain":
             if gradient.samples.names != ["sample"]:
                 raise ValueError(
-                    "invalid samples for 'energy' output 'strain' gradients: "
+                    f"invalid samples for '{name}' output 'strain' gradients: "
                     f"expected the names to be ['sample'], got {gradient.samples.names}"
                 )
 
             if len(gradient.components) != 2:
                 raise ValueError(
-                    "invalid components for 'energy' output 'strain' gradients: "
+                    f"invalid components for '{name}' output 'strain' gradients: "
                     "expected two components"
                 )
 
             if gradient.components[0] != Labels("xyz_1", xyz):
                 raise ValueError(
-                    "invalid components for 'energy' output 'strain' gradients: "
+                    f"invalid components for '{name}' output 'strain' gradients: "
                     "expected Labels('xyz_1', [[0], [1], [2]]) for the first component"
                 )
 
             if gradient.components[1] != Labels("xyz_2", xyz):
                 raise ValueError(
-                    "invalid components for 'energy' output 'strain' gradients: "
+                    f"invalid components for '{name}' output 'strain' gradients: "
                     "expected Labels('xyz_2', [[0], [1], [2]]) for the second component"
                 )
 
@@ -160,164 +186,19 @@ def _check_energy(
         if parameter == "positions":
             if gradient.samples.names != ["sample", "system", "atom"]:
                 raise ValueError(
-                    "invalid samples for 'energy' output 'positions' gradients: "
+                    f"invalid samples for '{name}' output 'positions' gradients: "
                     "expected the names to be ['sample', 'system', 'atom'], "
                     f"got {gradient.samples.names}"
                 )
 
             if len(gradient.components) != 1:
                 raise ValueError(
-                    "invalid components for 'energy' output 'positions' gradients: "
+                    f"invalid components for '{name}' output 'positions' gradients: "
                     "expected one component"
                 )
 
             if gradient.components[0] != Labels("xyz", xyz):
                 raise ValueError(
-                    "invalid components for 'energy' output 'positions' gradients: "
+                    f"invalid components for '{name}' output 'positions' gradients: "
                     "expected Labels('xyz', [[0], [1], [2]]) for the first component"
-                )
-
-
-def _check_energy_ensemble(
-    systems: List[System],
-    request: ModelOutput,
-    selected_atoms: Optional[Labels],
-    energy_ensemble: TensorMap,
-):
-    """Check the "energy_ensemble" output metadata"""
-    if energy_ensemble.keys != Labels("_", torch.tensor([[0]])):
-        raise ValueError(
-            "invalid keys for 'energy_ensemble' output: expected `Labels('_', [[0]])`"
-        )
-
-    device = energy_ensemble.device
-    energy_ensemble_block = energy_ensemble.block_by_id(0)
-
-    if request.per_atom:
-        expected_samples_names = ["system", "atom"]
-    else:
-        expected_samples_names = ["system"]
-
-    if energy_ensemble_block.samples.names != expected_samples_names:
-        raise ValueError(
-            "invalid sample names for 'energy_ensemble' output: "
-            f"expected {expected_samples_names}, got "
-            f"{energy_ensemble_block.samples.names}"
-        )
-
-    # check samples values from systems & selected_atoms
-    if request.per_atom:
-        expected_values: List[List[int]] = []
-        for s, system in enumerate(systems):
-            for a in range(len(system)):
-                expected_values.append([s, a])
-
-        expected_samples = Labels(
-            ["system", "atom"], torch.tensor(expected_values, device=device)
-        )
-        if selected_atoms is not None:
-            expected_samples = expected_samples.intersection(selected_atoms)
-
-        if len(expected_samples.union(energy_ensemble_block.samples)) != len(
-            expected_samples
-        ):
-            raise ValueError(
-                "invalid samples entries for 'energy_ensemble_block' output, they "
-                "do not match the `systems` and `selected_atoms`. "
-                f"Expected samples:\n{expected_samples}"
-            )
-
-    else:
-        expected_samples = Labels(
-            "system", torch.arange(len(systems), device=device).reshape(-1, 1)
-        )
-        if selected_atoms is not None:
-            selected_systems = Labels(
-                "system", torch.unique(selected_atoms.column("system")).reshape(-1, 1)
-            )
-            expected_samples = expected_samples.intersection(selected_systems)
-
-        if len(expected_samples.union(energy_ensemble_block.samples)) != len(
-            expected_samples
-        ):
-            raise ValueError(
-                "invalid samples entries for 'energy_ensemble' output, they do not "
-                "match the `systems` and `selected_atoms`. "
-                f"Expected samples:\n{expected_samples}"
-            )
-
-    if len(energy_ensemble_block.components) != 0:
-        raise ValueError(
-            "invalid components for 'energy_ensemble' output: components "
-            "should be empty"
-        )
-
-    if energy_ensemble_block.properties != Labels(
-        "ensemble_member",
-        torch.arange(energy_ensemble_block.values.shape[1], device=device).reshape(
-            -1, 1
-        ),
-    ):
-        raise ValueError(
-            "invalid properties for 'energy_ensemble' output: expected a Labels "
-            "object with the name 'ensemble_member' and the values being the indices "
-            "of the ensemble members from 0 to the number of ensemble members minus "
-            "one."
-        )
-
-    for parameter, gradient in energy_ensemble_block.gradients():
-        if parameter not in ["strain", "positions"]:
-            raise ValueError(
-                f"invalid gradient for 'energy_ensemble' output: {parameter}"
-            )
-
-        xyz = torch.tensor([[0], [1], [2]], device=device)
-        # strain gradient checks
-        if parameter == "strain":
-            if gradient.samples.names != ["sample"]:
-                raise ValueError(
-                    "invalid samples for 'energy_ensemble' output 'strain' gradients: "
-                    f"expected the names to be ['sample'], got {gradient.samples.names}"
-                )
-
-            if len(gradient.components) != 2:
-                raise ValueError(
-                    "invalid components for 'energy_ensemble' output 'strain' "
-                    "gradients: expected two components"
-                )
-
-            if gradient.components[0] != Labels("xyz_1", xyz):
-                raise ValueError(
-                    "invalid components for 'energy_ensemble' output 'strain' "
-                    "gradients: expected Labels('xyz_1', [[0], [1], [2]]) for the "
-                    "first component"
-                )
-
-            if gradient.components[1] != Labels("xyz_2", xyz):
-                raise ValueError(
-                    "invalid components for 'energy_ensemble' output 'strain' "
-                    "gradients: expected Labels('xyz_2', [[0], [1], [2]]) for the "
-                    "second component"
-                )
-
-        # positions gradient checks
-        if parameter == "positions":
-            if gradient.samples.names != ["sample", "system", "atom"]:
-                raise ValueError(
-                    "invalid samples for 'energy_ensemble' output 'positions' "
-                    "gradients: expected the names to be "
-                    f"['sample', 'system', 'atom'], got {gradient.samples.names}"
-                )
-
-            if len(gradient.components) != 1:
-                raise ValueError(
-                    "invalid components for 'energy_ensemble' output 'positions' "
-                    "gradients: expected one component"
-                )
-
-            if gradient.components[0] != Labels("xyz", xyz):
-                raise ValueError(
-                    "invalid components for 'energy_ensemble' output 'positions' "
-                    "gradients: expected Labels('xyz', [[0], [1], [2]]) for the first "
-                    "component"
                 )

--- a/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
@@ -45,6 +45,10 @@ def _check_outputs(
 
         if name == "energy":
             _check_energy(systems, request, selected_atoms, energy=value)
+        elif name == "energy_ensemble":
+            _check_energy_ensemble(
+                systems, request, selected_atoms, energy_ensemble=value
+            )
         else:
             # this is a non-standard output, there is nothing to check
             continue
@@ -171,4 +175,149 @@ def _check_energy(
                 raise ValueError(
                     "invalid components for 'energy' output 'positions' gradients: "
                     "expected Labels('xyz', [[0], [1], [2]]) for the first component"
+                )
+
+
+def _check_energy_ensemble(
+    systems: List[System],
+    request: ModelOutput,
+    selected_atoms: Optional[Labels],
+    energy_ensemble: TensorMap,
+):
+    """Check the "energy_ensemble" output metadata"""
+    if energy_ensemble.keys != Labels("_", torch.tensor([[0]])):
+        raise ValueError(
+            "invalid keys for 'energy_ensemble' output: expected `Labels('_', [[0]])`"
+        )
+
+    device = energy_ensemble.device
+    energy_ensemble_block = energy_ensemble.block_by_id(0)
+
+    if request.per_atom:
+        expected_samples_names = ["system", "atom"]
+    else:
+        expected_samples_names = ["system"]
+
+    if energy_ensemble_block.samples.names != expected_samples_names:
+        raise ValueError(
+            "invalid sample names for 'energy_ensemble' output: "
+            f"expected {expected_samples_names}, got "
+            f"{energy_ensemble_block.samples.names}"
+        )
+
+    # check samples values from systems & selected_atoms
+    if request.per_atom:
+        expected_values: List[List[int]] = []
+        for s, system in enumerate(systems):
+            for a in range(len(system)):
+                expected_values.append([s, a])
+
+        expected_samples = Labels(
+            ["system", "atom"], torch.tensor(expected_values, device=device)
+        )
+        if selected_atoms is not None:
+            expected_samples = expected_samples.intersection(selected_atoms)
+
+        if len(expected_samples.union(energy_ensemble_block.samples)) != len(
+            expected_samples
+        ):
+            raise ValueError(
+                "invalid samples entries for 'energy_ensemble_block' output, they "
+                "do not match the `systems` and `selected_atoms`. "
+                f"Expected samples:\n{expected_samples}"
+            )
+
+    else:
+        expected_samples = Labels(
+            "system", torch.arange(len(systems), device=device).reshape(-1, 1)
+        )
+        if selected_atoms is not None:
+            selected_systems = Labels(
+                "system", torch.unique(selected_atoms.column("system")).reshape(-1, 1)
+            )
+            expected_samples = expected_samples.intersection(selected_systems)
+
+        if len(expected_samples.union(energy_ensemble_block.samples)) != len(
+            expected_samples
+        ):
+            raise ValueError(
+                "invalid samples entries for 'energy_ensemble' output, they do not "
+                "match the `systems` and `selected_atoms`. "
+                f"Expected samples:\n{expected_samples}"
+            )
+
+    if len(energy_ensemble_block.components) != 0:
+        raise ValueError(
+            "invalid components for 'energy_ensemble' output: components "
+            "should be empty"
+        )
+
+    if energy_ensemble_block.properties != Labels(
+        "ensemble_member",
+        torch.arange(energy_ensemble_block.values.shape[1], device=device).reshape(
+            -1, 1
+        ),
+    ):
+        raise ValueError(
+            "invalid properties for 'energy_ensemble' output: expected a Labels "
+            "object with the name 'ensemble_member' and the values being the indices "
+            "of the ensemble members from 0 to the number of ensemble members minus "
+            "one."
+        )
+
+    for parameter, gradient in energy_ensemble_block.gradients():
+        if parameter not in ["strain", "positions"]:
+            raise ValueError(
+                f"invalid gradient for 'energy_ensemble' output: {parameter}"
+            )
+
+        xyz = torch.tensor([[0], [1], [2]], device=device)
+        # strain gradient checks
+        if parameter == "strain":
+            if gradient.samples.names != ["sample"]:
+                raise ValueError(
+                    "invalid samples for 'energy_ensemble' output 'strain' gradients: "
+                    f"expected the names to be ['sample'], got {gradient.samples.names}"
+                )
+
+            if len(gradient.components) != 2:
+                raise ValueError(
+                    "invalid components for 'energy_ensemble' output 'strain' "
+                    "gradients: expected two components"
+                )
+
+            if gradient.components[0] != Labels("xyz_1", xyz):
+                raise ValueError(
+                    "invalid components for 'energy_ensemble' output 'strain' "
+                    "gradients: expected Labels('xyz_1', [[0], [1], [2]]) for the "
+                    "first component"
+                )
+
+            if gradient.components[1] != Labels("xyz_2", xyz):
+                raise ValueError(
+                    "invalid components for 'energy_ensemble' output 'strain' "
+                    "gradients: expected Labels('xyz_2', [[0], [1], [2]]) for the "
+                    "second component"
+                )
+
+        # positions gradient checks
+        if parameter == "positions":
+            if gradient.samples.names != ["sample", "system", "atom"]:
+                raise ValueError(
+                    "invalid samples for 'energy_ensemble' output 'positions' "
+                    "gradients: expected the names to be "
+                    f"['sample', 'system', 'atom'], got {gradient.samples.names}"
+                )
+
+            if len(gradient.components) != 1:
+                raise ValueError(
+                    "invalid components for 'energy_ensemble' output 'positions' "
+                    "gradients: expected one component"
+                )
+
+            if gradient.components[0] != Labels("xyz", xyz):
+                raise ValueError(
+                    "invalid components for 'energy_ensemble' output 'positions' "
+                    "gradients: expected Labels('xyz', [[0], [1], [2]]) for the first "
+                    "component"
                 )

--- a/python/metatensor-torch/tests/atomistic/model.py
+++ b/python/metatensor-torch/tests/atomistic/model.py
@@ -9,6 +9,7 @@ from metatensor.torch import Labels, TensorBlock, TensorMap
 from metatensor.torch.atomistic import (
     MetatensorAtomisticModel,
     ModelCapabilities,
+    ModelEvaluationOptions,
     ModelMetadata,
     ModelOutput,
     NeighborListOptions,
@@ -144,6 +145,32 @@ class FullModel(torch.nn.Module):
         return result
 
 
+class EnergyEnsembleModel(torch.nn.Module):
+    """A metatensor atomistic model returning an energy ensemble"""
+
+    def forward(
+        self,
+        systems: List[System],
+        outputs: Dict[str, ModelOutput],
+        selected_atoms: Optional[Labels] = None,
+    ) -> Dict[str, TensorMap]:
+        assert "energy_ensemble" in outputs
+        assert not outputs["energy_ensemble"].per_atom
+        assert selected_atoms is None
+
+        return_dict: Dict[str, TensorMap] = {}
+        block = TensorBlock(
+            values=torch.tensor([[0.0, 1.0, 2.0]] * len(systems), dtype=torch.float64),
+            samples=Labels("system", torch.arange(len(systems)).reshape(-1, 1)),
+            components=[],
+            properties=Labels("ensemble_member", torch.tensor([[0], [1], [2]])),
+        )
+        return_dict["energy_ensemble"] = TensorMap(
+            Labels("_", torch.tensor([[0]])), [block]
+        )
+        return return_dict
+
+
 def test_requested_neighbor_lists():
     model = FullModel()
     model.train(False)
@@ -240,3 +267,49 @@ def test_bad_capabilities():
     )
     with pytest.raises(ValueError, match=message):
         ModelCapabilities(outputs={"not-a-standard::": ModelOutput()})
+
+
+def test_energy_ensemble_model():
+    model = EnergyEnsembleModel()
+    model.eval()
+
+    capabilities = ModelCapabilities(
+        length_unit="angstrom",
+        atomic_types=[1, 2, 3],
+        interaction_range=4.3,
+        outputs={
+            "energy_ensemble": ModelOutput(
+                quantity="",
+                unit="",
+                per_atom=False,
+                explicit_gradients=[],
+            ),
+        },
+        supported_devices=["cpu"],
+        dtype="float64",
+    )
+
+    metadata = ModelMetadata()
+    atomistic = MetatensorAtomisticModel(model, metadata, capabilities)
+
+    system = System(
+        types=torch.tensor([1, 2]),
+        positions=torch.tensor(
+            [[1, 1, 1], [0, 0, 0]], dtype=torch.float64, requires_grad=True
+        ),
+        cell=torch.zeros([3, 3], dtype=torch.float64),
+    )
+
+    outputs = {
+        "energy_ensemble": ModelOutput(quantity="energy", unit="eV", per_atom=False),
+    }
+    options = ModelEvaluationOptions(
+        length_unit="angstrom", outputs=outputs, selected_atoms=None
+    )
+
+    result = atomistic([system, system], options, check_consistency=True)
+    assert "energy_ensemble" in result
+    assert result["energy_ensemble"].keys == Labels("_", torch.tensor([[0]]))
+    assert result["energy_ensemble"].block().values.shape[0] == 2
+    assert result["energy_ensemble"].block().samples.names == ["system"]
+    assert result["energy_ensemble"].block().properties.names == ["ensemble_member"]

--- a/python/metatensor-torch/tests/atomistic/outputs.py
+++ b/python/metatensor-torch/tests/atomistic/outputs.py
@@ -1,0 +1,74 @@
+from typing import Dict, List, Optional
+
+import torch
+
+from metatensor.torch import Labels, TensorBlock, TensorMap
+from metatensor.torch.atomistic import (
+    MetatensorAtomisticModel,
+    ModelCapabilities,
+    ModelEvaluationOptions,
+    ModelMetadata,
+    ModelOutput,
+    System,
+)
+
+
+class EnergyEnsembleModel(torch.nn.Module):
+    """A metatensor atomistic model returning an energy ensemble"""
+
+    def forward(
+        self,
+        systems: List[System],
+        outputs: Dict[str, ModelOutput],
+        selected_atoms: Optional[Labels] = None,
+    ) -> Dict[str, TensorMap]:
+        assert "energy_ensemble" in outputs
+        assert not outputs["energy_ensemble"].per_atom
+        assert selected_atoms is None
+
+        return_dict: Dict[str, TensorMap] = {}
+        block = TensorBlock(
+            values=torch.tensor([[0.0, 1.0, 2.0]] * len(systems), dtype=torch.float64),
+            samples=Labels("system", torch.arange(len(systems)).reshape(-1, 1)),
+            components=[],
+            properties=Labels("energy", torch.tensor([[0], [1], [2]])),
+        )
+        return_dict["energy_ensemble"] = TensorMap(
+            Labels("_", torch.tensor([[0]])), [block]
+        )
+        return return_dict
+
+
+def test_energy_ensemble_model():
+    model = EnergyEnsembleModel()
+
+    capabilities = ModelCapabilities(
+        length_unit="angstrom",
+        atomic_types=[1, 2, 3],
+        interaction_range=4.3,
+        outputs={"energy_ensemble": ModelOutput(per_atom=False)},
+        supported_devices=["cpu"],
+        dtype="float64",
+    )
+
+    atomistic = MetatensorAtomisticModel(model.eval(), ModelMetadata(), capabilities)
+
+    system = System(
+        types=torch.tensor([1, 2, 3]),
+        positions=torch.tensor([[1, 1, 1], [2, 2, 2], [3, 3, 3]], dtype=torch.float64),
+        cell=torch.zeros([3, 3], dtype=torch.float64),
+    )
+
+    options = ModelEvaluationOptions(
+        outputs={"energy_ensemble": ModelOutput(per_atom=False)}
+    )
+
+    result = atomistic([system, system], options, check_consistency=True)
+    assert "energy_ensemble" in result
+
+    ensemble = result["energy_ensemble"]
+
+    assert ensemble.keys == Labels("_", torch.tensor([[0]]))
+    assert list(ensemble.block().values.shape) == [2, 3]
+    assert ensemble.block().samples.names == ["system"]
+    assert ensemble.block().properties.names == ["energy"]


### PR DESCRIPTION
This PR implements ensembles of energies as a new standard output for atomistic models (#650). It also makes the necessary changes to the ASE calculator to make this property (which is not standard in ASE) available to the user. In addition, the dipole is also registered as a new property and added to the ASE calculator

TODO: actual conversion factors for dipoles

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1719201793.zip)

<!-- download-section Documentation end -->