### PR TITLE
Do not use `ctx->saved_data` in autograd

### DIFF
--- a/metatensor-torch/src/atomistic/system.cpp
+++ b/metatensor-torch/src/atomistic/system.cpp
@@ -212,8 +212,7 @@ torch::Tensor NeighborsAutograd::forward(
         }
     }
 
-    ctx->save_for_backward({positions, cell});
-    ctx->saved_data["neighbors"] = neighbors;
+    ctx->save_for_backward({positions, cell, neighbors->values(), neighbors->samples()->values()});
 
     return distances;
 }
@@ -228,9 +227,9 @@ std::vector<torch::Tensor> NeighborsAutograd::backward(
     auto saved_variables = ctx->get_saved_variables();
     auto positions = saved_variables[0];
     auto cell = saved_variables[1];
-    auto neighbors = ctx->saved_data["neighbors"].toCustomClass<TensorBlockHolder>();
-    auto samples = neighbors->samples()->values();
-    auto distances = neighbors->values();
+
+    auto distances = saved_variables[2];
+    auto samples = saved_variables[3];
 
     auto positions_grad = torch::Tensor();
     if (positions.requires_grad()) {


### PR DESCRIPTION
PyTorch **sometimes** does not free the corresponding data when dropping the computational graph, leaking the corresponding memory. I don't quite understand when or why this happen, a basic example with a single node in the computational graph does not suffer from the same issue.

This was causing memory leaks when running MD simulations (I found this while debugging something unrelated in the LAMMPS interface).

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1687033155.zip)

<!-- download-section Documentation end -->