### PR TITLE
Fix incompatible arguments of torch::throw()

### DIFF
--- a/metatensor-torch/src/labels.cpp
+++ b/metatensor-torch/src/labels.cpp
@@ -839,7 +839,7 @@ LabelsEntryHolder::LabelsEntryHolder(TorchLabels labels, int64_t index):
         std::ostringstream ss;
         ss << "out of range for tensor of size " << labels_->values().sizes();
         ss << " at dimension 0";
-        throw torch::IndexError(ss.str(), "<no backtrace>");
+        throw torch::IndexError(c10::SourceLocation{}, ss.str());
 #endif
     }
 


### PR DESCRIPTION
I had to apply this patch to mcomplie metatensor_torch.
IndexError expects a source location as first argument.



<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1795965283.zip)

<!-- download-section Documentation end -->