### PR TITLE
Features standard output

### DIFF
--- a/docs/src/atomistic/outputs.rst
+++ b/docs/src/atomistic/outputs.rst
@@ -167,3 +167,65 @@ Energy ensemble gradients
 
 The gradient metadata for energy ensemble is the same as for the ``energy``
 output (see `Energy gradients`_).
+
+.. _features:
+
+Features
+^^^^^^^^
+
+Features are numerical vectors representing a given structure or
+atom/atom-centered environment in an abstract n-dimensional space. They are also
+sometimes called descriptors, representations, embedding, *etc.*
+
+Features can be computed with some analytical expression (for example `SOAP
+power spectrum`_, `atom-centered symmetry functions`_, …), or learned internally
+by a neural-network or a similar architecture.
+
+.. _SOAP power spectrum: https://doi.org/10.1103/PhysRevB.87.184115
+.. _Atom-centered symmetry functions: https://doi.org/10.1063/1.3553717
+
+In metatensor atomistic models, they are associated with the ``"features"`` key
+in the model outputs, and must adhere to the following metadata:
+
+.. list-table:: Metadata for features output
+  :widths: 2 3 7
+  :header-rows: 1
+
+  * - Metadata
+    - Names
+    - Description
+
+  * - keys
+    - ``"_"``
+    - the features keys must have a single dimension named ``"_"``, with a single
+      entry set to ``0``. The feature is always a
+      :py:class:`metatensor.torch.TensorMap` with a single block.
+
+  * - samples
+    - ``["system", "atom"]`` or ``["system"]``
+    - the samples should be named ``["system", "atom"]`` for per-atom outputs;
+      or ``["system"]`` for global outputs.
+
+      The ``"system"`` index should always be 0, and the ``"atom"`` index should
+      be the index of the atom (between 0 and the total number of atoms). If
+      ``selected_atoms`` is provided, then only the selected atoms for each
+      system should be part of the samples.
+
+  * - components
+    -
+    - the features must not have any components.
+
+  * - properties
+    -
+    - the features can have arbitrary properties.
+
+.. note::
+  Features are typically handled without a unit, so the ``"unit"`` field of
+  :py:func:`metatensor.torch.atomistic.ModelOutput` is mainly left empty.
+
+Features gradients
+------------------
+
+As for the :ref:`energy <energy-gradients>`, features are typically used with
+automatic gradient differentiation. Explicit gradients could be allowed if you
+have a use case for them, but are currently not until they are fully specified.

