### PR TITLE
Implement Labels selection

### DIFF
--- a/docs/src/core/reference/c/labels.rst
+++ b/docs/src/core/reference/c/labels.rst
@@ -13,6 +13,7 @@ The following functions operate on :c:type:`mts_labels_t`:
 - :c:func:`mts_labels_position`: get the position of an entry in the labels
 - :c:func:`mts_labels_union`: get the union of two labels
 - :c:func:`mts_labels_intersection`: get the intersection of two labels
+- :c:func:`mts_labels_select`: select entries in labels that match a selection
 - :c:func:`mts_labels_set_user_data`: store some data inside the labels for later retrieval
 - :c:func:`mts_labels_user_data`: retrieve data stored earlier in the labels
 
@@ -29,6 +30,8 @@ The following functions operate on :c:type:`mts_labels_t`:
 .. doxygenfunction:: mts_labels_union
 
 .. doxygenfunction:: mts_labels_intersection
+
+.. doxygenfunction:: mts_labels_select
 
 .. doxygenfunction:: mts_labels_set_user_data
 

--- a/julia/src/generated/_c_api.jl
+++ b/julia/src/generated/_c_api.jl
@@ -152,6 +152,14 @@ function mts_labels_intersection(first::mts_labels_t, second::mts_labels_t, resu
     )
 end
 
