### PR TITLE
Allow for extra metadata in atomistic models

### DIFF
--- a/metatensor-torch/CHANGELOG.md
+++ b/metatensor-torch/CHANGELOG.md
@@ -23,6 +23,7 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 - `read_model_metadata` to load only the `ModelMetadata` from an exported
   atomistic model without having to load the whole model.
+- Users can now store arbitrary additional metadata in `ModelMetadata.extra`
 
 ## [Version 0.5.3](https://github.com/lab-cosmo/metatensor/releases/tag/metatensor-torch-v0.5.3) - 2024-07-15
 

--- a/metatensor-torch/include/metatensor/torch/atomistic/model.hpp
+++ b/metatensor-torch/include/metatensor/torch/atomistic/model.hpp
@@ -243,12 +243,14 @@ public:
         std::string name_,
         std::string description_,
         std::vector<std::string> authors_,
-        torch::Dict<std::string, std::vector<std::string>> references_
+        torch::Dict<std::string, std::vector<std::string>> references_,
+        torch::Dict<std::string, std::string> extra_metadata_
     ):
         name(std::move(name_)),
         description(std::move(description_)),
         authors(std::move(authors_)),
-        references(references_)
+        references(references_),
+        extra_metadata(extra_metadata_)
     {
         this->validate();
     }
@@ -273,6 +275,9 @@ public:
     ///   used by this model
     /// - "model": for reference specific to this exact model
     torch::Dict<std::string, std::vector<std::string>> references;
+
+    /// Extra metadata about this model. This can be anything.
+    torch::Dict<std::string, std::string> extra_metadata;
 
     /// Implementation of Python's `__repr__` and `__str__`, printing all
     /// metadata about this model.

--- a/metatensor-torch/include/metatensor/torch/atomistic/model.hpp
+++ b/metatensor-torch/include/metatensor/torch/atomistic/model.hpp
@@ -244,13 +244,13 @@ public:
         std::string description_,
         std::vector<std::string> authors_,
         torch::Dict<std::string, std::vector<std::string>> references_,
-        torch::Dict<std::string, std::string> extra_metadata_
+        torch::Dict<std::string, std::string> extra_
     ):
         name(std::move(name_)),
         description(std::move(description_)),
         authors(std::move(authors_)),
         references(references_),
-        extra_metadata(extra_metadata_)
+        extra(extra_)
     {
         this->validate();
     }
@@ -276,8 +276,9 @@ public:
     /// - "model": for reference specific to this exact model
     torch::Dict<std::string, std::vector<std::string>> references;
 
-    /// Extra metadata about this model. This can be anything.
-    torch::Dict<std::string, std::string> extra_metadata;
+    /// Extra metadata about this model. This can be anything, and it is intended
+    /// to be used by models to store data they need.
+    torch::Dict<std::string, std::string> extra;
 
     /// Implementation of Python's `__repr__` and `__str__`, printing all
     /// metadata about this model.

--- a/metatensor-torch/src/atomistic/model.cpp
+++ b/metatensor-torch/src/atomistic/model.cpp
@@ -468,6 +468,12 @@ std::string ModelMetadataHolder::to_json() const {
     }
     result["references"] = references;
 
+    auto extra = nlohmann::json::object();
+    for (const auto& it: this->extra) {
+        extra[it.key()] = it.value();
+    }
+    result["extra"] = extra;
+
     return result.dump(/*indent*/4, /*indent_char*/' ', /*ensure_ascii*/ true);
 }
 
@@ -544,6 +550,19 @@ ModelMetadata ModelMetadataHolder::from_json(std::string_view json) {
                 "'references.model' in JSON for ModelMetadata"
             );
             result->references.insert("model", std::move(model));
+        }
+    }
+
+    if (data.contains("extra")) {
+        if (!data["extra"].is_object()) {
+            throw std::runtime_error("'extra' in JSON for ModelMetadata must be an object");
+        }
+
+        for (const auto& item: data["extra"].items()) {
+            if (!item.value().is_string()) {
+                throw std::runtime_error("extra values in JSON for ModelMetadata must be strings");
+            }
+            result->extra.insert(item.key(), item.value());
         }
     }
 

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -371,13 +371,15 @@ TORCH_LIBRARY(metatensor, m) {
                 std::string,
                 std::string,
                 std::vector<std::string>,
-                torch::Dict<std::string, std::vector<std::string>>
+                torch::Dict<std::string, std::vector<std::string>>,
+                torch::Dict<std::string, std::string>
             >(),
             DOCSTRING, {
                 torch::arg("name") = "",
                 torch::arg("description") = "",
                 torch::arg("authors") = std::vector<std::string>(),
                 torch::arg("references") = torch::Dict<std::string, std::vector<std::string>>(),
+                torch::arg("extra_metadata") = torch::Dict<std::string, std::string>(),
             }
         )
         .def("__repr__", &ModelMetadataHolder::print)
