### PR TITLE
Do not use transpose in ASE calculator

### DIFF
--- a/python/metatensor-torch/metatensor/torch/atomistic/ase_calculator.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/ase_calculator.py
@@ -536,7 +536,7 @@ def _full_3x3_to_voigt_6_stress(stress):
     Re-implementation of ``ase.stress.full_3x3_to_voigt_6_stress`` which does not do the
     stress symmetrization correctly (they do ``(stress[1, 2] + stress[1, 2]) / 2.0``)
     """
-    return np.transpose(
+    return np.array(
         [
             stress[0, 0],
             stress[1, 1],


### PR DESCRIPTION
When converting the stress in the ASE calculator, we're using `np.transpose` on a list of floats, but that does nothing and it just converts the list to an array.



# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1670552491.zip)

<!-- download-section Documentation end -->