### PR TITLE
Allow loading npz files which use DEFLATE compression

### DIFF
--- a/metatensor-core/Cargo.toml
+++ b/metatensor-core/Cargo.toml
@@ -24,7 +24,7 @@ smallvec = {version = "1", features = ["union"]}
 # implementation of the NPZ serialization format
 byteorder = {version = "1"}
 num-traits = {version = "0.2", default-features = false}
-zip = {version = "0.6", default-features = false}
+zip = {version = "0.6", default-features = false, features = ["deflate"]}
 
 [build-dependencies]
 cbindgen = { version = "0.26", default-features = false }

--- a/python/metatensor-core/tests/serialization.py
+++ b/python/metatensor-core/tests/serialization.py
@@ -80,6 +80,30 @@ def test_load(use_numpy, memory_buffer, standalone_fn):
     assert gradient.values.shape == (59, 3, 5, 3)
 
 
+@pytest.mark.parametrize("use_numpy", (True, False))
+def test_load_deflate(use_numpy):
+    # This file was saved using DEFLATE to compress the different ZIP archive members
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "metatensor-operations",
+        "tests",
+        "data",
+        "qm7-power-spectrum.npz",
+    )
+
+    tensor = metatensor.load(path, use_numpy=use_numpy)
+
+    assert isinstance(tensor, TensorMap)
+    assert tensor.keys.names == [
+        "center_type",
+        "neighbor_1_type",
+        "neighbor_2_type",
+    ]
+    assert len(tensor.keys) == 17
+
+
 # using tmpdir as pytest-built-in fixture
 # https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html#the-tmpdir-and-tmpdir-factory-fixtures
 @pytest.mark.parametrize("use_numpy", (True, False))


### PR DESCRIPTION
This does not change file saving, we are still only using STORED in this case.

Fix #469.

This is mainly intended to remove the surprising behavior as seen in the issue, where a file that should be loaded can only be loaded through numpy and not metatensor-core. Such files should be rare, since one has to go out of their way to create it (saving with metatensor/numpy, then loading as a normal npz and re-saving with different settings).


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1663633276.zip)

<!-- download-section Documentation end -->

<!-- download-section Build Python wheels start -->
⚙️ [Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1664257799.zip)

<!-- download-section Build Python wheels end -->