### PR TITLE
Fix metadata in merged metatensor-torch wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -271,10 +271,14 @@ jobs:
           mkdir dist/unpacked
           find dist -name "*.whl" -print -exec python -m wheel unpack --dest dist/unpacked/ {} ';'
 
-          sed -i "s/Requires-Dist: torch ==.*/$MERGED_TORCH_REQUIRE/" dist/unpacked/metatensor_torch-*/metatensor_torch-*.dist-info/METADATA
+          sed -i "s/Requires-Dist: torch.*/$MERGED_TORCH_REQUIRE/" dist/unpacked/metatensor_torch-*/metatensor_torch-*.dist-info/METADATA
 
           echo "\n\n METADATA = \n\n"
           cat dist/unpacked/metatensor_torch-*/metatensor_torch-*.dist-info/METADATA
+
+          # check the right metadata was added to the file. grep will exit with
+          # code `1` if the line is not found, which will stop CI
+          grep "$MERGED_TORCH_REQUIRE" dist/unpacked/metatensor_torch-*/metatensor_torch-*.dist-info/METADATA
 
           # repack the directory as a new wheel
           mkdir wheelhouse


### PR DESCRIPTION
The wheels for metatensor-torch v0.5.4 contain wrong metadata: they all declare requiring a single specific version of torch when they are actually compatible with any (supported) version. This is because our script to edit the metadata failed (the matched string changed from `torch ==2.2.*` to `torch==2.2.*`). This should fix it and account for both cases.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1882716057.zip)

<!-- download-section Documentation end -->

<!-- download-section Build Python wheels start -->
⚙️ [Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/lab-cosmo/metatensor/actions/artifacts/1882935007.zip)

<!-- download-section Build Python wheels end -->