### PR TITLE
Stop leaking memory for values stored inside blocks

### DIFF
--- a/python/metatensor-core/metatensor/block.py
+++ b/python/metatensor-core/metatensor/block.py
@@ -203,6 +203,12 @@ class TensorBlock:
         return copy.deepcopy(self)
 
     def __repr__(self) -> str:
+        if self._actual_ptr is None:
+            return (
+                "Empty TensorBlock (data has been moved to another "
+                "TensorBlock or TensorMap)"
+            )
+
         if len(self._gradient_parameters) != 0:
             s = f"Gradient TensorBlock ('{'/'.join(self._gradient_parameters)}')\n"
         else:


### PR DESCRIPTION
ctypes.py_object(obj) does NOT give us the Py_Object* corresponding to `obj`, but a wrapper that keeps it's own reference to `obj`. Multiple calls give us different wrapper, meaning our manual Py_IncRef/Py_DecRef where acting on different wrappers and keeping `obj` alive.

This only affects metatensor-core in Python, and was found & reported by @ppegolo. Below is a script that shows the leak:

```py
import resource

import numpy as np
import torch

from metatensor import Labels, TensorBlock, TensorMap


class Model(torch.nn.Module):
    def __init__(self, size):

        super().__init__()
        self.model = torch.nn.Sequential(torch.nn.Linear(size, size))

    def forward(self, features):
        blocks = []

        for feat in features.blocks():
            blocks.append(
                TensorBlock(
                    values=self.model(feat.values),
                    samples=feat.samples,
                    components=feat.components,
                    properties=feat.properties,
                )
            )

        return blocks


def print_mem_usage():
    usage = resource.getrusage(resource.RUSAGE_SELF)
    print(f"using {usage[2] / 1024/ 1024:5.5} MiB")


keys = Labels(["key"], np.array([[i] for i in range(1)]))

n_s = 10000
n_p = 1000
block = [
    TensorBlock(
        values=torch.randn(n_s, 1, n_p),
        samples=Labels(["s"], values=np.arange(n_s).reshape(n_s, 1)),
        components=[Labels(["c"], values=np.array([[0]]))],
        properties=Labels(["p"], values=np.arange(n_p).reshape(n_p, 1)),
    )
    for i in range(1)
]
feats = TensorMap(keys, block)


model = Model(size=feats[0].values.shape[-1])
for epoch in range(40):
    blocks = model.forward(feats)
    print(epoch, end=" ")
    print_mem_usage()

```

Running this on master produces:

```
0 using 257.44 MiB
1 using 299.64 MiB
2 using 341.86 MiB
3 using 384.05 MiB
4 using 426.23 MiB
5 using 464.52 MiB
6 using 464.52 MiB
7 using 464.52 MiB
8 using 464.52 MiB
9 using 468.58 MiB
10 using 506.73 MiB
11 using 544.91 MiB
12 using 587.09 MiB
13 using 625.27 MiB
14 using 625.28 MiB
15 using 625.28 MiB
16 using 625.28 MiB
17 using 625.28 MiB
18 using 625.3 MiB
19 using 625.31 MiB
20 using 663.48 MiB
21 using 701.64 MiB
22 using 701.64 MiB
23 using 701.64 MiB
24 using 701.64 MiB
25 using 701.64 MiB
26 using 701.64 MiB
27 using 701.66 MiB
28 using 739.81 MiB
29 using 739.81 MiB
30 using 739.81 MiB
31 using 739.81 MiB
32 using 739.81 MiB
33 using 739.81 MiB
34 using 739.81 MiB
35 using 739.81 MiB
36 using 777.97 MiB
37 using 777.97 MiB
38 using 777.97 MiB
39 using 777.97 MiB
```

and on this branch:

```
0 using 257.66 MiB
1 using 303.97 MiB
2 using 312.03 MiB
3 using 312.05 MiB
4 using 312.05 MiB
5 using 312.05 MiB
6 using 312.09 MiB
7 using 316.14 MiB
8 using 316.14 MiB
9 using 316.14 MiB
10 using 316.14 MiB
11 using 320.17 MiB
12 using 320.17 MiB
13 using 320.17 MiB
14 using 320.17 MiB
15 using 320.17 MiB
16 using 320.19 MiB
17 using 320.22 MiB
18 using 320.22 MiB
19 using 320.22 MiB
20 using 320.22 MiB
21 using 320.22 MiB
22 using 320.22 MiB
23 using 320.22 MiB
24 using 320.22 MiB
25 using 320.22 MiB
26 using 320.23 MiB
27 using 320.23 MiB
28 using 320.23 MiB
29 using 320.25 MiB
30 using 320.25 MiB
31 using 320.25 MiB
32 using 320.25 MiB
33 using 320.25 MiB
34 using 320.25 MiB
35 using 320.25 MiB
36 using 320.25 MiB
37 using 320.25 MiB
38 using 320.25 MiB
39 using 320.25 MiB
```


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