@@ -386,6 +388,7 @@ TORCH_LIBRARY(metatensor, m) {
         .def_readwrite("description", &ModelMetadataHolder::description)
         .def_readwrite("authors", &ModelMetadataHolder::authors)
         .def_readwrite("references", &ModelMetadataHolder::references)
+        .def_readwrite("extra_metadata", &ModelMetadataHolder::extra_metadata)
         .def_pickle(
             [](const ModelMetadata& self) -> std::string {
                 return self->to_json();

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -379,7 +379,7 @@ TORCH_LIBRARY(metatensor, m) {
                 torch::arg("description") = "",
                 torch::arg("authors") = std::vector<std::string>(),
                 torch::arg("references") = torch::Dict<std::string, std::vector<std::string>>(),
-                torch::arg("extra_metadata") = torch::Dict<std::string, std::string>(),
+                torch::arg("extra") = torch::Dict<std::string, std::string>(),
             }
         )
         .def("__repr__", &ModelMetadataHolder::print)
@@ -388,7 +388,7 @@ TORCH_LIBRARY(metatensor, m) {
         .def_readwrite("description", &ModelMetadataHolder::description)
         .def_readwrite("authors", &ModelMetadataHolder::authors)
         .def_readwrite("references", &ModelMetadataHolder::references)
-        .def_readwrite("extra_metadata", &ModelMetadataHolder::extra_metadata)
+        .def_readwrite("extra", &ModelMetadataHolder::extra)
         .def_pickle(
             [](const ModelMetadata& self) -> std::string {
                 return self->to_json();

--- a/metatensor-torch/tests/atomistic.cpp
+++ b/metatensor-torch/tests/atomistic.cpp
@@ -293,6 +293,7 @@ TEST_CASE("Models metadata") {
     ],
     "class": "ModelMetadata",
     "description": "describing it",
+    "extra": {},
     "name": "some name",
     "references": {
         "architecture": [

--- a/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
@@ -399,7 +399,7 @@ class ModelMetadata:
         description: str = "",
         authors: List[str] = [],  # noqa: B006
         references: Dict[str, List[str]] = {},  # noqa: B006
-        extra_metadata: Dict[str, str] = {},  # noqa: B006
+        extra: Dict[str, str] = {},  # noqa: B006
     ):
         pass
 
@@ -423,10 +423,11 @@ class ModelMetadata:
     - "model": for reference specific to this exact model
     """
 
-    extra_metadata: Dict[str, str]
+    extra: Dict[str, str]
     """
     Any additional metadata that is not contained in the other fields. There are
-    no constraints on the keys or values of this dictionary.
+    no constraints on the keys or values of this dictionary. The extra metadata
+    is intended to be used by models to store data they need.
     """
 
 

--- a/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
@@ -399,6 +399,7 @@ class ModelMetadata:
         description: str = "",
         authors: List[str] = [],  # noqa: B006
         references: Dict[str, List[str]] = {},  # noqa: B006
+        extra_metadata: Dict[str, str] = {},  # noqa: B006
     ):
         pass
 
@@ -420,6 +421,12 @@ class ModelMetadata:
     - "architecture": for reference that introduced the general architecture
       used by this model
     - "model": for reference specific to this exact model
+    """
+
+    extra_metadata: Dict[str, str]
+    """
+    Any additional metadata that is not contained in the other fields. There are
+    no constraints on the keys or values of this dictionary.
     """
 
 

--- a/python/metatensor-torch/tests/atomistic/metadata.py
+++ b/python/metatensor-torch/tests/atomistic/metadata.py
@@ -226,3 +226,26 @@ Please cite the following references when using this model:
   * ref-4
 """
     assert str(metadata) == expected
+
+
+def test_with_extra_metadata():
+
+    metadata = ModelMetadata(
+        name="SOTA model",
+        description="This is a state-of-the-art model",
+        authors=["Author 1", "Author 2"],
+        references={
+            "model": ["ref-1", "ref-2"],
+            "architecture": ["ref-3"],
+            "implementation": ["ref-3"],
+        },
+        extra_metadata={
+            "number_of_parameters": "1000",
+            "foo": "bar",
+            "GPU?": "Yes",
+        },
+    )
+
+    assert metadata.extra_metadata["number_of_parameters"] == "1000"
+    assert metadata.extra_metadata["foo"] == "bar"
+    assert metadata.extra_metadata["GPU?"] == "Yes"

--- a/python/metatensor-torch/tests/atomistic/metadata.py
+++ b/python/metatensor-torch/tests/atomistic/metadata.py
@@ -228,7 +228,7 @@ Please cite the following references when using this model:
     assert str(metadata) == expected
 
 
-def test_with_extra_metadata():
+def test_with_extra_metadata(tmpdir):
 
     metadata = ModelMetadata(
         name="SOTA model",
@@ -239,13 +239,20 @@ def test_with_extra_metadata():
             "architecture": ["ref-3"],
             "implementation": ["ref-3"],
         },
-        extra_metadata={
+        extra={
             "number_of_parameters": "1000",
             "foo": "bar",
             "GPU?": "Yes",
         },
     )
 
-    assert metadata.extra_metadata["number_of_parameters"] == "1000"
-    assert metadata.extra_metadata["foo"] == "bar"
-    assert metadata.extra_metadata["GPU?"] == "Yes"
+    assert metadata.extra["number_of_parameters"] == "1000"
+    assert metadata.extra["foo"] == "bar"
+    assert metadata.extra["GPU?"] == "Yes"
+
+    torch.save(metadata, str(tmpdir.join("metadata.pt")))
+    loaded_metadata = torch.load(str(tmpdir.join("metadata.pt")))
+
+    assert loaded_metadata.extra["number_of_parameters"] == "1000"
+    assert loaded_metadata.extra["foo"] == "bar"
+    assert loaded_metadata.extra["GPU?"] == "Yes"


### PR DESCRIPTION
As in the title.
Should we print this extra metadata with the other metadata or not?
Should we implement a getter? (The other fields don't have it though)



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1766765529.zip)

<!-- download-section Documentation end -->