### PR TITLE
Use pyproject.toml for manage pytest warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,14 @@ learn = ["python/metatensor-learn/", ".tox/*/lib/python*/site-packages/"]
 [tool.coverage.report]
 show_missing = true
 omit = ["documentation.py"]
+
+### ======================================================================== ###
+
+[tool.pytest.ini_options]
+# ignore" a bunch of internal warnings with Python 3.12 and PyTorch
+filterwarnings = [
+    "error",
+    "ignore:ast.Str is deprecated and will be removed in Python 3.14:DeprecationWarning",
+    "ignore:Attribute s is deprecated and will be removed in Python 3.14:DeprecationWarning",
+    "ignore:ast.NameConstant is deprecated and will be removed in Python 3.14:DeprecationWarning",
+]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 # https://github.com/tox-dev/tox/issues/3238
 requires = tox==4.14.0
 
-# these are the default environments, i.e. the list of tests running when you
-# execute `tox` in the command-line without anything else
+# these are the default environments, i.e. the list of tests running when you execute
+# `tox` in the command-line without anything else
 envlist =
     lint
     core-tests
@@ -21,22 +21,15 @@ package = external
 package_env = build-metatensor-core
 lint_folders = "{toxinidir}/python" "{toxinidir}/setup.py"
 build_single_wheel = --no-deps --no-build-isolation --check-build-dependencies
-warning_options = -W error \
-    -W "ignore:ast.Str is deprecated and will be removed in Python 3.14:DeprecationWarning" \
-    -W "ignore:Attribute s is deprecated and will be removed in Python 3.14:DeprecationWarning" \
-    -W "ignore:ast.NameConstant is deprecated and will be removed in Python 3.14:DeprecationWarning"
-# the "-W ignore" flags above are for PyTorch, which triggers a bunch of
-# internal warnings with Python 3.12
 
 setenv =
-    # store code coverage in a per-env file, so different envs don't override
-    # each other
+    # store code coverage in a per-env file, so different envs don't override each other
     COVERAGE_FILE={env_dir}/.coverage
 
 test_options =
-    --cov={env_site_packages_dir}/metatensor --cov-report= \
-    --import-mode=append \
-    {[testenv]warning_options}
+    --cov={env_site_packages_dir}/metatensor \
+    --cov-report= \
+    --import-mode=append
 
 packaging_deps =
     setuptools
@@ -52,8 +45,8 @@ testing_deps =
 
 
 [testenv:build-metatensor-core]
-# note: this is not redundant with the same value in the root [testenv]
-# without this one, cmake can not find the MSVC compiler on Windows CI
+# note: this is not redundant with the same value in the root [testenv] without this
+# one, cmake can not find the MSVC compiler on Windows CI
 passenv = *
 
 description =
@@ -213,7 +206,7 @@ commands =
     pip install python/metatensor-torch {[testenv]build_single_wheel} --force-reinstall
 
     # run documentation tests
-    pytest --doctest-modules --pyargs metatensor {[testenv]warning_options}
+    pytest --doctest-modules --pyargs metatensor
 
 
 [testenv:lint]


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Manage pytest warnings inside the  `pyproject.toml` instead of list of command line flags inside the `tox.ini`

# Contributor (creator of pull-request) checklist

 - ~[ ] Tests updated (for new features and bugfixes)?~
 - ~[ ] Documentation updated (for new features)?~
 - ~[ ] Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
