### PR TITLE
Improve the version list in docs

### DIFF
--- a/docs/extensions/versions_list.py
+++ b/docs/extensions/versions_list.py
@@ -1,13 +1,107 @@
-from sphinx_design.grids import GridItemCardDirective
+import docutils
+from packaging.version import parse as version_parse
+from sphinx.util.docutils import SphinxDirective
 
 
 DOC_ROOT = "https://docs.metatensor.org/"
 
 
-class GridItemVersion(GridItemCardDirective):
+class VersionList(SphinxDirective):
     """
-    Wrapper for GridItemCardDirective (``.. grid-item-card::``) as used for versions
-    lists in the docs.
+    Directive for a list of previous versions of the documentation.
+
+    This is rendered by manually generating ReST using sphinx-design directives.
+    """
+
+    has_content = True
+    required_arguments = 0
+    optional_arguments = 0
+    option_spec = {
+        "tag-prefix": str,
+        "url-suffix": str,
+    }
+
+    def run(self):
+        # group together versions with the same major & minor components
+        grouped_versions = {}
+        content = self.parse_content_to_nodes()
+        for node in content:
+            if not isinstance(node, VersionNode):
+                raise ValueError(
+                    "only `.. version::` is allowed inside `.. version-list::`"
+                )
+
+            version = version_parse(node.version)
+            group = (version.major, version.minor)
+            if group not in grouped_versions:
+                grouped_versions[group] = []
+
+            grouped_versions[group].append(node)
+
+        # generate ReST with the desired markup
+        generated_content = """
+.. grid::
+    :margin: 0 0 0 0\n"""
+
+        for group_i, (version_short, group) in enumerate(grouped_versions.items()):
+
+            if group_i < 3:
+                generated_content += f"""
+    .. grid-item::
+        :columns: 12 6 3 3
+        :class: sd-p-1
+
+        .. dropdown:: Version {version_short[0]}.{version_short[1]}
+            :class-body: sd-mb-0  sd-pb-0
+            :class-title: font-size-small\n"""
+            elif group_i == 3:
+                generated_content += """
+    .. grid-item::
+        :columns: 12 6 3 3
+        :class: sd-p-1
+
+        .. dropdown:: Older versions
+            :class-body: sd-mb-0  sd-pb-0
+            :class-title: font-size-small\n"""
+
+            for node in group:
+                version = node.version
+                tag_prefix = self.options["tag-prefix"]
+
+                url_suffix = (
+                    node.url_suffix
+                    if node.url_suffix is not None
+                    else self.options["url-suffix"]
+                )
+
+                generated_content += f"""
+            .. card:: {version}
+                :class-body: sd-p-2
+                :class-title: sd-mb-0
+                :text-align: center
+                :link: {DOC_ROOT}/{tag_prefix}{version}/{url_suffix}
+                :link-type: url\n"""
+
+        # parse the generated ReST
+        return self.parse_text_to_nodes(generated_content)
+
+
+class VersionNode(docutils.nodes.Node):
+    """
+    Node for a single version directive. This is only used to transmit information
+    between the ``.. version::`` directive and the version list, and never rendered on
+    its own.
+    """
+
+    def __init__(self, version, url_suffix):
+        self.version = version
+        self.url_suffix = url_suffix
+
+
+class VersionItem(SphinxDirective):
+    """
+    A single item in a version list. This can override the url suffix if a different url
+    was used for this version.
     """
 
     has_content = False
@@ -15,33 +109,18 @@ class GridItemVersion(GridItemCardDirective):
     optional_arguments = 0
     final_argument_whitespace = False
     option_spec = {
-        "tag-prefix": str,
         "url-suffix": str,
     }
 
     def run(self):
