### PR TITLE
Minor improvements to atomistic examples and documentation

### DIFF
--- a/python/examples/atomistic/1-export-atomistic-model.py
+++ b/python/examples/atomistic/1-export-atomistic-model.py
@@ -91,9 +91,11 @@ class SingleAtomEnergy(torch.nn.Module):
         outputs: Dict[str, ModelOutput],
         selected_atoms: Optional[Labels] = None,
     ) -> Dict[str, TensorMap]:
-        # if the model user did not request an energy calculation, we have nothing to do
-        if "energy" not in outputs:
-            return {}
+        if list(outputs.keys()) != ["energy"]:
+            raise ValueError(
+                "this model can only compute 'energy', but `outputs` contains other "
+                f"keys: {', '.join(outputs.keys())}"
+            )
 
         # we don't want to worry about selected_atoms yet
         if selected_atoms is not None:

--- a/python/examples/atomistic/2-running-ase-md.py
+++ b/python/examples/atomistic/2-running-ase-md.py
@@ -92,9 +92,11 @@ class HarmonicModel(torch.nn.Module):
         outputs: Dict[str, ModelOutput],
         selected_atoms: Optional[Labels],
     ) -> Dict[str, TensorMap]:
-        # if the model user did not request an energy calculation, we have nothing to do
-        if "energy" not in outputs:
-            return {}
+        if list(outputs.keys()) != ["energy"]:
+            raise ValueError(
+                "this model can only compute 'energy', but `outputs` contains other "
+                f"keys: {', '.join(outputs.keys())}"
+            )
 
         # we don't want to worry about selected_atoms yet
         if selected_atoms is not None:

--- a/python/examples/atomistic/3-profiling.py
+++ b/python/examples/atomistic/3-profiling.py
@@ -74,9 +74,11 @@ class HarmonicModel(torch.nn.Module):
         outputs: Dict[str, ModelOutput],
         selected_atoms: Optional[Labels],
     ) -> Dict[str, TensorMap]:
-        # if the model user did not request an energy calculation, we have nothing to do
-        if "energy" not in outputs:
-            return {}
+        if list(outputs.keys()) != ["energy"]:
+            raise ValueError(
+                "this model can only compute 'energy', but `outputs` contains other "
+                f"keys: {', '.join(outputs.keys())}"
+            )
 
         # we don't want to worry about selected_atoms yet
         if selected_atoms is not None:

--- a/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
@@ -77,7 +77,8 @@ class System:
 
             Due to limitations in TorchScript C++ extensions, the dtype is returned as
             an integer, which can not be compared with :py:class:`torch.dtype`
-            instances. See :py:meth:`TensorBlock.dtype` for more information.
+            instances. See :py:attr:`TensorBlock.dtype
+            <metatensor.torch.TensorBlock.dtype>` for more information.
         """
 
     def to(

--- a/python/metatensor-torch/metatensor/torch/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/documentation.py
@@ -1232,7 +1232,7 @@ class TensorMap:
 
             Due to limitations in TorchScript C++ extensions, the dtype is returned as
             an integer, which can not be compared with :py:class:`torch.dtype`
-            instances. See :py:meth:`TensorBlock.dtype` for more information.
+            instances. See :py:attr:`TensorBlock.dtype` for more information.
         """
 
     def to(


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

In the atomistic example, we currently return an empty dictionary (`{}`) if the output key does not match the supported keys of a model. I believe this approach is not ideal because the keys of the returned dictionary from a model should match what is requested by the user/engine. This concept is often referred to as _type consistency_ or _type fidelity_.

For example, if the engine requests the keys "energy" and "other_energy", the model should return a dictionary containing these keys or raise an error.

If the model is part of a larger model, the larger model can handle the branching based on the output keys.

I can also add the explanation above as a comment in the code and/or the docs if we think it may be helpful.

Additionally, I fixed broken links to the TensorBlock.dtype attribute.

# Contributor (creator of pull-request) checklist

 - ~[ ] Tests updated (for new features and bugfixes)?~
 - [x] Documentation updated (for new features)?
 - ~[ ] Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1756355100.zip)

<!-- download-section Documentation end -->