### PR TITLE
Fix strain device in ASE calculator

### DIFF
--- a/python/metatensor-torch/metatensor/torch/atomistic/ase_calculator.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/ase_calculator.py
@@ -264,7 +264,7 @@ class MetatensorCalculator(ase.calculators.calculator.Calculator):
             if "stress" in properties:
                 do_backward = True
 
-                strain = torch.eye(3, requires_grad=True, device=positions.device, dtype=self._dtype)
+                strain = torch.eye(3, requires_grad=True, device=self._device, dtype=self._dtype)
 
                 positions = positions @ strain
                 positions.retain_grad()

--- a/python/metatensor-torch/metatensor/torch/atomistic/ase_calculator.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/ase_calculator.py
@@ -264,12 +264,12 @@ class MetatensorCalculator(ase.calculators.calculator.Calculator):
             if "stress" in properties:
                 do_backward = True
 
-                scaling = torch.eye(3, requires_grad=True, dtype=self._dtype)
+                strain = torch.eye(3, requires_grad=True, device=positions.device, dtype=self._dtype)
 
-                positions = positions @ scaling
+                positions = positions @ strain
                 positions.retain_grad()
 
-                cell = cell @ scaling
+                cell = cell @ strain
 
             if "stresses" in properties:
                 raise NotImplementedError("'stresses' are not implemented yet")
@@ -345,7 +345,7 @@ class MetatensorCalculator(ase.calculators.calculator.Calculator):
                 self.results["forces"] = forces_values.numpy()
 
             if "stress" in properties:
-                stress_values = -scaling.grad.reshape(3, 3) / atoms.cell.volume
+                stress_values = -strain.grad.reshape(3, 3) / atoms.cell.volume
                 stress_values = stress_values.to(device="cpu").to(dtype=torch.float64)
                 self.results["stress"] = _full_3x3_to_voigt_6_stress(
                     stress_values.numpy()

--- a/python/metatensor-torch/metatensor/torch/atomistic/ase_calculator.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/ase_calculator.py
@@ -264,7 +264,9 @@ class MetatensorCalculator(ase.calculators.calculator.Calculator):
             if "stress" in properties:
                 do_backward = True
 
-                strain = torch.eye(3, requires_grad=True, device=self._device, dtype=self._dtype)
+                strain = torch.eye(
+                    3, requires_grad=True, device=self._device, dtype=self._dtype
+                )
 
                 positions = positions @ strain
                 positions.retain_grad()


### PR DESCRIPTION
Fixes a small bug: the device wasn't chosen properly for the strain in the ASE calculator. The strain was also called "scaling", I've renamed it to strain for consistency within our codes



# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1623842506.zip)

<!-- download-section Documentation end -->