### PR TITLE
Drop support for PyTorch <2.1

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -101,7 +101,7 @@ jobs:
     name: ${{ matrix.name }} (torch v${{ matrix.torch-version }})
     strategy:
       matrix:
-        torch-version: ['1.12', '1.13', '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6']
+        torch-version: ['2.1', '2.2', '2.3', '2.4', '2.5', '2.6']
         arch: ['arm64', 'x86_64']
         os: ['ubuntu-22.04', 'ubuntu-22.04-arm', 'macos-13', 'macos-14', 'windows-2022']
         exclude:
@@ -111,9 +111,6 @@ jobs:
           - {os: ubuntu-22.04, arch: arm64}
           - {os: macos-14, arch: x86_64}
           - {os: ubuntu-22.04-arm, arch: x86_64}
-          # arch arm64 on macos is only supported for torch >= 2.0
-          - {os: macos-14, arch: arm64, torch-version: '1.12'}
-          - {os: macos-14, arch: arm64, torch-version: '1.13'}
           # arch x86_64 on macos is only supported for torch <2.3
           - {os: macos-13, arch: x86_64, torch-version: '2.3'}
           - {os: macos-13, arch: x86_64, torch-version: '2.4'}
@@ -147,9 +144,6 @@ jobs:
             rust-target: x86_64-pc-windows-msvc
             cibw-arch: AMD64
           # add the right python version image for each torch version
-          - {torch-version: '1.12', cibw-python: 'cp310-*'}
-          - {torch-version: '1.13', cibw-python: 'cp310-*'}
-          - {torch-version: '2.0', cibw-python: 'cp311-*'}
           - {torch-version: '2.1', cibw-python: 'cp311-*'}
           - {torch-version: '2.2', cibw-python: 'cp312-*'}
           - {torch-version: '2.3', cibw-python: 'cp312-*'}
@@ -157,9 +151,6 @@ jobs:
           - {torch-version: '2.5', cibw-python: 'cp312-*'}
           - {torch-version: '2.6', cibw-python: 'cp312-*'}
           # set the right manylinux image to use
-          - {torch-version: '1.12', manylinux-version: "2014"}
-          - {torch-version: '1.13', manylinux-version: "2014"}
-          - {torch-version: '2.0', manylinux-version: "2014"}
           - {torch-version: '2.1', manylinux-version: "2014"}
           - {torch-version: '2.2', manylinux-version: "2014"}
           - {torch-version: '2.3', manylinux-version: "2014"}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             python-version: "3.9"
-            torch-version: "1.12.*"
+            torch-version: "2.1"
             numpy-version-pin: "<2.0"
           - os: ubuntu-22.04
             python-version: "3.9"

--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -27,7 +27,7 @@ jobs:
           - os: ubuntu-22.04
             container: ubuntu:20.04
             extra-name: ", cmake 3.16"
-            torch-version: "1.12"
+            torch-version: "2.1"
             cargo-test-flags: ""
             cxx-flags: -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -g
 

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -154,7 +154,7 @@ and use it will depend on the programming language you are using.
 
         We provide pre-compiled wheels on PyPI that are compatible with all the
         supported torch versions at the time of metatensor-torch release.
-        Currently PyTorch version 1.12 and above is supported.
+        Currently PyTorch version 2.1 and above is supported.
 
         If you want to use the code with an unsupported PyTorch version, or a
         new release of PyTorch which did not exist yet when we released
@@ -235,7 +235,7 @@ and use it will depend on the programming language you are using.
         - :ref:`the C++ interface <install-c>` of metatensor.
         - the C++ part of PyTorch, which you can install `on it's own
           <https://pytorch.org/get-started/locally/>`_. We are compatible with
-          libtorch version 1.12 or above. You can also use the same library as
+          libtorch version 2.1 or above. You can also use the same library as
           the Python version of torch by adding the output of the command below
           to ``CMAKE_PREFIX_PATH``:
 

--- a/metatensor-torch/CMakeLists.txt
+++ b/metatensor-torch/CMakeLists.txt
@@ -96,7 +96,7 @@ endif()
 # fixed version in `cmake/FindCUDNN.cmake`
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
 
