### PR TITLE
Fix render issue in split docs

### DIFF
--- a/python/metatensor-operations/metatensor/operations/split.py
+++ b/python/metatensor-operations/metatensor/operations/split.py
@@ -89,10 +89,10 @@ def split(
     Split a :py:class:`TensorMap` into multiple :py:class:`TensorMap`.
 
     The operation is based on some specified groups of indices, along either the
-    "samples" or "properties" ``axis``. The number of returned :py:class:`TensorMap`s is
-    equal to the number of :py:class:`Labels` objects passed in ``grouped_labels``. Each
-    returned :py:class`TensorMap` will have the same keys and number of blocks at the
-    input ``tensor``, but with the dimensions of the blocks reduced to only contain the
+    "samples" or "properties" ``axis``. The length of the returned list is equal to the
+    number of :py:class:`Labels` objects passed in ``grouped_labels``. Each returned
+    :py:class`TensorMap` will have the same keys and number of blocks at the input
+    ``tensor``, but with the dimensions of the blocks reduced to only contain the
     specified indices for the corresponding group.
 
     For example, to split a tensor along the ``"samples"`` axis, according to the
@@ -198,10 +198,10 @@ def split_block(
     """
     Splits an input :py:class:`TensorBlock` into multiple :py:class:`TensorBlock`
     objects based on some specified ``grouped_labels``, along either the ``"samples"``
-    or ``"properties"`` ``axis``. The number of returned :py:class:`TensorBlock` is
-    equal to the number of :py:class:`Labels` objects passed in ``grouped_labels``. Each
-    returned :py:class`TensorBlock` will have the same keys and number of blocks at the
-    input ``tensor``, but with the dimensions of the blocks reduced to only contain the
+    or ``"properties"`` ``axis``. The length of the returned list is equal to the number
+    of :py:class:`Labels` objects passed in ``grouped_labels``. Each returned
+    :py:class`TensorBlock` will have the same keys and number of blocks at the input
+    ``tensor``, but with the dimensions of the blocks reduced to only contain the
     specified indices for the corresponding group.
 
     For example, to split a block along the ``"samples"`` axis, according to the


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

In `rst` is not supported to put any character other than a space after closing a markup. But, we have something like this in docstring of the split method

```rst
:py:class:`TensorMap`s
```

The produced rendering is not as expected

![Screenshot 2024-07-31 at 12 49 33](https://github.com/user-attachments/assets/11cdee29-c1ac-4fae-bfb3-e30cce006d2a)

I changed the sentence so that the paragraph looks like this

<img width="678" alt="Screenshot 2024-07-31 at 12 54 26" src="https://github.com/user-attachments/assets/4ec8d68e-15e0-4f11-a711-d4ca65bce62a">



# Contributor (creator of pull-request) checklist

 - ~[ ] Tests updated (for new features and bugfixes)?~
 - [x] Documentation updated (for new features)?
 - ~[ ] Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1759673529.zip)

<!-- download-section Documentation end -->