### PR TITLE
Better error message in case of mismatch torch between build and run time

### DIFF
--- a/python/metatensor-torch/metatensor/torch/_c_lib.py
+++ b/python/metatensor-torch/metatensor/torch/_c_lib.py
@@ -112,7 +112,20 @@ def _load_library():
     metatensor._c_lib._get_library()
 
     # load the C++ operators and custom classes
-    torch.ops.load_library(_lib_path())
+    try:
+        torch.ops.load_library(_lib_path())
+    except Exception as e:
+        if "undefined symbol" in str(e):
+            file_name = os.path.basename(_lib_path())
+            raise ImportError(
+                f"{file_name} is not compatible with the current PyTorch "
+                "installation.\nThis can happen if PyTorch comes from one source "
+                "(pip, conda, custom), but metatensor-torch comes from a different "
+                "one.\nIn this case, you can try to compile metatensor-torch yourself "
+                "with `pip install --no-binary=metatensor-torch metatensor-torch`"
+            ) from e
+        else:
+            raise e
 
     lib_version = torch.ops.metatensor.version()
     if not version_compatible(lib_version, __version__):

--- a/rust/metatensor-sys/Cargo.toml
+++ b/rust/metatensor-sys/Cargo.toml
@@ -28,5 +28,6 @@ static = []
 cmake = "0.1.49"
 which = "5"
 
-# This is the last version supporting rustc 1.65
+# these are the last version supporting rustc 1.65
 home = "=0.5.5"
+cc = "=1.0.105"


### PR DESCRIPTION
See #665 for one example of this, the same happens on TODI (CSCS super computer) when using the NVIDIA provided container.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1678291919.zip)

<!-- download-section Documentation end -->

<!-- download-section Build Python wheels start -->
⚙️ [Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1678385834.zip)

<!-- download-section Build Python wheels end -->