-find_package(Torch 1.12 REQUIRED)
+find_package(Torch 2.1 REQUIRED)
 
 set(METATENSOR_TORCH_HEADERS
     "include/metatensor/torch/array.hpp"

--- a/python/metatensor_learn/metatensor/learn/_backend.py
+++ b/python/metatensor_learn/metatensor/learn/_backend.py
@@ -50,13 +50,7 @@ def is_metatensor_class(value, typ):
         return True
     else:
         if _HAS_TORCH and isinstance(value, torch.ScriptObject):
-            if _version_at_least(torch.__version__, "2.1.0"):
-                # _type() is only working for torch >= 2.1
-                is_metatensor_torch_class = "metatensor" in str(value._type())
-            else:
-                # we don't know, it's fine
-                is_metatensor_torch_class = False
-
+            is_metatensor_torch_class = "metatensor" in str(value._type())
             if is_metatensor_torch_class:
                 warnings.warn(
                     "Trying to use code from ``metatensor.learn`` with objects from "

--- a/python/metatensor_operations/metatensor/operations/_backend.py
+++ b/python/metatensor_operations/metatensor/operations/_backend.py
@@ -75,13 +75,7 @@ def is_metatensor_class(value, typ):
         return True
     else:
         if _HAS_TORCH and isinstance(value, torch.ScriptObject):
-            if _version_at_least(torch.__version__, "2.1.0"):
-                # _type() is only working for torch >= 2.1
-                is_metatensor_torch_class = "metatensor" in str(value._type())
-            else:
-                # we don't know, it's fine
-                is_metatensor_torch_class = False
-
+            is_metatensor_torch_class = "metatensor" in str(value._type())
             if is_metatensor_torch_class:
                 warnings.warn(
                     "Trying to use operations from metatensor with objects from "

--- a/python/metatensor_operations/metatensor/operations/_dispatch.py
+++ b/python/metatensor_operations/metatensor/operations/_dispatch.py
@@ -21,7 +21,6 @@ try:
 
     torch_dtype = torch.dtype
     torch_device = torch.device
-    torch_version = parse_version(torch.__version__)
 
 except ImportError:
 
@@ -33,8 +32,6 @@ except ImportError:
 
     class torch_device:
         pass
-
-    torch_version = (0, 0, 0)
 
 
 UNKNOWN_ARRAY_TYPE = (
@@ -490,7 +487,7 @@ def index_add(output_array, input_array, index):
     output_array.index_add_(0, torch.tensor(index),input_array)
 
     """
-    index = to_index_array(index)
+    _index_array_checks(index)
     if isinstance(input_array, TorchTensor):
         if not isinstance(index, TorchTensor):
             index = torch.tensor(index).to(device=input_array.device)
@@ -860,7 +857,7 @@ def to(
         raise TypeError(UNKNOWN_ARRAY_TYPE)
 
 
-def _to_index_array_checks(array):
+def _index_array_checks(array):
     if len(array.shape) != 1:
         raise ValueError("Index arrays must be 1D")
 
@@ -872,33 +869,6 @@ def _to_index_array_checks(array):
             raise ValueError("Index arrays must be integers")
     else:
         raise TypeError(UNKNOWN_ARRAY_TYPE)
-
-
-if torch_version >= (2, 0, 0):
-
-    def to_index_array(array):
-        """
-        Returns an array that is suitable for indexing a dimension of
-        a different array.
-        """
-        _to_index_array_checks(array)
-        return array
-
-else:
-
-    def to_index_array(array):
-        """
-        Returns an array that is suitable for indexing a dimension of
-        a different array, converting torch data to long/64-bit integers
-        """
-        _to_index_array_checks(array)
-
-        if isinstance(array, TorchTensor):
-            return array.to(torch.long)
-        elif isinstance(array, np.ndarray):
-            return array
-        else:
-            raise TypeError(UNKNOWN_ARRAY_TYPE)
 
 
 def unique(array, axis: Optional[int] = None):

--- a/python/metatensor_operations/metatensor/operations/abs.py
+++ b/python/metatensor_operations/metatensor/operations/abs.py
@@ -40,7 +40,7 @@ def _abs_block(block: TensorBlock) -> TensorBlock:
         # The sign_values have the same dimensions as that of the block.values.
         # Reshape the sign_values to allow multiplication with gradient.values
         new_grad = gradient.values[:] * sign_values[
-            _dispatch.to_index_array(gradient.samples.column("sample"))
+            gradient.samples.column("sample")
         ].reshape([-1] + [1] * diff_components + _shape)
 
         gradient = TensorBlock(

--- a/python/metatensor_operations/metatensor/operations/divide.py
+++ b/python/metatensor_operations/metatensor/operations/divide.py
@@ -1,6 +1,5 @@
 from typing import List, Union
 
-from . import _dispatch
 from ._backend import (
     TensorBlock,
     TensorMap,
@@ -75,16 +74,14 @@ def _divide_block_block(block_1: TensorBlock, block_2: TensorBlock) -> TensorBlo
 
         gradient_samples_to_values_samples_1 = gradient_1.samples.column("sample")
         gradient_samples_to_values_samples_2 = gradient_2.samples.column("sample")
-        gradient_values = -block_1.values[
-            _dispatch.to_index_array(gradient_samples_to_values_samples_1)
-        ].reshape(
+        gradient_values = -block_1.values[gradient_samples_to_values_samples_1].reshape(
             [-1] + [1] * diff_components + _shape
         ) * gradient_2.values / block_2.values[
-            _dispatch.to_index_array(gradient_samples_to_values_samples_2)
+            gradient_samples_to_values_samples_2
         ].reshape(
             [-1] + [1] * diff_components + _shape
         ) ** 2 + gradient_1.values / block_2.values[
-            _dispatch.to_index_array(gradient_samples_to_values_samples_2)
+            gradient_samples_to_values_samples_2
         ].reshape([-1] + [1] * diff_components + _shape)
 
         result_block.add_gradient(

--- a/python/metatensor_operations/metatensor/operations/multiply.py
+++ b/python/metatensor_operations/metatensor/operations/multiply.py
@@ -1,6 +1,5 @@
 from typing import List, Union
 
-from . import _dispatch
 from ._backend import (
     TensorBlock,
     TensorMap,
@@ -75,12 +74,10 @@ def _multiply_block_block(block_1: TensorBlock, block_2: TensorBlock) -> TensorB
 
         gradient_samples_to_values_samples_1 = gradient_1.samples.column("sample")
         gradient_samples_to_values_samples_2 = gradient_2.samples.column("sample")
-        gradient_values = block_1.values[
-            _dispatch.to_index_array(gradient_samples_to_values_samples_1)
-        ].reshape(
+        gradient_values = block_1.values[gradient_samples_to_values_samples_1].reshape(
             [-1] + [1] * diff_components + _shape
         ) * gradient_2.values + gradient_1.values * block_2.values[
-            _dispatch.to_index_array(gradient_samples_to_values_samples_2)
+            gradient_samples_to_values_samples_2
         ].reshape([-1] + [1] * diff_components + _shape)
 
         result_block.add_gradient(

--- a/python/metatensor_operations/metatensor/operations/one_hot.py
+++ b/python/metatensor_operations/metatensor/operations/one_hot.py
@@ -72,7 +72,5 @@ def one_hot(labels: Labels, dimension: Labels):
             )
         indices[i] = position
 
-    one_hot_array = _dispatch.eye_like(dimension.values, len(dimension))[
-        _dispatch.to_index_array(indices)
-    ]
+    one_hot_array = _dispatch.eye_like(dimension.values, len(dimension))[indices]
     return one_hot_array

--- a/python/metatensor_operations/metatensor/operations/pow.py
+++ b/python/metatensor_operations/metatensor/operations/pow.py
@@ -1,6 +1,5 @@
 from typing import List, Union
 
-from . import _dispatch
 from ._backend import (
     TensorBlock,
     TensorMap,
@@ -38,9 +37,9 @@ def _pow_block_constant(block: TensorBlock, constant: float) -> TensorBlock:
         values_grad = (
             constant
             * gradient_values
-            * block.values[
-                _dispatch.to_index_array(gradient_samples_to_values_samples)
-            ].reshape([-1] + [1] * diff_components + _shape)
+            * block.values[gradient_samples_to_values_samples].reshape(
+                [-1] + [1] * diff_components + _shape
+            )
             ** (constant - 1)
         )
 

--- a/python/metatensor_operations/metatensor/operations/reduce_over_samples.py
+++ b/python/metatensor_operations/metatensor/operations/reduce_over_samples.py
@@ -242,7 +242,7 @@ def _reduce_over_samples_block(
 
         # change the first columns of the samples array with the mapping
         # between samples and gradient.samples
-        samples[:, 0] = index[_dispatch.to_index_array(samples[:, 0])]
+        samples[:, 0] = index[samples[:, 0]]
 
         new_gradient_samples, index_gradient = _dispatch.unique_with_inverse(
             samples[:, :], axis=0

--- a/python/metatensor_operations/metatensor/operations/slice.py
+++ b/python/metatensor_operations/metatensor/operations/slice.py
@@ -75,7 +75,7 @@ def _slice_block(
                 sample_column = sample_column.copy()
 
             # Create a samples filter for the Gradient TensorBlock
-            grad_samples_mask = mask[_dispatch.to_index_array(sample_column)]
+            grad_samples_mask = mask[sample_column]
 
             new_grad_samples_values = _dispatch.mask(
                 gradient.samples.values, 0, grad_samples_mask
@@ -85,7 +85,7 @@ def _slice_block(
                 # update the "sample" column of the gradient samples
                 # to refer to the new samples
                 new_grad_samples_values[:, 0] = sample_map[
-                    _dispatch.to_index_array(new_grad_samples_values[:, 0])
+                    new_grad_samples_values[:, 0]
                 ]
 
                 new_grad_samples = Labels(

--- a/python/metatensor_operations/metatensor/operations/sort.py
+++ b/python/metatensor_operations/metatensor/operations/sort.py
@@ -55,9 +55,7 @@ def _sort_single_gradient_block(
         # adapt sample column in gradient samples to the one of the sorted values of
         # the gradient_block the gradient is attached to
         sample_values = _dispatch.copy(sample_values)
-        sample_values[:, 0] = sorted_idx_inverse[
-            _dispatch.to_index_array(sample_values[:, 0])
-        ]
+        sample_values[:, 0] = sorted_idx_inverse[sample_values[:, 0]]
 
         # sort the samples in gradient regularly moving the rows considering all columns
         sorted_idx = _dispatch.argsort_labels_values(sample_values, reverse=descending)

--- a/python/metatensor_torch/build-backend/backend.py
+++ b/python/metatensor_torch/build-backend/backend.py
@@ -34,7 +34,7 @@ FORCED_TORCH_VERSION = os.environ.get("METATENSOR_TORCH_BUILD_WITH_TORCH_VERSION
 if FORCED_TORCH_VERSION is not None:
     TORCH_DEP = f"torch =={FORCED_TORCH_VERSION}"
 else:
-    TORCH_DEP = "torch >=1.12"
+    TORCH_DEP = "torch >=2.1"
 
 # ==================================================================================== #
 #                   Build backend functions definition                                 #

--- a/python/metatensor_torch/setup.py
+++ b/python/metatensor_torch/setup.py
@@ -321,7 +321,7 @@ if __name__ == "__main__":
         torch_version = f"== {torch_v_major}.{torch_v_minor}.*"
     except ImportError:
         # otherwise we are building a sdist
-        torch_version = ">= 1.12"
+        torch_version = ">= 2.1"
 
     install_requires = [f"torch {torch_version}", "vesin"]
 

--- a/python/metatensor_torch/tests/atomistic/metadata.py
+++ b/python/metatensor_torch/tests/atomistic/metadata.py
@@ -1,7 +1,6 @@
 from typing import Dict, List, Optional
 
 import torch
-from packaging import version
 
 from metatensor.torch import Labels
 from metatensor.torch.atomistic import (
@@ -251,12 +250,7 @@ def test_with_extra_metadata(tmpdir):
 
     torch.save(metadata, str(tmpdir.join("metadata.pt")))
 
-    if version.parse(torch.__version__) >= version.parse("1.13"):
-        loaded_metadata = torch.load(
-            str(tmpdir.join("metadata.pt")), weights_only=False
-        )
-    else:
-        loaded_metadata = torch.load(str(tmpdir.join("metadata.pt")))
+    loaded_metadata = torch.load(str(tmpdir.join("metadata.pt")), weights_only=False)
 
     assert loaded_metadata.extra["number_of_parameters"] == "1000"
     assert loaded_metadata.extra["foo"] == "bar"

--- a/python/metatensor_torch/tests/atomistic/model.py
+++ b/python/metatensor_torch/tests/atomistic/model.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional
 
 import pytest
 import torch
-from packaging import version
 
 from metatensor.torch import Labels, TensorBlock, TensorMap
 from metatensor.torch.atomistic import (
@@ -455,5 +454,4 @@ def test_predictions(model, tmp_path, n_systems):
     result = model_loaded(systems, evaluation_options, check_consistency=True)
     assert "tests::dummy::long_name" in result
     assert isinstance(result["tests::dummy::long_name"], torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert result["tests::dummy::long_name"]._type().name() == "TensorMap"
+    assert result["tests::dummy::long_name"]._type().name() == "TensorMap"

--- a/python/metatensor_torch/tests/atomistic/neighbors.py
+++ b/python/metatensor_torch/tests/atomistic/neighbors.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-from packaging import version
 
 from metatensor.torch.atomistic import (
     NeighborListOptions,
@@ -55,8 +54,7 @@ def test_neighbor_list_options():
         - hello
         - another one
 """
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert repr(options) == expected
+    assert repr(options) == expected
 
 
 @pytest.mark.skipif(not HAVE_ASE, reason="this tests requires ASE neighbor list")

--- a/python/metatensor_torch/tests/atomistic/systems.py
+++ b/python/metatensor_torch/tests/atomistic/systems.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-from packaging import version
 
 import metatensor.torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
@@ -68,9 +67,7 @@ def test_system(types, positions, cell, pbc, neighbors):
 
     expected = "System with 8 atoms, periodic cell: [12, 0, 0, 0, 12.3, 0, 0, 0, 10]"
     assert str(system) == expected
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        # custom __repr__ definitions are only available since torch 2.1
-        assert repr(system) == expected
+    assert repr(system) == expected
 
     system = System(
         types,
@@ -80,9 +77,7 @@ def test_system(types, positions, cell, pbc, neighbors):
     )
     expected = "System with 8 atoms, non periodic"
     assert str(system) == expected
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        # custom __repr__ definitions are only available since torch 2.1
-        assert repr(system) == expected
+    assert repr(system) == expected
 
     options = NeighborListOptions(cutoff=3.5, full_list=False, strict=True)
     system.add_neighbor_list(options, neighbors)
@@ -475,12 +470,10 @@ def test_to(system, neighbors):
     system.add_data("test-data", TensorMap(Labels.single(), [block]))
 
     assert system.device.type == torch.device("cpu").type
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        check_dtype(system, torch.float32)
+    check_dtype(system, torch.float32)
 
     converted = system.to(dtype=torch.float64)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        check_dtype(converted, torch.float64)
+    check_dtype(converted, torch.float64)
 
     devices = ["meta", torch.device("meta")]
     if _tests_utils.can_use_mps_backend():

--- a/python/metatensor_torch/tests/block.py
+++ b/python/metatensor_torch/tests/block.py
@@ -3,7 +3,6 @@ from typing import List, Optional, Tuple
 
 import pytest
 import torch
-from packaging import version
 from torch import Tensor
 
 from metatensor.torch import Labels, TensorBlock
@@ -100,10 +99,7 @@ def test_repr():
     gradients: ['g']
 """
     assert str(block) == expected
-
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        # custom __repr__ definitions are only available since torch 2.1
-        assert repr(block) == expected
+    assert repr(block) == expected
 
     expected = """Gradient TensorBlock ('g')
     samples (3): ['sample', 'g']
@@ -112,10 +108,7 @@ def test_repr():
     gradients: None
 """
     assert str(block.gradient("g")) == expected
-
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        # custom __repr__ definitions are only available since torch 2.1
-        assert repr(block.gradient("g")) == expected
+    assert repr(block.gradient("g")) == expected
 
 
 def test_copy():
@@ -284,14 +277,12 @@ def test_to():
     )
 
     assert block.device.type == torch.device("cpu").type
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        check_dtype(block, torch.float32)
-        check_dtype(block.gradient("g"), torch.float32)
+    check_dtype(block, torch.float32)
+    check_dtype(block.gradient("g"), torch.float32)
 
     converted = block.to(dtype=torch.float64)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        check_dtype(converted, torch.float64)
-        check_dtype(converted.gradient("g"), torch.float64)
+    check_dtype(converted, torch.float64)
+    check_dtype(converted.gradient("g"), torch.float64)
 
     devices = ["meta", torch.device("meta")]
     if _tests_utils.can_use_mps_backend():

--- a/python/metatensor_torch/tests/labels.py
+++ b/python/metatensor_torch/tests/labels.py
@@ -2,7 +2,6 @@ from typing import Any, List, Optional, Tuple, Union
 
 import pytest
 import torch
-from packaging import version
 from torch import Tensor
 
 from metatensor.torch import Labels, LabelsEntry
@@ -20,7 +19,7 @@ def test_constructor():
     assert torch.all(labels.values == torch.Tensor([[0, 0], [0, 1]]))
 
     # positional arguments + names is a list
-    labels = Labels(["c"], torch.LongTensor([[0], [2], [-1]]))
+    labels = Labels(["c"], torch.tensor([[0], [2], [-1]]))
     assert labels.names == ["c"]
     assert torch.all(labels.values == torch.Tensor([[0], [2], [-1]]))
 
@@ -137,10 +136,7 @@ def test_repr():
 
     expected = "Labels(\n    aaa  bbb\n     1    2\n     3    4\n)"
     assert str(labels) == expected
-
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        # custom __repr__ definitions are only available since torch 2.1
-        assert repr(labels) == expected
+    assert repr(labels) == expected
 
     expected = "LabelsEntry(aaa=1, bbb=2)"
     assert str(labels[0]) == expected
@@ -365,8 +361,8 @@ def test_union():
     union_2, first_mapping, second_mapping = first.union_and_mapping(second)
 
     assert union == union_2
-    assert torch.all(first_mapping == torch.LongTensor([0, 1]))
-    assert torch.all(second_mapping == torch.LongTensor([2, 1, 3]))
+    assert torch.all(first_mapping == torch.tensor([0, 1]))
+    assert torch.all(second_mapping == torch.tensor([2, 1, 3]))
 
     # check that union preserves devices
     first = first.to("meta")
@@ -402,8 +398,8 @@ def test_intersection():
     )
 
     assert intersection == intersection_2
-    assert torch.all(first_mapping == torch.LongTensor([-1, 0]))
-    assert torch.all(second_mapping == torch.LongTensor([-1, 0, -1]))
+    assert torch.all(first_mapping == torch.tensor([-1, 0]))
+    assert torch.all(second_mapping == torch.tensor([-1, 0, -1]))
 
     # check that intersection preserves devices
     first = first.to("meta")
@@ -439,7 +435,7 @@ def test_difference():
     difference_2, mapping = first.difference_and_mapping(second)
 
     assert difference == difference_2
-    assert torch.all(mapping == torch.LongTensor([0, -1]))
+    assert torch.all(mapping == torch.tensor([0, -1]))
 
     # check that difference preserves devices
     first = first.to("meta")

--- a/python/metatensor_torch/tests/operations/abs.py
+++ b/python/metatensor_torch/tests/operations/abs.py
@@ -2,7 +2,6 @@ import io
 import os
 
 import torch
-from packaging import version
 
 import metatensor.torch
 
@@ -24,8 +23,7 @@ def test_abs():
 
     # check output type
     assert isinstance(abs_tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert abs_tensor._type().name() == "TensorMap"
+    assert abs_tensor._type().name() == "TensorMap"
 
     # check metadata
     assert metatensor.torch.equal_metadata(abs_tensor, tensor)

--- a/python/metatensor_torch/tests/operations/add.py
+++ b/python/metatensor_torch/tests/operations/add.py
@@ -3,7 +3,6 @@ import os
 
 import pytest
 import torch
-from packaging import version
 
 import metatensor
 import metatensor.torch
@@ -33,11 +32,7 @@ def test_type_error(tensor_path):
         r"`metatensor.torch.add\(...\)` instead of `metatensor.add\(...\)`"
     )
     with pytest.raises(TypeError, match=error):
-        if version.parse(torch.__version__) >= version.parse("2.1"):
-            with pytest.warns(UserWarning, match=warning):
-                metatensor.add(tensor, tensor)
-        else:
-            # no warning before torch 2.1
+        with pytest.warns(UserWarning, match=warning):
             metatensor.add(tensor, tensor)
 
 

--- a/python/metatensor_torch/tests/operations/block_from_array.py
+++ b/python/metatensor_torch/tests/operations/block_from_array.py
@@ -2,7 +2,6 @@ import io
 
 import pytest
 import torch
-from packaging import version
 
 import metatensor.torch
 
@@ -14,8 +13,7 @@ def test_block_from_array(device):
 
     # check output type
     assert isinstance(block, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert block._type().name() == "TensorBlock"
+    assert block._type().name() == "TensorBlock"
 
     # check values
     if device != "meta":

--- a/python/metatensor_torch/tests/operations/detach.py
+++ b/python/metatensor_torch/tests/operations/detach.py
@@ -2,7 +2,6 @@ import io
 import os
 
 import torch
-from packaging import version
 
 import metatensor.torch
 
@@ -25,8 +24,7 @@ def test_detach():
     tensor = metatensor.torch.requires_grad(tensor)
 
     assert isinstance(tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert tensor._type().name() == "TensorMap"
+    assert tensor._type().name() == "TensorMap"
 
     for block in tensor:
         assert block.values.requires_grad
@@ -34,8 +32,7 @@ def test_detach():
     tensor = metatensor.torch.detach(tensor)
 
     assert isinstance(tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert tensor._type().name() == "TensorMap"
+    assert tensor._type().name() == "TensorMap"
 
     for block in tensor:
         assert not block.values.requires_grad

--- a/python/metatensor_torch/tests/operations/dot.py
+++ b/python/metatensor_torch/tests/operations/dot.py
@@ -2,7 +2,6 @@ import io
 import os
 
 import torch
-from packaging import version
 
 import metatensor.torch
 
@@ -24,8 +23,7 @@ def test_dot():
 
     # right output type
     assert isinstance(dot_tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert dot_tensor._type().name() == "TensorMap"
+    assert dot_tensor._type().name() == "TensorMap"
 
     # right metadata
     for key in tensor.keys:

--- a/python/metatensor_torch/tests/operations/drop_blocks.py
+++ b/python/metatensor_torch/tests/operations/drop_blocks.py
@@ -2,7 +2,6 @@ import io
 import os
 
 import torch
-from packaging import version
 
 import metatensor.torch
 from metatensor.torch import Labels
@@ -36,8 +35,7 @@ def test_drop_blocks():
 
     # check type
     assert isinstance(tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert tensor._type().name() == "TensorMap"
+    assert tensor._type().name() == "TensorMap"
 
     # check remaining block
     expected_keys = Labels(names=["center_type"], values=torch.tensor([[6]]))

--- a/python/metatensor_torch/tests/operations/empty_like.py
+++ b/python/metatensor_torch/tests/operations/empty_like.py
@@ -2,7 +2,6 @@ import io
 import os
 
 import torch
-from packaging import version
 
 import metatensor.torch
 
@@ -24,8 +23,7 @@ def test_empty_like():
 
     # right output type
     assert isinstance(empty_tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert empty_tensor._type().name() == "TensorMap"
+    assert empty_tensor._type().name() == "TensorMap"
 
     # right metadata
     assert metatensor.torch.equal_metadata(empty_tensor, tensor)

--- a/python/metatensor_torch/tests/operations/filter_blocks.py
+++ b/python/metatensor_torch/tests/operations/filter_blocks.py
@@ -2,7 +2,6 @@ import io
 import os
 
 import torch
-from packaging import version
 
 import metatensor.torch
 from metatensor.torch import Labels
@@ -36,8 +35,7 @@ def test_filter_blocks():
 
     # check type
     assert isinstance(tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert tensor._type().name() == "TensorMap"
+    assert tensor._type().name() == "TensorMap"
 
     # check remaining block
     expected_keys = Labels(names=["center_type"], values=torch.tensor([[1], [8]]))

--- a/python/metatensor_torch/tests/operations/join.py
+++ b/python/metatensor_torch/tests/operations/join.py
@@ -2,7 +2,6 @@ import io
 import os
 
 import torch
-from packaging import version
 
 import metatensor.torch
 
@@ -23,8 +22,7 @@ def test_join():
     joined_tensor = metatensor.torch.join([tensor, tensor], axis="properties")
 
     assert isinstance(joined_tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert joined_tensor._type().name() == "TensorMap"
+    assert joined_tensor._type().name() == "TensorMap"
 
     # test keys
     assert joined_tensor.keys == tensor.keys

--- a/python/metatensor_torch/tests/operations/lstsq.py
+++ b/python/metatensor_torch/tests/operations/lstsq.py
@@ -1,7 +1,6 @@
 import io
 
 import torch
-from packaging import version
 
 import metatensor.torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
@@ -34,8 +33,7 @@ def test_lstsq():
 
     # check output type
     assert isinstance(solution_tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert solution_tensor._type().name() == "TensorMap"
+    assert solution_tensor._type().name() == "TensorMap"
 
     # check content
     expected_solution = TensorMap(

--- a/python/metatensor_torch/tests/operations/ones_like.py
+++ b/python/metatensor_torch/tests/operations/ones_like.py
@@ -2,7 +2,6 @@ import io
 import os
 
 import torch
-from packaging import version
 
 import metatensor.torch
 
@@ -24,8 +23,7 @@ def test_ones_like():
 
     # right output type
     assert isinstance(ones_tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert ones_tensor._type().name() == "TensorMap"
+    assert ones_tensor._type().name() == "TensorMap"
 
     # right metadata
     assert metatensor.torch.equal_metadata(ones_tensor, tensor)

--- a/python/metatensor_torch/tests/operations/random_like.py
+++ b/python/metatensor_torch/tests/operations/random_like.py
@@ -2,7 +2,6 @@ import io
 import os
 
 import torch
-from packaging import version
 
 import metatensor.torch
 
@@ -24,8 +23,7 @@ def test_random_uniform_like():
 
     # right output type
     assert isinstance(random_tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert random_tensor._type().name() == "TensorMap"
+    assert random_tensor._type().name() == "TensorMap"
 
     # right metadata
     assert metatensor.torch.equal_metadata(random_tensor, tensor)

--- a/python/metatensor_torch/tests/operations/remove_gradients.py
+++ b/python/metatensor_torch/tests/operations/remove_gradients.py
@@ -2,7 +2,6 @@ import io
 import os
 
 import torch
-from packaging import version
 
 import metatensor.torch
 
@@ -24,16 +23,14 @@ def test_remove_gradients():
     )
 
     assert isinstance(tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert tensor._type().name() == "TensorMap"
+    assert tensor._type().name() == "TensorMap"
 
     assert set(tensor.block(0).gradients_list()) == set(["strain", "positions"])
 
     tensor = metatensor.torch.remove_gradients(tensor, ["positions"])
 
     assert isinstance(tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert tensor._type().name() == "TensorMap"
+    assert tensor._type().name() == "TensorMap"
 
     assert tensor.block(0).gradients_list() == ["strain"]
 

--- a/python/metatensor_torch/tests/operations/requires_grad.py
+++ b/python/metatensor_torch/tests/operations/requires_grad.py
@@ -2,7 +2,6 @@ import io
 import os
 
 import torch
-from packaging import version
 
 import metatensor.torch
 
@@ -26,8 +25,7 @@ def test_requires_grad():
     tensor = metatensor.torch.requires_grad(tensor)
 
     assert isinstance(tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert tensor._type().name() == "TensorMap"
+    assert tensor._type().name() == "TensorMap"
 
     for block in tensor:
         assert block.values.requires_grad
@@ -35,8 +33,7 @@ def test_requires_grad():
     tensor = metatensor.torch.requires_grad(tensor, False)
 
     assert isinstance(tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert tensor._type().name() == "TensorMap"
+    assert tensor._type().name() == "TensorMap"
 
     for block in tensor:
         assert not block.values.requires_grad

--- a/python/metatensor_torch/tests/operations/slice.py
+++ b/python/metatensor_torch/tests/operations/slice.py
@@ -1,7 +1,6 @@
 import io
 
 import torch
-from packaging import version
 
 import metatensor.torch
 from metatensor.torch import Labels, TensorMap
@@ -25,11 +24,9 @@ def test_slice():
 
     # check type
     assert isinstance(sliced_tensor_samples, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert sliced_tensor_samples._type().name() == "TensorMap"
+    assert sliced_tensor_samples._type().name() == "TensorMap"
     assert isinstance(sliced_tensor_properties, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert sliced_tensor_properties._type().name() == "TensorMap"
+    assert sliced_tensor_properties._type().name() == "TensorMap"
 
     # check values
     assert torch.equal(sliced_tensor_samples.block().values, torch.tensor([[3, 4, 5]]))
@@ -51,11 +48,9 @@ def test_slice_block():
 
     # check type
     assert isinstance(sliced_block_samples, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert sliced_block_samples._type().name() == "TensorBlock"
+    assert sliced_block_samples._type().name() == "TensorBlock"
     assert isinstance(sliced_block_properties, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert sliced_block_properties._type().name() == "TensorBlock"
+    assert sliced_block_properties._type().name() == "TensorBlock"
 
     # check values
     assert torch.equal(sliced_block_samples.values, torch.tensor([[3, 4, 5]]))

--- a/python/metatensor_torch/tests/operations/solve.py
+++ b/python/metatensor_torch/tests/operations/solve.py
@@ -1,7 +1,6 @@
 import io
 
 import torch
-from packaging import version
 
 import metatensor.torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
@@ -34,8 +33,7 @@ def test_solve():
 
     # check output type
     assert isinstance(solution_tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert solution_tensor._type().name() == "TensorMap"
+    assert solution_tensor._type().name() == "TensorMap"
 
     # check content
     expected_solution = TensorMap(

--- a/python/metatensor_torch/tests/operations/sort.py
+++ b/python/metatensor_torch/tests/operations/sort.py
@@ -3,7 +3,6 @@ import os
 
 import pytest
 import torch
-from packaging import version
 
 import metatensor.torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
@@ -27,8 +26,7 @@ def test_sort():
 
     # right output type
     assert isinstance(sorted_tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert sorted_tensor._type().name() == "TensorMap"
+    assert sorted_tensor._type().name() == "TensorMap"
 
 
 def test_save():

--- a/python/metatensor_torch/tests/operations/split.py
+++ b/python/metatensor_torch/tests/operations/split.py
@@ -2,7 +2,6 @@ import io
 
 import pytest
 import torch
-from packaging import version
 
 import metatensor.torch
 from metatensor.torch import Labels, TensorMap
@@ -59,13 +58,11 @@ def test_split(selections):
     # check type
     assert isinstance(split_tensors_samples, list)
     assert isinstance(split_tensors_samples[0], torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert split_tensors_samples[0]._type().name() == "TensorMap"
+    assert split_tensors_samples[0]._type().name() == "TensorMap"
 
     assert isinstance(split_tensors_properties, list)
     assert isinstance(split_tensors_properties[0], torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert split_tensors_properties[0]._type().name() == "TensorMap"
+    assert split_tensors_properties[0]._type().name() == "TensorMap"
 
     # check values
     assert torch.equal(
@@ -106,13 +103,11 @@ def test_split_block():
     # check type
     assert isinstance(split_blocks_samples, list)
     assert isinstance(split_blocks_samples[0], torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert split_blocks_samples[0]._type().name() == "TensorBlock"
+    assert split_blocks_samples[0]._type().name() == "TensorBlock"
 
     assert isinstance(split_blocks_properties, list)
     assert isinstance(split_blocks_properties[0], torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert split_blocks_properties[0]._type().name() == "TensorBlock"
+    assert split_blocks_properties[0]._type().name() == "TensorBlock"
 
     # check values
     assert torch.equal(split_blocks_samples[0].values, torch.tensor([[0, 1, 2]]))

--- a/python/metatensor_torch/tests/operations/unique_metadata.py
+++ b/python/metatensor_torch/tests/operations/unique_metadata.py
@@ -3,7 +3,6 @@ import os
 
 import pytest
 import torch
-from packaging import version
 
 import metatensor.torch
 
@@ -33,8 +32,7 @@ def test_unique_metadata(tensor):
 
     # check type
     assert isinstance(unique_labels, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert unique_labels._type().name() == "Labels"
+    assert unique_labels._type().name() == "Labels"
 
     # check label names
     assert unique_labels.names == ["system"]
@@ -48,8 +46,7 @@ def test_unique_metadata(tensor):
     )
 
     assert isinstance(unique_labels, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert unique_labels._type().name() == "Labels"
+    assert unique_labels._type().name() == "Labels"
 
     assert unique_labels.names == ["atom"]
 
@@ -65,8 +62,7 @@ def test_unique_metadata_block(tensor):
 
     # check type
     assert isinstance(unique_labels, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert unique_labels._type().name() == "Labels"
+    assert unique_labels._type().name() == "Labels"
 
     # check label names
     assert unique_labels.names == ["system"]
@@ -80,8 +76,7 @@ def test_unique_metadata_block(tensor):
     )
 
     assert isinstance(unique_labels, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert unique_labels._type().name() == "Labels"
+    assert unique_labels._type().name() == "Labels"
 
     assert unique_labels.names == ["atom"]
 

--- a/python/metatensor_torch/tests/operations/zeros_like.py
+++ b/python/metatensor_torch/tests/operations/zeros_like.py
@@ -2,7 +2,6 @@ import io
 import os
 
 import torch
-from packaging import version
 
 import metatensor.torch
 
@@ -24,8 +23,7 @@ def test_zeros_like():
 
     # right output type
     assert isinstance(zero_tensor, torch.ScriptObject)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        assert zero_tensor._type().name() == "TensorMap"
+    assert zero_tensor._type().name() == "TensorMap"
 
     # right metadata
     assert metatensor.torch.equal_metadata(zero_tensor, tensor)

--- a/python/metatensor_torch/tests/serialization.py
+++ b/python/metatensor_torch/tests/serialization.py
@@ -4,7 +4,6 @@ from typing import Union
 import numpy as np
 import pytest
 import torch
-from packaging import version
 
 import metatensor.torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
@@ -140,10 +139,7 @@ def test_pickle(tmpdir, tensor_path):
 
     with tmpdir.as_cwd():
         torch.save(tensor, tmpfile)
-        if version.parse(torch.__version__) >= version.parse("1.13"):
-            loaded = torch.load(tmpfile, weights_only=False)
-        else:
-            loaded = torch.load(tmpfile)
+        loaded = torch.load(tmpfile, weights_only=False)
 
     check_tensor(loaded)
 
@@ -222,11 +218,7 @@ def test_pickle_block(tmpdir, block_path):
 
     with tmpdir.as_cwd():
         torch.save(block, tmpfile)
-
-        if version.parse(torch.__version__) >= version.parse("1.13"):
-            loaded = torch.load(tmpfile, weights_only=False)
-        else:
-            loaded = torch.load(tmpfile)
+        loaded = torch.load(tmpfile, weights_only=False)
 
     check_block(loaded)
 
@@ -280,11 +272,7 @@ def test_pickle_labels(tmpdir, labels_path):
 
     with tmpdir.as_cwd():
         torch.save(labels, tmpfile)
-
-        if version.parse(torch.__version__) >= version.parse("1.13"):
-            loaded = torch.load(tmpfile, weights_only=False)
-        else:
-            loaded = torch.load(tmpfile)
+        loaded = torch.load(tmpfile, weights_only=False)
 
     check_labels(loaded)
 

--- a/python/metatensor_torch/tests/tensor.py
+++ b/python/metatensor_torch/tests/tensor.py
@@ -2,7 +2,6 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import pytest
 import torch
-from packaging import version
 
 from metatensor.torch import Labels, LabelsEntry, TensorBlock, TensorMap
 
@@ -37,10 +36,7 @@ keys: key_1  key_2
         2      3"""
     assert expected == str(tensor)
     assert expected == tensor.print(6)
-
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        # custom __repr__ definitions are only available since torch 2.1
-        assert repr(tensor) == expected
+    assert repr(tensor) == expected
 
 
 def test_print_large(large_tensor):
@@ -79,9 +75,7 @@ keys: key_1  key_2
         2      5
         3      5"""
 
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        # custom __repr__ definitions are only available since torch 2.1
-        assert repr(large_tensor) == expected
+    assert repr(large_tensor) == expected
 
 
 def test_labels_names(tensor):
@@ -510,12 +504,10 @@ def test_different_dtype(meta_tensor):
 
 def test_to(tensor):
     assert tensor.device.type == torch.device("cpu").type
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        check_dtype(tensor, torch.float32)
+    check_dtype(tensor, torch.float32)
 
     converted = tensor.to(dtype=torch.float64)
-    if version.parse(torch.__version__) >= version.parse("2.1"):
-        check_dtype(converted, torch.float64)
+    check_dtype(converted, torch.float64)
 
     devices = ["meta", torch.device("meta")]
     if _tests_utils.can_use_mps_backend():


### PR DESCRIPTION
I would like to be able to use `_type()` unconditionally, and it was properly fixed in 2.1. This also removes a lot of special cases from the code.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