-        version = self.arguments.pop()
-        self.arguments.append(f"Version {version}")
-
-        tag_prefix = self.options.pop("tag-prefix")
-        url_suffix = self.options.pop("url-suffix")
-
-        self.options["link"] = f"{DOC_ROOT}/{tag_prefix}{version}/{url_suffix}"
-        self.options["link-type"] = "url"
-        self.options["columns"] = [
-            "sd-col-xs-12",
-            "sd-col-sm-6",
-            "sd-col-md-3",
-            "sd-col-lg-3",
+        return [
+            VersionNode(
+                version=self.arguments[0],
+                url_suffix=self.options.get("url-suffix"),
+            )
         ]
-        # add padding all around the content
-        self.options["class-body"] = ["sd-p-2"]
-        # remove margin on the bottom
-        self.options["class-title"] = ["sd-mb-0"]
-        self.options["text-align"] = ["sd-text-center"]
-
-        return super().run()
 
 
 def setup(app):
-    app.add_directive("grid-item-version", GridItemVersion)
+    app.add_directive("version-list", VersionList)
+    app.add_directive("version", VersionItem)

--- a/docs/src/atomistic/reference/index.rst
+++ b/docs/src/atomistic/reference/index.rst
@@ -9,20 +9,21 @@ API reference
   ``metatensor-torch`` version |metatensor-torch-version|. For other versions,
   look in the following pages:
 
-  .. grid::
-    :margin: 0 0 0 0
 
-    .. grid-item-version:: 0.3.0
-        :tag-prefix: metatensor-torch-v
-        :url-suffix: atomistic/reference/index.html
+  .. version-list::
+    :tag-prefix: metatensor-torch-v
+    :url-suffix: atomistic/reference/index.html
 
-    .. grid-item-version:: 0.2.1
-        :tag-prefix: metatensor-torch-v
-        :url-suffix: atomistic/reference/index.html
+    .. version:: 0.5.3
+    .. version:: 0.5.2
+    .. version:: 0.5.1
+    .. version:: 0.5.0
+    .. version:: 0.4.0
+    .. version:: 0.3.0
+    .. version:: 0.2.1
 
-    .. grid-item-version:: 0.2.0
-        :tag-prefix: metatensor-torch-v
-        :url-suffix: atomistic/reference/index.html
+    .. version:: 0.2.0
+      :url-suffix: reference/torch/index.html
 
 
 The atomistic machine learning models capabilities of metatensor are part of the

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -153,7 +153,8 @@ rst_prolog = f"""
 
 # -- General configuration ---------------------------------------------------
 
-needs_sphinx = "4.0.0"
+needs_sphinx = "7.4.0"
+suppress_warnings = ["config.cache"]
 
 python_use_unqualified_type_names = True
 

--- a/docs/src/core/reference/c/index.rst
+++ b/docs/src/core/reference/c/index.rst
@@ -8,44 +8,16 @@ C API reference
   This is the documentation for ``metatensor-core`` version
   |metatensor-core-version|. For other versions, look in the following pages:
 
-  .. grid::
-    :margin: 0 0 0 0
+  .. version-list::
+    :tag-prefix: metatensor-core-v
+    :url-suffix: core/reference/c/index.html
 
-    .. grid-item-version:: 0.1.9
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/c/index.html
-
-    .. grid-item-version:: 0.1.7
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/c/index.html
-
-    .. grid-item-version:: 0.1.6
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/c/index.html
-
-    .. grid-item-version:: 0.1.5
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/c/index.html
-
-    .. grid-item-version:: 0.1.4
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/c/index.html
-
-    .. grid-item-version:: 0.1.3
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/c/index.html
-
-    .. grid-item-version:: 0.1.2
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/c/index.html
-
-    .. grid-item-version:: 0.1.1
-      :tag-prefix: metatensor-core-v
-      :url-suffix: reference/c/index.html
-
-    .. grid-item-version:: 0.1.0
-      :tag-prefix: metatensor-core-v
-      :url-suffix: reference/c/index.html
+    .. version:: 0.1.9
+    .. version:: 0.1.7
+    .. version:: 0.1.6
+    .. version:: 0.1.5
+    .. version:: 0.1.4
+    .. version:: 0.1.3
 
 ``metatensor`` offers a C API that can be called from any language able to call
 C functions (in particular, this includes Python, Fortran with ``iso_c_env``,

--- a/docs/src/core/reference/cxx/index.rst
+++ b/docs/src/core/reference/cxx/index.rst
@@ -8,44 +8,16 @@ C++ API reference
   This is the documentation for ``metatensor-core`` version
   |metatensor-core-version|. For other versions, look in the following pages:
 
-  .. grid::
-    :margin: 0 0 0 0
+  .. version-list::
+    :tag-prefix: metatensor-core-v
+    :url-suffix: core/reference/cxx/index.html
 
-    .. grid-item-version:: 0.1.9
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/cxx/index.html
-
-    .. grid-item-version:: 0.1.7
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/cxx/index.html
-
-    .. grid-item-version:: 0.1.6
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/cxx/index.html
-
-    .. grid-item-version:: 0.1.5
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/cxx/index.html
-
-    .. grid-item-version:: 0.1.4
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/cxx/index.html
-
-    .. grid-item-version:: 0.1.3
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/cxx/index.html
-
-    .. grid-item-version:: 0.1.2
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/cxx/index.html
-
-    .. grid-item-version:: 0.1.1
-      :tag-prefix: metatensor-core-v
-      :url-suffix: reference/cxx/index.html
-
-    .. grid-item-version:: 0.1.0
-      :tag-prefix: metatensor-core-v
-      :url-suffix: reference/cxx/index.html
+    .. version:: 0.1.9
+    .. version:: 0.1.7
+    .. version:: 0.1.6
+    .. version:: 0.1.5
+    .. version:: 0.1.4
+    .. version:: 0.1.3
 
 Metatensor offers a C++ API, built on top of the :ref:`C API <c-api-core>`.
 You can the provided classes and functions in your own code by :ref:`installing

--- a/docs/src/core/reference/python/index.rst
+++ b/docs/src/core/reference/python/index.rst
@@ -8,44 +8,16 @@ Python API reference
   This is the documentation for ``metatensor-core`` version
   |metatensor-core-version|. For other versions, look in the following pages:
 
-  .. grid::
-    :margin: 0 0 0 0
+  .. version-list::
+    :tag-prefix: metatensor-core-v
+    :url-suffix: core/reference/python/index.html
 
-    .. grid-item-version:: 0.1.9
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/python/index.html
-
-    .. grid-item-version:: 0.1.7
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/python/index.html
-
-    .. grid-item-version:: 0.1.6
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/python/index.html
-
-    .. grid-item-version:: 0.1.5
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/python/index.html
-
-    .. grid-item-version:: 0.1.4
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/python/index.html
-
-    .. grid-item-version:: 0.1.3
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/python/index.html
-
-    .. grid-item-version:: 0.1.2
-      :tag-prefix: metatensor-core-v
-      :url-suffix: core/reference/python/index.html
-
-    .. grid-item-version:: 0.1.1
-      :tag-prefix: metatensor-core-v
-      :url-suffix: reference/python/index.html
-
-    .. grid-item-version:: 0.1.0
-      :tag-prefix: metatensor-core-v
-      :url-suffix: reference/python/index.html
+    .. version:: 0.1.9
+    .. version:: 0.1.7
+    .. version:: 0.1.6
+    .. version:: 0.1.5
+    .. version:: 0.1.4
+    .. version:: 0.1.3
 
 
 .. py:currentmodule:: metatensor

--- a/docs/src/learn/reference/index.rst
+++ b/docs/src/learn/reference/index.rst
@@ -8,26 +8,14 @@ API reference
   This is the documentation for ``metatensor-learn`` version
   |metatensor-learn-version|. For other versions, look in the following pages:
 
+  .. version-list::
+    :tag-prefix: metatensor-learn-v
+    :url-suffix: learn/reference/index.html
 
-  .. grid::
-    :margin: 0 0 0 0
-
-    .. grid-item-version:: 0.2.2
-        :tag-prefix: metatensor-learn-v
-        :url-suffix: learn/reference/index.html
-
-    .. grid-item-version:: 0.2.1
-        :tag-prefix: metatensor-learn-v
-        :url-suffix: learn/reference/index.html
-
-    .. grid-item-version:: 0.2.0
-        :tag-prefix: metatensor-learn-v
-        :url-suffix: learn/reference/index.html
-
-    .. grid-item-version:: 0.1.0
-        :tag-prefix: metatensor-learn-v
-        :url-suffix: learn/reference/index.html
-
+    .. version:: 0.2.2
+    .. version:: 0.2.1
+    .. version:: 0.2.0
+    .. version:: 0.1.0
 
 .. toctree::
     :maxdepth: 3

--- a/docs/src/operations/reference/index.rst
+++ b/docs/src/operations/reference/index.rst
@@ -9,25 +9,16 @@ API reference
   |metatensor-operations-version|. For other versions, look in the following
   pages:
 
-  .. grid::
-    :margin: 0 0 0 0
+  .. version-list::
+    :tag-prefix: metatensor-operations-v
+    :url-suffix: operations/reference/index.html
 
-    .. grid-item-version:: 0.2.2
-        :tag-prefix: metatensor-operations-v
-        :url-suffix: operations/reference/index.html
+    .. version:: 0.2.2
+    .. version:: 0.2.1
+    .. version:: 0.2.0
 
-    .. grid-item-version:: 0.2.1
-        :tag-prefix: metatensor-operations-v
-        :url-suffix: operations/reference/index.html
-
-    .. grid-item-version:: 0.2.0
-        :tag-prefix: metatensor-operations-v
-        :url-suffix: operations/reference/index.html
-
-    .. grid-item-version:: 0.1.0
-        :tag-prefix: metatensor-operations-v
-        :url-suffix: reference/operations/index.html
-
+    .. version:: 0.1.0
+      :url-suffix: reference/operations/index.html
 
 All operations are automatically re-exported from
 ``metatensor.operations.<xxx>`` as ``metatensor.<xxx>`` when using the Python

--- a/docs/src/torch/reference/index.rst
+++ b/docs/src/torch/reference/index.rst
@@ -8,45 +8,23 @@ API reference
   This is the documentation for ``metatensor-torch`` version
   |metatensor-torch-version|. For other versions, look in the following pages:
 
-  .. grid::
-    :margin: 0 0 0 0
+  .. version-list::
+    :tag-prefix: metatensor-torch-v
+    :url-suffix: torch/reference/index.html
 
-    .. grid-item-version:: 0.5.3
-        :tag-prefix: metatensor-torch-v
-        :url-suffix: torch/reference/index.html
+    .. version:: 0.5.3
+    .. version:: 0.5.2
+    .. version:: 0.5.1
+    .. version:: 0.5.0
+    .. version:: 0.4.0
+    .. version:: 0.3.0
+    .. version:: 0.2.1
 
-    .. grid-item-version:: 0.5.2
-        :tag-prefix: metatensor-torch-v
-        :url-suffix: torch/reference/index.html
+    .. version:: 0.2.0
+      :url-suffix: reference/torch/index.html
 
-    .. grid-item-version:: 0.5.1
-        :tag-prefix: metatensor-torch-v
-        :url-suffix: torch/reference/index.html
-
-    .. grid-item-version:: 0.5.0
-        :tag-prefix: metatensor-torch-v
-        :url-suffix: torch/reference/index.html
-
-    .. grid-item-version:: 0.4.0
-        :tag-prefix: metatensor-torch-v
-        :url-suffix: torch/reference/index.html
-
-    .. grid-item-version:: 0.3.0
-        :tag-prefix: metatensor-torch-v
-        :url-suffix: torch/reference/index.html
-
-    .. grid-item-version:: 0.2.1
-        :tag-prefix: metatensor-torch-v
-        :url-suffix: torch/reference/index.html
-
-    .. grid-item-version:: 0.2.0
-        :tag-prefix: metatensor-torch-v
-        :url-suffix: reference/torch/index.html
-
-    .. grid-item-version:: 0.1.0
-        :tag-prefix: metatensor-torch-v
-        :url-suffix: reference/torch/index.html
-
+    .. version:: 0.1.0
+      :url-suffix: reference/torch/index.html
 
 .. py:currentmodule:: metatensor.torch
 

--- a/docs/static/css/metatensor.css
+++ b/docs/static/css/metatensor.css
@@ -32,3 +32,7 @@ body[data-theme="auto"] {
         }
     }
 }
+
+.font-size-small {
+    font-size: small !important;
+}

--- a/metatensor-core/include/metatensor.hpp
+++ b/metatensor-core/include/metatensor.hpp
@@ -2163,8 +2163,8 @@ public:
     /// `keys_to_move.count() == 0`), then the new property labels will contain
     /// entries corresponding to the merged blocks only. For example, merging a
     /// block with key `a=0` and properties `p=1, 2` with a block with key `a=2`
-    /// and properties `p=1, 3` will produce a block with properties `a, p = (0,
-    /// 1), (0, 2), (2, 1), (2, 3)`.
+    /// and properties `p=1, 3` will produce a block with properties
+    /// `a, p = (0, 1), (0, 2), (2, 1), (2, 3)`.
     ///
     /// If `keys_to_move` contains entries, then the property labels must be the
     /// same for all the merged blocks. In that case, the merged property labels

--- a/tox.ini
+++ b/tox.ini
@@ -245,7 +245,7 @@ deps =
     {[testenv]packaging_deps}
     cmake
 
-    sphinx == 7.2.6
+    sphinx == 7.4.*
     sphinx-toggleprompt # hide the prompt (>>>) in python doctests
     sphinx-gallery      # convert python files into nice documentation
     pygments            # syntax highligthing


### PR DESCRIPTION
This changes the extension we use for linking to previous versions of the documentation, making the source code and rendered version cleaner.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1861291718.zip)

<!-- download-section Documentation end -->