--- a/metatensor-torch/src/atomistic/model.cpp
+++ b/metatensor-torch/src/atomistic/model.cpp
@@ -137,7 +137,8 @@ ModelOutput ModelOutputHolder::from_json(std::string_view json) {
 
 std::unordered_set<std::string> KNOWN_OUTPUTS = {
     "energy",
-    "energy_ensemble"
+    "energy_ensemble",
+    "features"
 };
 
 void ModelCapabilitiesHolder::set_outputs(torch::Dict<std::string, ModelOutput> outputs) {

--- a/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/outputs.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Optional
 
 import torch
 
-from .. import Labels, TensorMap, dtype_name
+from .. import Labels, TensorBlock, TensorMap, dtype_name
 from . import ModelOutput, System
 
 
@@ -43,22 +43,10 @@ def _check_outputs(
                 f"the model did not produce the '{name}' output, which was requested"
             )
 
-        if name == "energy":
-            _check_energy_like(
-                "energy",
-                value,
-                systems,
-                request,
-                selected_atoms,
-            )
-        elif name == "energy_ensemble":
-            _check_energy_like(
-                "energy_ensemble",
-                value,
-                systems,
-                request,
-                selected_atoms,
-            )
+        if name in ["energy", "energy_ensemble"]:
+            _check_energy_like(name, value, systems, request, selected_atoms)
+        elif name == "features":
+            _check_features(value, systems, request, selected_atoms)
         else:
             # this is a non-standard output, there is nothing to check
             continue
@@ -74,69 +62,21 @@ def _check_energy_like(
     """
     Check either "energy" or "energy_ensemble" output metadata
     """
-
     assert name in ["energy", "energy_ensemble"]
 
-    if value.keys != Labels("_", torch.tensor([[0]])):
-        raise ValueError(
-            f"invalid keys for '{name}' output: expected `Labels('_', [[0]])`"
-        )
+    # Ensure the output contains a single block with the expected key
+    _validate_single_block(name, value)
 
-    device = value.device
+    # Check samples values from systems & selected_atoms
+    _validate_atomic_samples(name, value, systems, request, selected_atoms)
+
     energy_block = value.block_by_id(0)
+    device = value.device
 
-    if request.per_atom:
-        expected_samples_names = ["system", "atom"]
-    else:
-        expected_samples_names = ["system"]
+    # Ensure that the block has no components
+    _validate_no_components(name, energy_block)
 
-    if energy_block.samples.names != expected_samples_names:
-        raise ValueError(
-            f"invalid sample names for '{name}' output: "
-            f"expected {expected_samples_names}, got {energy_block.samples.names}"
-        )
-
-    # check samples values from systems & selected_atoms
-    if request.per_atom:
-        expected_values: List[List[int]] = []
-        for s, system in enumerate(systems):
-            for a in range(len(system)):
-                expected_values.append([s, a])
-
-        expected_samples = Labels(
-            ["system", "atom"], torch.tensor(expected_values, device=device)
-        )
-        if selected_atoms is not None:
-            expected_samples = expected_samples.intersection(selected_atoms)
-
-        if len(expected_samples.union(energy_block.samples)) != len(expected_samples):
-            raise ValueError(
-                f"invalid samples entries for '{name}' output, they do not match the "
-                f"`systems` and `selected_atoms`. Expected samples:\n{expected_samples}"
-            )
-
-    else:
-        expected_samples = Labels(
-            "system", torch.arange(len(systems), device=device).reshape(-1, 1)
-        )
-        if selected_atoms is not None:
-            selected_systems = Labels(
-                "system", torch.unique(selected_atoms.column("system")).reshape(-1, 1)
-            )
-            expected_samples = expected_samples.intersection(selected_systems)
-
-        if len(expected_samples.union(energy_block.samples)) != len(expected_samples):
-            raise ValueError(
-                f"invalid samples entries for '{name}' output, they do not match the "
-                f"`systems` and `selected_atoms`. Expected samples:\n{expected_samples}"
-            )
-
-    if len(energy_block.components) != 0:
-        raise ValueError(
-            f"invalid components for '{name}' output: components should be empty"
-        )
-
-    # the only difference between energy & energy_ensemble is in the properties
+    # The only difference between energy & energy_ensemble is in the properties
     if name == "energy":
         expected_properties = Labels("energy", torch.tensor([[0]], device=device))
         message = "`Labels('energy', [[0]])`"
@@ -202,3 +142,107 @@ def _check_energy_like(
                     f"invalid components for '{name}' output 'positions' gradients: "
                     "expected Labels('xyz', [[0], [1], [2]]) for the first component"
                 )
+
+
+def _check_features(
+    value: TensorMap,
+    systems: List[System],
+    request: ModelOutput,
+    selected_atoms: Optional[Labels],
+):
+    """
+    Check "features" output metadata. It is standardized with Plumed
+    https://www.plumed.org/doc-master/user-doc/html/_m_e_t_a_t_e_n_s_o_r.html
+    """
+    # Ensure the output contains a single block with the expected key
+    _validate_single_block("features", value)
+
+    # Check samples values from systems & selected_atoms
+    _validate_atomic_samples("features", value, systems, request, selected_atoms)
+
+    features_block = value.block_by_id(0)
+
+    # Check that the block has no components
+    _validate_no_components("features", features_block)
+
+    # Should not have any explicit gradients
+    # all gradient calculations are done using autograd
+    if len(features_block.gradients_list()) > 0:
+        raise ValueError(
+            "invalid gradients for 'features' output: it should not have any explicit",
+            "gradients. all gradient calculations should be done using autograd",
+        )
+
+
+def _validate_atomic_samples(
+    name: str,
+    value: TensorMap,
+    systems: List[System],
+    request: ModelOutput,
+    selected_atoms: Optional[Labels],
+):
+    """
+    Validates the sample labels in the output against the expected structure
+    """
+    device = value.device
+    block = value.block_by_id(0)
+
+    # Check if the samples names are as expected based on whether the output is
+    # per-atom or global
+    if request.per_atom:
+        expected_samples_names = ["system", "atom"]
+    else:
+        expected_samples_names = ["system"]
+
+    if block.samples.names != expected_samples_names:
+        raise ValueError(
+            f"invalid sample names for '{name}' output: "
+            f"expected {expected_samples_names}, got {block.samples.names}"
+        )
+
+    # Check if the samples match the systems and selected_atoms
+    if request.per_atom:
+        expected_values: List[List[int]] = []
+        for s, system in enumerate(systems):
+            for a in range(len(system)):
+                expected_values.append([s, a])
+        expected_samples = Labels(
+            ["system", "atom"], torch.tensor(expected_values, device=device)
+        )
+        if selected_atoms is not None:
+            expected_samples = expected_samples.intersection(selected_atoms)
+    else:
+        expected_samples = Labels(
+            "system", torch.arange(len(systems), device=device).reshape(-1, 1)
+        )
+        if selected_atoms is not None:
+            selected_systems = Labels(
+                "system", torch.unique(selected_atoms.column("system")).reshape(-1, 1)
+            )
+            expected_samples = expected_samples.intersection(selected_systems)
+
+    if len(expected_samples.union(block.samples)) != len(expected_samples):
+        raise ValueError(
+            f"invalid samples entries for '{name}' output, they do not match the "
+            f"`systems` and `selected_atoms`. Expected samples:\n{expected_samples}"
+        )
+
+
+def _validate_single_block(name: str, value: TensorMap):
+    """
+    Ensure the TensorMap has a single block with the expected key
+    """
+    if value.keys != Labels("_", torch.tensor([[0]])):
+        raise ValueError(
+            f"invalid keys for '{name}' output: expected `Labels('_', [[0]])`"
+        )
+
+
+def _validate_no_components(name: str, block: TensorBlock):
+    """
+    Ensure the block has no components"
+    """
+    if len(block.components) != 0:
+        raise ValueError(
+            f"invalid components for {name} output: components should be empty"
+        )

--- a/python/metatensor-torch/tests/atomistic/outputs.py
+++ b/python/metatensor-torch/tests/atomistic/outputs.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Optional
 
+import pytest
 import torch
 
 from metatensor.torch import Labels, TensorBlock, TensorMap
@@ -13,8 +14,36 @@ from metatensor.torch.atomistic import (
 )
 
 
-class EnergyEnsembleModel(torch.nn.Module):
-    """A metatensor atomistic model returning an energy ensemble"""
+@pytest.fixture
+def system():
+    return System(
+        types=torch.tensor([1, 2, 3]),
+        positions=torch.tensor([[1, 1, 1], [2, 2, 2], [3, 3, 3]], dtype=torch.float64),
+        cell=torch.zeros([3, 3], dtype=torch.float64),
+    )
+
+
+@pytest.fixture
+def get_capabilities() -> callable:
+    def _create_capabilities(output_name: str) -> ModelCapabilities:
+        return ModelCapabilities(
+            length_unit="angstrom",
+            atomic_types=[1, 2, 3],
+            interaction_range=4.3,
+            outputs={output_name: ModelOutput(per_atom=False)},
+            supported_devices=["cpu"],
+            dtype="float64",
+        )
+
+    return _create_capabilities
+
+
+class BaseAtomisticModel(torch.nn.Module):
+    """Base class for metatensor atomistic models"""
+
+    def __init__(self, output_name: str):
+        super().__init__()
+        self.output_name = output_name
 
     def forward(
         self,
@@ -22,42 +51,37 @@ class EnergyEnsembleModel(torch.nn.Module):
         outputs: Dict[str, ModelOutput],
         selected_atoms: Optional[Labels] = None,
     ) -> Dict[str, TensorMap]:
-        assert "energy_ensemble" in outputs
-        assert not outputs["energy_ensemble"].per_atom
+        assert self.output_name in outputs
+        assert not outputs[self.output_name].per_atom
         assert selected_atoms is None
 
-        return_dict: Dict[str, TensorMap] = {}
         block = TensorBlock(
             values=torch.tensor([[0.0, 1.0, 2.0]] * len(systems), dtype=torch.float64),
             samples=Labels("system", torch.arange(len(systems)).reshape(-1, 1)),
             components=[],
             properties=Labels("energy", torch.tensor([[0], [1], [2]])),
         )
-        return_dict["energy_ensemble"] = TensorMap(
-            Labels("_", torch.tensor([[0]])), [block]
-        )
-        return return_dict
+        return {self.output_name: TensorMap(Labels("_", torch.tensor([[0]])), [block])}
 
 
-def test_energy_ensemble_model():
+class EnergyEnsembleModel(BaseAtomisticModel):
+    """A metatensor atomistic model returning an energy ensemble"""
+
+    def __init__(self):
+        super().__init__("energy_ensemble")
+
+
+class FeaturesModel(BaseAtomisticModel):
+    """A metatensor atomistic model returning features"""
+
+    def __init__(self):
+        super().__init__("features")
+
+
+def test_energy_ensemble_model(system, get_capabilities):
     model = EnergyEnsembleModel()
-
-    capabilities = ModelCapabilities(
-        length_unit="angstrom",
-        atomic_types=[1, 2, 3],
-        interaction_range=4.3,
-        outputs={"energy_ensemble": ModelOutput(per_atom=False)},
-        supported_devices=["cpu"],
-        dtype="float64",
-    )
-
+    capabilities = get_capabilities("energy_ensemble")
     atomistic = MetatensorAtomisticModel(model.eval(), ModelMetadata(), capabilities)
-
-    system = System(
-        types=torch.tensor([1, 2, 3]),
-        positions=torch.tensor([[1, 1, 1], [2, 2, 2], [3, 3, 3]], dtype=torch.float64),
-        cell=torch.zeros([3, 3], dtype=torch.float64),
-    )
 
     options = ModelEvaluationOptions(
         outputs={"energy_ensemble": ModelOutput(per_atom=False)}
@@ -72,3 +96,22 @@ def test_energy_ensemble_model():
     assert list(ensemble.block().values.shape) == [2, 3]
     assert ensemble.block().samples.names == ["system"]
     assert ensemble.block().properties.names == ["energy"]
+
+
+def test_features_model(system, get_capabilities):
+    model = FeaturesModel()
+    capabilities = get_capabilities("features")
+    atomistic = MetatensorAtomisticModel(model.eval(), ModelMetadata(), capabilities)
+
+    options = ModelEvaluationOptions(outputs={"features": ModelOutput(per_atom=False)})
+
+    result = atomistic([system, system], options, check_consistency=True)
+    assert "features" in result
+
+    features = result["features"]
+    assert features.keys == Labels("_", torch.tensor([[0]]))
+    assert list(features.block().values.shape) == [2, 3]
+    assert features.block().samples.names == ["system"]
+    assert features.block().properties.names == ["energy"]
+    assert features.block().components == []
+    assert len(result["features"].blocks()) == 1


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->
Added a new standard output "features" to return the internal or learned features from a model (model's intermediate values before final predictions). The output format checks were taken from the Plumed [doc](https://www.plumed.org/doc-master/user-doc/html/_m_e_t_a_t_e_n_s_o_r.html).


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1874675914.zip)

<!-- download-section Documentation end -->