+function mts_labels_select(labels::mts_labels_t, selection::mts_labels_t, selected::Ptr{Int64}, selected_count::Ptr{UIntptr})
+    ccall((:mts_labels_select, libmetatensor), 
+        mts_status_t,
+        (mts_labels_t, mts_labels_t, Ptr{Int64}, Ptr{UIntptr},),
+        labels, selection, selected, selected_count
+    )
+end
+
 function mts_labels_free(labels::Ptr{mts_labels_t})
     ccall((:mts_labels_free, libmetatensor), 
         mts_status_t,

--- a/metatensor-core/CHANGELOG.md
+++ b/metatensor-core/CHANGELOG.md
@@ -19,9 +19,17 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 ### metatensor-core C++
 
+#### Added
+
+- `Labels::select` to sub-select entries in labels
+
 ### metatensor-core C
 
+- `mts_labels_select` to sub-select entries in labels
+
 ### metatensor-core Python
+
+- `Labels.select` to sub-select entries in labels
 
 ### metatensor-core Julia
 

--- a/metatensor-core/include/metatensor.h
+++ b/metatensor-core/include/metatensor.h
@@ -448,6 +448,32 @@ mts_status_t mts_labels_intersection(struct mts_labels_t first,
                                      uintptr_t second_mapping_count);
 
 /**
+ * Select entries in the `labels` that match the `selection`.
+ *
+ * The selection's names must be a subset of the name of the `labels` names.
+ *
+ * All entries in the `labels` that match one of the entry in the `selection`
+ * for all the selection's dimension will be picked. Any entry in the
+ * `selection` but not in the `labels` will be ignored.
+ *
+ * @param labels Labels on which to run the selection
+ * @param selection definition of the selection criteria. Multiple entries are
+ *        interpreted as a logical `or` operation.
+ * @param selected on input, a pointer to an array with space for
+ *        `*selected_count` entries. On output, the first `*selected_count`
+ *        values will contain the index in `labels` of selected entries.
+ * @param selected_count on input, size of the `selected` array. On output,
+ *        this will contain the number of selected entries.
+ * @returns The status code of this operation. If the status is not
+ *          `MTS_SUCCESS`, you can use `mts_last_error()` to get the full
+ *          error message.
+ */
+mts_status_t mts_labels_select(struct mts_labels_t labels,
+                               struct mts_labels_t selection,
+                               int64_t *selected,
+                               uintptr_t *selected_count);
+
+/**
  * Decrease the reference count of `labels`, and release the corresponding
  * memory once the reference count reaches 0.
  *

--- a/metatensor-core/include/metatensor.hpp
+++ b/metatensor-core/include/metatensor.hpp
@@ -1316,9 +1316,6 @@ public:
     ///        a pointer to an array containing `other.count()` elements, to be
     ///        filled by this function. Otherwise it should be a `nullptr`.
     /// @param second_mapping_count number of elements in `second_mapping`
-    /// @returns The status code of this operation. If the status is not
-    ///          `MTS_SUCCESS`, you can use `mts_last_error()` to get the full
-    ///          error message.
     Labels set_union(
         const Labels& other,
         int64_t* first_mapping = nullptr,
@@ -1359,9 +1356,6 @@ public:
     ///        entries in `other` to the positions in the union, this should be
     ///        a vector containing `other.count()` elements, to be filled by
     ///        this function. Otherwise it should be an empty vector.
-    /// @returns The status code of this operation. If the status is not
-    ///          `MTS_SUCCESS`, you can use `mts_last_error()` to get the full
-    ///          error message.
     Labels set_union(
         const Labels& other,
         std::vector<int64_t>& first_mapping,
@@ -1411,9 +1405,6 @@ public:
     ///        `nullptr`. If an entry in `other` is not used in the
     ///        intersection, the mapping will be set to -1.
     /// @param second_mapping_count number of elements in `second_mapping`
-    /// @returns The status code of this operation. If the status is not
-    ///          `MTS_SUCCESS`, you can use `mts_last_error()` to get the full
-    ///          error message.
     Labels set_intersection(
         const Labels& other,
         int64_t* first_mapping = nullptr,
@@ -1458,9 +1449,6 @@ public:
     ///        filled by this function. Otherwise it should be an empty vector.
     ///        If an entry in `other` is not used in the intersection, the
     ///        mapping will be set to -1.
-    /// @returns The status code of this operation. If the status is not
-    ///          `MTS_SUCCESS`, you can use `mts_last_error()` to get the full
-    ///          error message.
     Labels set_intersection(
         const Labels& other,
         std::vector<int64_t>& first_mapping,
@@ -1485,6 +1473,44 @@ public:
             second_mapping_ptr,
             second_mapping_count
         );
+    }
+
+    /// Select entries in these `Labels` that match the `selection`.
+    ///
+    /// The selection's names must be a subset of the names of these labels.
+    ///
+    /// All entries in these `Labels` that match one of the entry in the
+    /// `selection` for all the selection's dimension will be picked. Any entry
+    /// in the `selection` but not in these `Labels` will be ignored.
+    ///
+    /// @param selection definition of the selection criteria. Multiple entries
+    ///        are interpreted as a logical `or` operation.
+    /// @param selected on input, a pointer to an array with space for
+    ///        `*selected_count` entries. On output, the first `*selected_count`
+    ///        values will contain the index in `labels` of selected entries.
+    /// @param selected_count on input, size of the `selected` array. On output,
+    ///        this will contain the number of selected entries.
+    void select(const Labels& selection, int64_t* selected, size_t *selected_count) const {
+        details::check_status(mts_labels_select(
+            labels_,
+            selection.labels_,
+            selected,
+            selected_count
+        ));
+    }
+
+    /// Select entries in these `Labels` that match the `selection`.
+    ///
+    /// This function does the same thing as the one above, but allocates and
+    /// return the list of selected indexes in a `std::vector`
+    std::vector<int64_t> select(const Labels& selection) const {
+        auto selected_count = this->count();
+        auto selected = std::vector<int64_t>(selected_count, -1);
+
+        this->select(selection, selected.data(), &selected_count);
+
+        selected.resize(selected_count);
+        return selected;
     }
 
     /*!

--- a/metatensor-core/tests/cpp/labels.cpp
+++ b/metatensor-core/tests/cpp/labels.cpp
@@ -116,6 +116,35 @@ TEST_CASE("Set operations") {
         expected = std::vector<int64_t>{-1, 0, -1};
         CHECK(second_mapping == expected);
     }
+
+    SECTION("select") {
+        // selection with a subset of names
+        auto labels = Labels({"aa", "bb"}, {{1, 1}, {1, 2}, {3, 2}, {2, 1}});
+        auto selection = Labels({"aa"}, {{1}, {2}, {5}});
+
+        auto selected = labels.select(selection);
+        CHECK(selected.size() == 3);
+        CHECK(selected == std::vector<int64_t>{0, 1, 3});
+
+        // selection with the same names
+        selection = Labels({"aa", "bb"}, {{1, 1}, {2, 1}, {5, 1}, {1, 2}});
+
+        selected = labels.select(selection);
+        CHECK(selected.size() == 3);
+        CHECK(selected == std::vector<int64_t>{0, 3, 1});
+
+        // empty selection
+        selection = Labels({"aa"}, {});
+
+        selected = labels.select(selection);
+        CHECK(selected.size() == 0);
+
+        // invalid selection names
+        selection = Labels({"aaa"}, {{1}});
+        CHECK_THROWS_WITH(labels.select(selection),
+            "invalid parameter: 'aaa' in selection is not part of these Labels"
+        );
+    }
 }
 
 struct UserData {

--- a/metatensor-torch/CHANGELOG.md
+++ b/metatensor-torch/CHANGELOG.md
@@ -24,6 +24,7 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 - `read_model_metadata` to load only the `ModelMetadata` from an exported
   atomistic model without having to load the whole model.
 - Users can now store arbitrary additional metadata in `ModelMetadata.extra`
+- Added `Labels.select` function to sub-select entries in labels
 
 ## [Version 0.5.3](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-torch-v0.5.3) - 2024-07-15
 

--- a/metatensor-torch/include/metatensor/torch/labels.hpp
+++ b/metatensor-torch/include/metatensor/torch/labels.hpp
@@ -179,6 +179,15 @@ public:
     /// output.
     std::tuple<TorchLabels, torch::Tensor, torch::Tensor> intersection_and_mapping(const TorchLabels& other) const;
 
+    /// Select entries in these `Labels` that match the `selection`.
+    ///
+    /// The selection's names must be a subset of the names of these labels.
+    ///
+    /// All entries in these `Labels` that match one of the entry in the
+    /// `selection` for all the selection's dimension will be picked. Any entry
+    /// in the `selection` but not in these `Labels` will be ignored.
+    torch::Tensor select(const TorchLabels& selection) const;
+
     /// Load serialized Labels from the given path
     static TorchLabels load(const std::string& path);
 

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -163,6 +163,7 @@ TORCH_LIBRARY(metatensor, m) {
         .def("union_and_mapping", &LabelsHolder::union_and_mapping, DOCSTRING, {torch::arg("other")})
         .def("intersection", &LabelsHolder::set_intersection, DOCSTRING, {torch::arg("other")})
         .def("intersection_and_mapping", &LabelsHolder::intersection_and_mapping, DOCSTRING, {torch::arg("other")})
+        .def("select", &LabelsHolder::select, DOCSTRING, {torch::arg("selection")})
         .def_pickle(
             // __getstate__
             [](const TorchLabels& self){ return self->save_buffer(); },

--- a/python/metatensor-core/metatensor/_c_api.py
+++ b/python/metatensor-core/metatensor/_c_api.py
@@ -151,6 +151,14 @@ def setup_functions(lib):
     ]
     lib.mts_labels_intersection.restype = _check_status
 
+    lib.mts_labels_select.argtypes = [
+        mts_labels_t,
+        mts_labels_t,
+        POINTER(ctypes.c_int64),
+        POINTER(c_uintptr_t),
+    ]
+    lib.mts_labels_select.restype = _check_status
+
     lib.mts_labels_free.argtypes = [
         POINTER(mts_labels_t),
     ]

--- a/python/metatensor-core/tests/labels.py
+++ b/python/metatensor-core/tests/labels.py
@@ -410,3 +410,25 @@ def test_values_reference():
     values = Labels(names=["_"], values=np.array(data).reshape(-1, 1)).values
 
     assert np.all(values.reshape(-1) == data)
+
+
+def test_select():
+    labels = Labels(["aa", "bb"], np.array([[1, 1], [1, 2], [3, 2], [2, 1]]))
+    selection = Labels(["aa"], np.array([[1], [2], [5]]))
+
+    assert np.all(labels.select(selection) == [0, 1, 3])
+
+    # selection with the same names
+    selection = Labels(["aa", "bb"], np.array([[1, 1], [2, 1], [5, 1], [1, 2]]))
+    assert np.all(labels.select(selection) == [0, 3, 1])
+
+    # empty selection
+    selection = Labels.empty(["aa"])
+    assert np.all(labels.select(selection) == [])
+
+    # invalid selection names
+    selection = Labels.empty(["aaaa"])
+
+    message = "invalid parameter: 'aaaa' in selection is not part of these Labels"
+    with pytest.raises(MetatensorError, match=message):
+        labels.select(selection)

--- a/python/metatensor-operations/tests/drop_blocks.py
+++ b/python/metatensor-operations/tests/drop_blocks.py
@@ -11,103 +11,84 @@ DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
 
 @pytest.fixture
-def test_tensor_map() -> TensorMap:
+def tensor() -> TensorMap:
     return metatensor.load(os.path.join(DATA_ROOT, "qm7-power-spectrum.npz"))
 
 
-def test_drop_all(test_tensor_map):
-    # test the behavior when all the keys are dropped
-    # expected behavior: empty TensorMap
-    keys = test_tensor_map.keys
-    tensor = metatensor.drop_blocks(test_tensor_map, keys)
-    empty_tensor = TensorMap(keys=Labels.empty(keys.names), blocks=[])
+def test_drop_all(tensor):
+    tensor = metatensor.drop_blocks(tensor, tensor.keys)
+    empty_tensor = TensorMap(keys=Labels.empty(tensor.keys.names), blocks=[])
     assert metatensor.equal(tensor, empty_tensor)
 
 
-def test_drop_two_random_keys(test_tensor_map):
+def test_drop_two_random_keys(tensor):
     # test the behavior when two random keys are dropped
-    n_blocks = len(test_tensor_map.keys)
-    np.random.seed(0xFEA123)
-    indices_to_drop = np.random.randint(0, n_blocks, 2)
+    n_blocks = len(tensor.keys)
+    indices_to_drop = np.random.choice(list(range(n_blocks)), size=3, replace=False)
 
-    values_to_drop = [test_tensor_map.keys[i].values for i in indices_to_drop]
-    keys_to_drop = Labels(
-        test_tensor_map.keys.names,
-        np.vstack(values_to_drop),
-    )
+    values_to_drop = [tensor.keys[i].values for i in indices_to_drop]
+    keys_to_drop = Labels(tensor.keys.names, np.vstack(values_to_drop))
 
     values_to_keep = [
-        test_tensor_map.keys[i].values
-        for i in range(n_blocks)
-        if i not in indices_to_drop
+        tensor.keys[i].values for i in range(n_blocks) if i not in indices_to_drop
     ]
-    keys_to_keep = Labels(
-        test_tensor_map.keys.names,
-        np.vstack(values_to_keep),
-    )
+    keys_to_keep = Labels(tensor.keys.names, np.vstack(values_to_keep))
 
-    ref_blocks = [test_tensor_map[key].copy() for key in keys_to_keep]
+    ref_blocks = [tensor[key].copy() for key in keys_to_keep]
     ref_tensor = TensorMap(keys_to_keep, ref_blocks)
 
-    new_tensor = metatensor.drop_blocks(test_tensor_map, keys_to_drop)
+    new_tensor = metatensor.drop_blocks(tensor, keys_to_drop)
     assert metatensor.equal(new_tensor, ref_tensor)
 
 
-def test_drop_nothing(test_tensor_map):
-    # test when an empty set of keys are dropped
-    empty_key = Labels.empty(test_tensor_map.keys.names)
-    new_tensor = metatensor.drop_blocks(test_tensor_map, empty_key)
-    assert new_tensor == test_tensor_map
+def test_drop_selection(tensor):
+    assert np.unique(tensor.keys["center_type"]).tolist() == [1, 6, 8]
+
+    keys_to_drop = Labels("center_type", np.array([[1]]))
+    new_tensor = metatensor.drop_blocks(tensor, keys_to_drop)
+
+    assert np.unique(new_tensor.keys["center_type"]).tolist() == [6, 8]
 
 
-def test_not_existent(test_tensor_map):
-    # test when keys that don't appear in the TensorMap are dropped
-    non_existent_key = Labels(
-        test_tensor_map.keys.names, np.array([[-1, -1, -1], [0, 0, 0]])
-    )
-    message = (
-        "\\(center_type=-1, neighbor_1_type=-1, neighbor_2_type=-1\\) "
-        "is not present in this tensor"
-    )
-    with pytest.raises(ValueError, match=message):
-        metatensor.drop_blocks(test_tensor_map, non_existent_key)
+def test_drop_nothing(tensor):
+    empty_key = Labels.empty(tensor.keys.names)
+    new_tensor = metatensor.drop_blocks(tensor, empty_key)
+    assert new_tensor == tensor
 
 
-def test_copy_flag(test_tensor_map):
+def test_copy_flag(tensor):
     """
     Checks that settings the copy flag to true or false gives the same result.
     Also checks that inplace modifications of the underlying data doesn't affect
     the copied returned tensor, but it does for the un-copied version.
     """
     # Define some keys to drop
-    values_to_drop = [test_tensor_map.keys[i].values for i in range(5)]
+    values_to_drop = [tensor.keys[i].values for i in range(5)]
     keys_to_drop = Labels(
-        test_tensor_map.keys.names,
+        tensor.keys.names,
         np.vstack(values_to_drop),
     )
 
     # Drop blocks with copy=True flag
-    new_tensor_copied = metatensor.drop_blocks(test_tensor_map, keys_to_drop, copy=True)
+    new_tensor_copied = metatensor.drop_blocks(tensor, keys_to_drop, copy=True)
 
     # Drop blocks with copy=False flag
-    new_tensor_not_copied = metatensor.drop_blocks(
-        test_tensor_map, keys_to_drop, copy=False
-    )
+    new_tensor_not_copied = metatensor.drop_blocks(tensor, keys_to_drop, copy=False)
 
     # Check that the resulting tensor are equal whether or not they are copied
     assert metatensor.equal(new_tensor_copied, new_tensor_not_copied)
 
     # Now modify the original tensor's block values in place
-    for block in test_tensor_map.blocks():
+    for block in tensor.blocks():
         block.values[:] += 3.14
 
     # The copied tensor's values should not have been edited
     for key in new_tensor_copied.keys:
-        assert np.all(new_tensor_copied[key].values != test_tensor_map[key].values)
+        assert np.all(new_tensor_copied[key].values != tensor[key].values)
 
     # But the un-copied tensor's values should have been
     for key in new_tensor_not_copied.keys:
-        assert np.all(new_tensor_not_copied[key].values == test_tensor_map[key].values)
+        assert np.all(new_tensor_not_copied[key].values == tensor[key].values)
         assert np.all(
             new_tensor_not_copied[key].values == new_tensor_copied[key].values[:] + 3.14
         )

--- a/python/metatensor-torch/metatensor/torch/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/documentation.py
@@ -579,6 +579,31 @@ class Labels:
             used in the output, the mapping for them is set to ``-1``.
         """
 
+    def select(self, selection: "Labels") -> torch.Tensor:
+        """
+        Select entries in these :py:class:`Labels` that match the ``selection``.
+
+        The selection's names must be a subset of the names of these labels.
+
+        All entries in these :py:class:`Labels` that match one of the entry in the
+        ``selection`` for all the selection's dimension will be picked. Any entry in the
+        ``selection`` but not in these :py:class:`Labels` will be ignored.
+
+        >>> import torch
+        >>> from metatensor.torch import Labels
+        >>> labels = Labels(
+        ...     names=["a", "b"],
+        ...     values=torch.tensor([[0, 1], [1, 2], [0, 3], [1, 1], [2, 4]]),
+        ... )
+        >>> selection = Labels(names=["a"], values=torch.tensor([[0], [2], [5]]))
+        >>> print(labels.select(selection))
+        tensor([0, 2, 4])
+
+        :param selection: description of the entries to select
+        :return: 1-dimensional tensor containing the integer indices of selected
+            entries
+        """
+
     def print(self, max_entries: int, indent: int) -> str:
         """print these :py:class:`Labels` to a string
 

--- a/rust/metatensor-sys/src/c_api.rs
+++ b/rust/metatensor-sys/src/c_api.rs
@@ -383,6 +383,13 @@ extern "C" {
         second_mapping_count: usize,
     ) -> mts_status_t;
     #[must_use]
+    pub fn mts_labels_select(
+        labels: mts_labels_t,
+        selection: mts_labels_t,
+        selected: *mut i64,
+        selected_count: *mut usize,
+    ) -> mts_status_t;
+    #[must_use]
     pub fn mts_labels_free(labels: *mut mts_labels_t) -> mts_status_t;
     #[must_use]
     pub fn mts_register_data_origin(


### PR DESCRIPTION
This function enables the selection of a subset of entries in Labels using another Labels to define the selection. Mulitple entries in the selection are interpreted as an `or` operation.

Fix #97 

Fix #700 as well, bringing the time for `slice_block` in the issue example to ~380ms, very similar to the manual implementation.

Still TBD: 

- [x] check the operations for opportunities to use the new function
- [ ] check the learn classes for opportunities to use the new function
- [x] check if we can replace the manual implementation in rascaline with this one


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1811714225.zip)

<!-- download-section Documentation end -->