### PR TITLE
Try to fix windows build on CI

### DIFF
--- a/metatensor-core/CMakeLists.txt
+++ b/metatensor-core/CMakeLists.txt
@@ -219,6 +219,8 @@ if (CARGO_VERSION_CHANGED)
 
         # Special case `msvcrt` to link with the debug version in Debug mode.
         list(TRANSFORM stripped_lib_list REPLACE "^msvcrt$" "\$<\$<CONFIG:Debug>:msvcrtd>")
+        # Don't try to pass a linker *flag* where CMake expects libraries
+        list(REMOVE_ITEM stripped_lib_list "/defaultlib:msvcrt")
 
         if (APPLE)
             # Prevent warnings about duplicated `System` in linked libraries
@@ -229,9 +231,9 @@ if (CARGO_VERSION_CHANGED)
         list(REMOVE_DUPLICATES stripped_lib_list)
         set(CARGO_DEFAULT_LIBRARIES "${stripped_lib_list}" CACHE INTERNAL "list of implicitly linked libraries")
 
-        if (${METATENSOR_MAIN_PROJECT})
+        # if (${METATENSOR_MAIN_PROJECT})
             message(STATUS "Cargo default link libraries are: ${CARGO_DEFAULT_LIBRARIES}")
-        endif()
+        # endif()
     else()
         message(FATAL_ERROR "could not find default static libs: `native-static-libs` not found in: `${cargo_static_libs_stderr}`")
     endif()


### PR DESCRIPTION
Rustc now includes `/defaultlib:msvcrt` in the `native-static-lib` output, but with our setup CMake interpret this as a library to link and not a linker flag. Since we are already linking to msvcrt anyway, I just remove this from the list of libraries we pass to CMake.


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1607891242.zip)

<!-- download-section Documentation end -->