### PR TITLE
Drop support for Python 3.8, require 3.9

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,10 +18,10 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            python-version: "3.8"
+            python-version: "3.9"
             torch-version: "1.12.*"
           - os: ubuntu-20.04
-            python-version: "3.8"
+            python-version: "3.9"
             torch-version: "2.3.*"
           - os: ubuntu-20.04
             python-version: "3.12"

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -21,7 +21,7 @@ on metatensor:
   use a version provided by your operating system. We need at least Rust version
   1.65 to build metatensor.
 - **Python**: you can install ``Python`` and ``pip`` from your operating system.
-  We require a Python version of at least 3.8.
+  We require a Python version of at least 3.9.
 - **tox**: a Python test runner, cf https://tox.readthedocs.io/en/latest/. You
   can install tox with ``pip install tox``.
 

--- a/metatensor-core/CHANGELOG.md
+++ b/metatensor-core/CHANGELOG.md
@@ -28,6 +28,10 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 - `TensorBlock.__len__` and `TensorBlock.shape`, which return the length and
   shape of the values in the block respectively
 
+#### Changed
+
+- We now require Python >= 3.9
+
 ### metatensor-core Julia
 
 #### Added

--- a/metatensor-torch/CHANGELOG.md
+++ b/metatensor-torch/CHANGELOG.md
@@ -22,6 +22,7 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 ### Changed
 
 - `MetatensorAtomisticModel.save()` always saves models on the CPU.
+- We now require Python >= 3.9
 
 ## [Version 0.5.2](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-torch-v0.5.2) - 2024-06-21
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [project]
 name = "metatensor"
 dynamic = ["version", "authors", "dependencies", "optional-dependencies"]
-requires-python = ">=3.8"
 
 readme = "README.md"
 license = {text = "BSD-3-Clause"}

--- a/python/metatensor-core/pyproject.toml
+++ b/python/metatensor-core/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "metatensor-core"
 dynamic = ["version", "authors"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 readme = "README.rst"
 license = {text = "BSD-3-Clause"}

--- a/python/metatensor-learn/CHANGELOG.md
+++ b/python/metatensor-learn/CHANGELOG.md
@@ -21,6 +21,7 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Dataset and DataLoader can now handle fields with a name which is not a valid
   Python identifier.
+- We now require Python >= 3.9
 
 
 ## [Version 0.2.2](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-learn-v0.2.2) - 2024-05-16

--- a/python/metatensor-learn/pyproject.toml
+++ b/python/metatensor-learn/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "metatensor-learn"
 dynamic = ["version", "authors", "dependencies"]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 
 readme = "README.rst"
 license = {text = "BSD-3-Clause"}

--- a/python/metatensor-operations/CHANGELOG.md
+++ b/python/metatensor-operations/CHANGELOG.md
@@ -17,6 +17,10 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
+### Changed
+
+- We now require Python >= 3.9
+
 ## [Version 0.2.2](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-operations-v0.2.2) - 2024-06-19
 
 ### Fixed

--- a/python/metatensor-operations/pyproject.toml
+++ b/python/metatensor-operations/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "metatensor-operations"
 dynamic = ["version", "authors", "dependencies"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 readme = "README.rst"
 license = {text = "BSD-3-Clause"}

--- a/python/metatensor-torch/pyproject.toml
+++ b/python/metatensor-torch/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "metatensor-torch"
 dynamic = ["version", "authors", "dependencies"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 readme = "README.rst"
 license = {text = "BSD-3-Clause"}


### PR DESCRIPTION
I need a feature from 3.9 in #479, and 3.8 will be EOL in a couple of months. Most of the scientific Python ecosystem also already dropped both 3.8 and 3.9, so we are not dropping faster than our own dependencies.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1659856596.zip)

<!-- download-section Documentation end -->