### PR TITLE
Fix documentation for printing `ModelMetadata`

### DIFF
--- a/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
@@ -385,7 +385,12 @@ class ModelEvaluationOptions:
 
 
 class ModelMetadata:
-    """Metadata about a specific exported model"""
+    """
+    Metadata about a specific exported model
+
+    This class implements the __str__ and __repr__ methods, so its representation can be
+    easily printed, logged, inserted into other strings, etc.
+    """
 
     def __init__(
         self,
@@ -415,12 +420,6 @@ class ModelMetadata:
       used by this model
     - "model": for reference specific to this exact model
     """
-
-    def print(self) -> str:
-        """
-        Format the model metadata into a string. This is the same format used for
-        ``__str__`` and ``__repr__``.
-        """
 
 
 def check_atomistic_model(path: str):

--- a/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
@@ -388,8 +388,8 @@ class ModelMetadata:
     """
     Metadata about a specific exported model
 
-    This class implements the __str__ and __repr__ methods, so its representation can be
-    easily printed, logged, inserted into other strings, etc.
+    This class implements the ``__str__`` and ``__repr__`` methods, so its
+    representation can be easily printed, logged, inserted into other strings, etc.
     """
 
     def __init__(


### PR DESCRIPTION
The documentation at https://docs.metatensor.org/latest/atomistic/reference/models/metadata.html
says there is a `ModelMetadata.print()` method, but it doesn't work at the moment because it's not registered



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1672240911.zip)

<!-- download-section Documentation end -->