### PR TITLE
Fix version pinning in Julia tests

### DIFF
--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -8,7 +8,7 @@ Metatensor_jll = "0a60894c-bde1-5a72-bbe5-9f45bee4e041"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
 [compat]
-Metatensor_jll = "= 0.1.2"
+Metatensor_jll = ">=0.1.14,<0.2.0"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
I played a bit with Metatensor_jll over the weekend, so now test are failing. 