### PR TITLE
Added the possibility to not check gradients on `equal_metadata`

### DIFF
--- a/python/metatensor_operations/tests/equal_metadata.py
+++ b/python/metatensor_operations/tests/equal_metadata.py
@@ -466,3 +466,10 @@ def test_remove_last_component(tensor_map):
 
     new_tensor = TensorMap(keys=tensor_map.keys, blocks=new_blocks)
     assert not mts.equal_metadata(tensor_map, new_tensor)
+
+
+def test_ignore_gradients(tensor_map):
+    """Check that we can compare tensormaps while ignoring gradients."""
+    new_tensor = mts.remove_gradients(tensor_map)
+    assert not mts.equal_metadata(tensor_map, new_tensor, check_gradients=True)
+    assert mts.equal_metadata(tensor_map, new_tensor, check_gradients=False)


### PR DESCRIPTION
In https://github.com/metatensor/metatrain/pull/693 we need a function that checks if all the labels are the same but doesn't check the gradients.

In this PR I added the possibility to `metatensor.equal_metadata` the possibility to avoid checking the gradients so that we can use the function for that purpose.

Also added an extra test to check that `check_gradients=False`. 

<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/3630008078.zip)

<!-- download-section Documentation docs end -->