### PR TITLE
Do not export models on device

### DIFF
--- a/python/metatensor-torch/metatensor/torch/atomistic/model.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/model.py
@@ -459,7 +459,7 @@ class MetatensorAtomisticModel(torch.nn.Module):
         if os.environ.get("PYTORCH_JIT") == "0":
             raise RuntimeError(
                 "found PYTORCH_JIT=0 in the environment, "
-                "we can not export models without TorchScript"
+                "we can not save models without TorchScript"
             )
 
         try:
@@ -483,7 +483,7 @@ class MetatensorAtomisticModel(torch.nn.Module):
         extensions, deps = _collect_extensions(extensions_path=collect_extensions)
 
         torch.jit.save(
-            module,
+            module.to("cpu"),  # this allows to torch.jit.load without devices
             file,
             _extra_files={
                 "torch-version": torch.__version__,


### PR DESCRIPTION
If one exports a model on a device and then tries to load it when the device is not available anymore, you will get
`cpp_module = torch._C.import_ir_module(cu, os.fspath(f), map_location, _extra_files, _restore_shapes)  # type: ignore[call-arg]`
`RuntimeError: No CUDA GPUs are available`

As a result, we should always save on CPU and then it is the responsibility of whoever loads the model to change the device if needed

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
