### PR TITLE
Rewrite `join` to no longer use `keys_to_xxx`

### DIFF
--- a/docs/src/operations/reference/manipulation/join.rst
+++ b/docs/src/operations/reference/manipulation/join.rst
@@ -2,3 +2,5 @@ join
 ====
 
 .. autofunction:: metatensor.join
+
+.. autofunction:: metatensor.join_blocks

--- a/python/metatensor_learn/tests/collate.py
+++ b/python/metatensor_learn/tests/collate.py
@@ -122,7 +122,7 @@ def test_group_and_join_tensormaps():
         blocks=[
             TensorBlock(
                 values=np.ones((2, 1)),
-                samples=Labels(["sample_index", "tensor"], np.array([[0, 0], [2, 1]])),
+                samples=Labels(["sample_index"], np.array([[0], [2]])),
                 components=[],
                 properties=Labels(["p"], np.array([[0]])),
             )
@@ -194,9 +194,7 @@ def test_group_and_join_torch_tensormaps():
         blocks=[
             TensorBlock(
                 values=torch.ones((2, 1)),
-                samples=Labels(
-                    ["sample_index", "tensor"], torch.tensor([[0, 0], [2, 1]])
-                ),
+                samples=Labels(["sample_index"], torch.tensor([[0], [2]])),
                 components=[],
                 properties=Labels(["p"], torch.tensor([[0]])),
             )
@@ -300,7 +298,7 @@ def test_group_and_join_tensormaps_different_keys_union():
     batch_idxs = [0, 2]  # i.e. batch size 2
     batch = group_and_join(
         [dset[i] for i in batch_idxs],
-        join_kwargs={"different_keys": "union", "remove_tensor_name": True},
+        join_kwargs={"different_keys": "union"},
     )
     assert batch.sample_indices == (0, 2)
 

--- a/python/metatensor_operations/CHANGELOG.md
+++ b/python/metatensor_operations/CHANGELOG.md
@@ -17,6 +17,21 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
+### Added
+
+- `join_blocks`, to join multiple blocks along samples or properties, with
+  similar semantics to `join`
+
+### Changed
+
+- `join` was rewritten and made faster. As part of this, we had to change the
+  API: `sort_samples` is not an option anymore, and `remove_tensor_name: bool`
+  was replaced by `add_dimension: Optional[str]=None`. You can set
+  `add_dimension="tensor"` to get the old behavior of
+  `remove_tensor_name=False`. The new default behavior is to not add extra
+  dimensions, and fail if the resulting samples or properties are not unique.
+
+
 ## [Version 0.3.4](https://github.com/metatensor/metatensor/releases/tag/metatensor-operations-v0.3.4) - 2025-07-28
 
 ### Fixed

--- a/python/metatensor_operations/metatensor/operations/__init__.py
+++ b/python/metatensor_operations/metatensor/operations/__init__.py
@@ -35,7 +35,7 @@ from ._is_contiguous import (  # noqa: F401
     is_contiguous,
     is_contiguous_block,
 )
-from ._join import join  # noqa: F401
+from ._join import join, join_blocks  # noqa: F401
 from ._lstsq import lstsq  # noqa: F401
 from ._make_contiguous import (  # noqa: F401
     make_contiguous,

--- a/python/metatensor_operations/metatensor/operations/_join.py
+++ b/python/metatensor_operations/metatensor/operations/_join.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List, Optional, Union
 
 from . import _dispatch
 from ._backend import (
@@ -9,36 +9,11 @@ from ._backend import (
     torch_jit_is_scripting,
     torch_jit_script,
 )
-from ._manipulate_dimension import remove_dimension
-from ._utils import _check_same_keys_raise
-
-
-def _disjoint_tensor_labels(tensors: List[TensorMap], axis: str) -> bool:
-    """Checks if all labels in a list of TensorMaps are disjoint.
-
-    We have to perform a check from all tensors to all others to ensure it
-    they are "fully" disjoint.
-    """
-    for i_tensor, first_tensor in enumerate(tensors[:-1]):
-        for second_tensor in tensors[i_tensor + 1 :]:
-            for key, first_block in first_tensor.items():
-                second_block = second_tensor.block(key)
-                if axis == "samples":
-                    first_labels = first_block.samples
-                    second_labels = second_block.samples
-                elif axis == "properties":
-                    first_labels = first_block.properties
-                    second_labels = second_block.properties
-                else:
-                    raise ValueError(
-                        "Only `'properties'` or `'samples'` are "
-                        "valid values for the `axis` parameter."
-                    )
-
-                if len(first_labels.intersection(second_labels)):
-                    return False
-
-    return True
+from ._utils import (
+    _check_blocks_raise,
+    _check_same_gradients_raise,
+    _check_same_keys_raise,
+)
 
 
 def _unique_str(str_list: List[str]):
@@ -185,172 +160,398 @@ def _tensors_union(tensors: List[TensorMap], axis: str) -> List[TensorMap]:
     return new_tensors
 
 
+def _join_block_samples(
+    blocks: List[TensorBlock],
+    fname: str,
+    add_dimension: Optional[str],
+) -> TensorBlock:
+    """
+    Actual implementation of block joining along samples.
+
+    :param blocks: blocks to join
+    :param fname: name of the function calling ``_join_block_samples``, to be used in
+        error messages
+    :param add_dimension: name of the dimension to add to the samples
+    """
+
+    assert len(blocks) != 0
+    if len(blocks) == 1:
+        return blocks[0]
+
+    first_block = blocks[0]
+    n_joined_samples = 0
+    for block in blocks:
+        n_joined_samples += block.values.shape[0]
+        _check_blocks_raise(first_block, block, fname, ["components", "properties"])
+        _check_same_gradients_raise(first_block, block, fname, ["components"])
+
+    shape = list(first_block.values.shape)
+    shape[0] = n_joined_samples
+
+    new_values = _dispatch.empty_like(first_block.values, shape=shape)
+
+    first_sample_size = first_block.samples.values.shape[1]
+    if add_dimension is None:
+        samples_size = first_sample_size
+    else:
+        samples_size = first_sample_size + 1
+
+    new_samples = _dispatch.empty_like(
+        first_block.samples.values,
+        shape=[n_joined_samples, samples_size],
+    )
+
+    start = 0
+    for block_i, block in enumerate(blocks):
+        stop = start + len(block.samples)
+        new_values[start:stop] = block.values[:]
+
+        new_samples[start:stop, :first_sample_size] = block.samples.values[:, :]
+        if add_dimension is not None:
+            new_samples[start:stop, first_sample_size] = block_i
+
+        start = stop
+
+    new_samples_names = first_block.samples.names
+    if add_dimension is not None:
+        new_samples_names.append(add_dimension)
+
+    new_block = TensorBlock(
+        new_values,
+        Labels(new_samples_names, new_samples),
+        first_block.components,
+        first_block.properties,
+    )
+
+    for parameter in first_block.gradients_list():
+        first_gradient = first_block.gradient(parameter)
+        gradients: List[TensorBlock] = []
+        n_gradient_samples = 0
+        for block in blocks:
+            gradient = block.gradient(parameter)
+            if len(gradient.gradients_list()) != 0:
+                raise NotImplementedError(
+                    "gradients of gradients are not yet supported"
+                )
+
+            n_gradient_samples += len(gradient.samples)
+            gradients.append(gradient)
+
+        shape = list(first_gradient.values.shape)
+        shape[0] = n_gradient_samples
+
+        new_values = _dispatch.empty_like(first_gradient.values, shape=shape)
+
+        new_samples = _dispatch.empty_like(
+            first_gradient.samples.values,
+            shape=[n_gradient_samples, first_gradient.samples.values.shape[1]],
+        )
+
+        start = 0
+        sample_shift = 0
+        for block, gradient in zip(blocks, gradients):
+            stop = start + len(gradient.samples)
+            new_values[start:stop] = gradient.values[:]
+
+            new_samples[start:stop] = gradient.samples.values[:]
+            # update the "sample" dimension, matching the shift in the values
+            new_samples[start:stop, 0] += sample_shift
+            sample_shift += len(block.samples)
+
+            start = stop
+
+        new_gradient = TensorBlock(
+            new_values,
+            Labels(first_gradient.samples.names, new_samples),
+            first_gradient.components,
+            first_gradient.properties,
+        )
+
+        new_block.add_gradient(parameter, new_gradient)
+
+    return new_block
+
+
+def _join_block_properties(
+    blocks: List[TensorBlock],
+    fname: str,
+    add_dimension: Optional[str],
+) -> TensorBlock:
+    """
+    Actual implementation of block joining along properties.
+
+    :param blocks: blocks to join
+    :param fname: name of the function calling ``_join_block_properties``, to be used in
+        error messages
+    :param add_dimension: name of the dimension to add to the properties
+    """
+
+    assert len(blocks) != 0
+    if len(blocks) == 1:
+        return blocks[0]
+
+    first_block = blocks[0]
+    property_names = first_block.properties.names
+    has_different_property_names = False
+    n_joined_properties = 0
+    for block in blocks:
+        n_joined_properties += block.values.shape[-1]
+        _check_blocks_raise(first_block, block, fname, ["samples", "components"])
+        _check_same_gradients_raise(first_block, block, fname, ["components"])
+
+        if block.properties.names != property_names:
+            has_different_property_names = True
+
+    shape = list(first_block.values.shape)
+    shape[-1] = n_joined_properties
+
+    new_values = _dispatch.empty_like(first_block.values, shape=shape)
+
+    first_properties_size = first_block.properties.values.shape[1]
+    if add_dimension is None:
+        properties_size = first_properties_size
+    else:
+        properties_size = first_properties_size + 1
+
+    if has_different_property_names:
+        if add_dimension is not None:
+            raise ValueError(
+                "We can not add an extra dimension to properties when the inputs "
+                "have different property names"
+            )
+
+        new_properties_values = _dispatch.empty_like(
+            first_block.samples.values, shape=[n_joined_properties, 2]
+        )
+    else:
+        new_properties_values = _dispatch.empty_like(
+            first_block.samples.values, shape=[n_joined_properties, properties_size]
+        )
+
+    start = 0
+    for block_i, block in enumerate(blocks):
+        stop = start + len(block.properties)
+        new_values[..., start:stop] = block.values[..., :]
+
+        if has_different_property_names:
+            new_properties_values[start:stop, 0] = block_i
+            new_properties_values[start:stop, 1] = _dispatch.int_array_like(
+                list(range(len(block.properties))), block.properties.values
+            )
+        else:
+            new_properties_values[start:stop, :first_properties_size] = (
+                block.properties.values[:]
+            )
+
+            if add_dimension is not None:
+                new_properties_values[start:stop, first_properties_size] = block_i
+
+        start = stop
+
+    # finalize the new properties
+    if has_different_property_names:
+        new_properties = Labels(
+            names=["joined_index", "property"],
+            values=new_properties_values,
+        )
+    else:
+        new_properties_names = first_block.properties.names
+        if add_dimension is not None:
+            new_properties_names.append(add_dimension)
+        new_properties = Labels(new_properties_names, new_properties_values)
+
+    new_block = TensorBlock(
+        new_values,
+        first_block.samples,
+        first_block.components,
+        new_properties,
+    )
+
+    for parameter in first_block.gradients_list():
+        first_gradient = first_block.gradient(parameter)
+        gradients: List[TensorBlock] = []
+        joined_gradient_samples = first_gradient.samples
+        for block in blocks:
+            gradient = block.gradient(parameter)
+            if len(gradient.gradients_list()) != 0:
+                raise NotImplementedError(
+                    "gradients of gradients are not yet supported"
+                )
+
+            joined_gradient_samples = joined_gradient_samples.union(gradient.samples)
+            gradients.append(gradient)
+
+        shape = list(first_gradient.values.shape)
+        shape[0] = len(joined_gradient_samples)
+        shape[-1] = len(new_properties)
+
+        # we need to use `zeros_like` instead of `empty_like`, because some
+        # gradients might be missing (i.e. implicitly zero) in some input blocks
+        new_values = _dispatch.zeros_like(first_gradient.values, shape=shape)
+
+        start = 0
+        for gradient in gradients:
+            stop = start + len(gradient.properties)
+            # find where we should put the current gradients in the joined samples
+            # we can not get the mapping in the first loop over gradients above since
+            # `joined_gradient_samples` could still change
+            _, _, mapping = joined_gradient_samples.union_and_mapping(gradient.samples)
+            new_values[mapping, ..., start:stop] = gradient.values
+            start = stop
+
+        new_gradient = TensorBlock(
+            new_values,
+            joined_gradient_samples,
+            first_gradient.components,
+            new_properties,
+        )
+
+        new_block.add_gradient(parameter, new_gradient)
+
+    return new_block
+
+
 @torch_jit_script
 def join(
     tensors: List[TensorMap],
     axis: str,
     different_keys: str = "error",
-    sort_samples: bool = False,
-    remove_tensor_name: bool = False,
+    add_dimension: Optional[str] = None,
 ) -> TensorMap:
-    """Join a sequence of :py:class:`TensorMap` with the same blocks along an axis.
+    """Join a sequence of :py:class:`TensorMap` with similar keys along an axis.
 
-    The ``axis`` parameter specifies the type of joining. For example, if
-    ``axis='properties'`` the tensor maps in `tensors` will be joined along the
-    `properties` dimension and for ``axis='samples'`` they will be the along the
-    `samples` dimension.
+    The ``axis`` parameter specifies the type of joining: with ``axis='properties'`` the
+    ``tensors`` will be joined along the ``properties`` and for ``axis='samples'`` they
+    will be joined along the ``samples``.
 
-    :param tensors:
-        sequence of :py:class:`TensorMap` for join
-    :param axis:
-        A string indicating how the tensormaps are stacked. Allowed
-        values are ``'properties'`` or ``'samples'``.
+    :param tensors: sequence of :py:class:`TensorMap` to join
+    :param axis: Along which axis the :py:class:`TensorMap`s should be joined. This can
+        be either ``'properties'`` or ``'samples'``.
     :param different_keys: Method to handle different keys between the tensors. For
         ``"error"`` keys in all tensors have to be the same. For ``"intersection"`` only
         blocks present in all tensors will be taken into account. For ``"union"``
         missing keys will be treated like if they where associated with an empty block.
-    :param sort_samples: whether to sort the samples of the merged ``tensors`` or keep
-        them in their original order.
-    :param remove_tensor_name:
-        Remove the extra ``tensor`` dimension from labels if possible. See examples
-        above for the case where this is applicable.
-    :return tensor_joined:
-        The stacked :py:class:`TensorMap` with more properties or samples
-        than the input TensorMap.
+    :param add_dimension: Add an the extra dimension to the joined labels with the given
+        name. See examples for the case where this is applicable. The dimension forms
+        the last dimension of the joined labels.
+    :return: The joined :py:class:`TensorMap` with more properties or samples than the
+        inputs.
 
     Examples
     --------
-    Possible clashes of the meta data like ``samples``/``properties`` will be resolved
-    by one of the three following strategies:
 
-    1. If Labels names are the same, the values are unique and
-       ``remove_tensor_name=True`` we keep the names and join the values
+    The first use case for this function is when joining ``TensorMap`` with the same
+    labels names (either along ``samples`` or ``properties``):
 
-       >>> import numpy as np
-       >>> import metatensor as mts
-       >>> from metatensor import Labels, TensorBlock, TensorMap
+    >>> import numpy as np
+    >>> import metatensor as mts
+    >>> from metatensor import Labels, TensorBlock, TensorMap
 
-       >>> values = np.array([[1.1, 2.1, 3.1]])
-       >>> samples = Labels("sample", np.array([[0]]))
+    >>> values = np.array([[1.1, 2.1, 3.1]])
+    >>> samples = Labels("sample", np.array([[0]]))
 
-       Define two disjoint :py:class:`Labels`.
+    Define two disjoint set of :py:class:`Labels`.
 
-       >>> properties_1 = Labels("n", np.array([[0], [2], [3]]))
-       >>> properties_2 = Labels("n", np.array([[1], [4], [5]]))
+    >>> properties_1 = Labels("n", np.array([[0], [2], [3]]))
+    >>> properties_2 = Labels("n", np.array([[1], [4], [5]]))
 
-       >>> block_1 = TensorBlock(
-       ...     values=values,
-       ...     samples=Labels.single(),
-       ...     components=[],
-       ...     properties=properties_1,
-       ... )
-       >>> block_2 = TensorBlock(
-       ...     values=values,
-       ...     samples=Labels.single(),
-       ...     components=[],
-       ...     properties=properties_2,
-       ... )
+    >>> block_1 = TensorBlock(
+    ...     values=values,
+    ...     samples=Labels.single(),
+    ...     components=[],
+    ...     properties=properties_1,
+    ... )
+    >>> block_2 = TensorBlock(
+    ...     values=values,
+    ...     samples=Labels.single(),
+    ...     components=[],
+    ...     properties=properties_2,
+    ... )
 
-       >>> tensor_1 = TensorMap(keys=Labels.single(), blocks=[block_1])
-       >>> tensor_2 = TensorMap(keys=Labels.single(), blocks=[block_2])
+    >>> tensor_1 = TensorMap(keys=Labels.single(), blocks=[block_1])
+    >>> tensor_2 = TensorMap(keys=Labels.single(), blocks=[block_2])
 
-       joining along the properties leads
+    joining along the properties leads to
 
-       >>> joined_tensor = mts.join(
-       ...     [tensor_1, tensor_2], axis="properties", remove_tensor_name=True
-       ... )
-       >>> joined_tensor[0].properties
-       Labels(
-           n
-           0
-           2
-           3
-           1
-           4
-           5
-       )
+    >>> joined_tensor = mts.join([tensor_1, tensor_2], axis="properties")
+    >>> joined_tensor[0].properties
+    Labels(
+        n
+        0
+        2
+        3
+        1
+        4
+        5
+    )
 
-       If ``remove_tensor_name=False`` There will be an extra dimension ``tensor``
-       added
+    Second, if the labels names are the same but the values are not unique, you can ask
+    to add an extra dimension to the labels when joining with ``add_dimension``, thus
+    creating unique values
 
-       >>> joined_tensor = mts.join(
-       ...     [tensor_1, tensor_2], axis="properties", remove_tensor_name=False
-       ... )
-       >>> joined_tensor[0].properties
-       Labels(
-           tensor  n
-             0     0
-             0     2
-             0     3
-             1     1
-             1     4
-             1     5
-       )
+    >>> properties_3 = Labels("n", np.array([[0], [2], [3]]))
 
-    2. If Labels names are the same but the values are not unique, a new dimension
-       ``"tensor"`` is added to the names.
+    ``properties_3`` has the same name and also shares values with ``properties_1`` as
+    defined above.
 
-       >>> properties_3 = Labels("n", np.array([[0], [2], [3]]))
+    >>> block_3 = TensorBlock(
+    ...     values=values,
+    ...     samples=Labels.single(),
+    ...     components=[],
+    ...     properties=properties_3,
+    ... )
+    >>> tensor_3 = TensorMap(keys=Labels.single(), blocks=[block_3])
 
-       ``properties_3`` has the same name and also shares values with ``properties_1``
-       as defined above.
+    joining along properties leads to
 
-       >>> block_3 = TensorBlock(
-       ...     values=values,
-       ...     samples=Labels.single(),
-       ...     components=[],
-       ...     properties=properties_3,
-       ... )
-       >>> tensor_3 = TensorMap(keys=Labels.single(), blocks=[block_3])
+    >>> joined_tensor = mts.join(
+    ...     [tensor_1, tensor_3], axis="properties", add_dimension="tensor"
+    ... )
+    >>> joined_tensor[0].properties
+    Labels(
+        n  tensor
+        0    0
+        2    0
+        3    0
+        0    1
+        2    1
+        3    1
+    )
 
-       joining along properties leads to
+    Finally, when joining along properties, if different ``TensorMap`` have different
+    property names, we'll re-create new properties labels containing the original tensor
+    index and the corresponding property index. This does not apply when joining along
+    samples.
 
-       >>> joined_tensor = mts.join([tensor_1, tensor_3], axis="properties")
-       >>> joined_tensor[0].properties
-       Labels(
-           tensor  n
-             0     0
-             0     2
-             0     3
-             1     0
-             1     2
-             1     3
-       )
+    >>> properties_4 = Labels(["a", "b"], np.array([[0, 0], [1, 2], [1, 3]]))
 
-    3. If Labels names are different we change the names to ("tensor", "property"). This
-       case is only supposed to happen when joining in the property dimension, hence the
-       choice of names:
+    ``properties_4`` has the different names compared to ``properties_1`` defined above.
 
-       >>> properties_4 = Labels(["a", "b"], np.array([[0, 0], [1, 2], [1, 3]]))
+    >>> block_4 = TensorBlock(
+    ...     values=values,
+    ...     samples=Labels.single(),
+    ...     components=[],
+    ...     properties=properties_4,
+    ... )
+    >>> tensor_4 = TensorMap(keys=Labels.single(), blocks=[block_4])
 
-       ``properties_4`` has the different names compared to ``properties_1``
-       defined above.
+    joining along properties leads to
 
-       >>> block_4 = TensorBlock(
-       ...     values=values,
-       ...     samples=Labels.single(),
-       ...     components=[],
-       ...     properties=properties_4,
-       ... )
-       >>> tensor_4 = TensorMap(keys=Labels.single(), blocks=[block_4])
-
-       joining along properties leads to
-
-        >>> joined_tensor = mts.join([tensor_1, tensor_4], axis="properties")
-        >>> joined_tensor[0].properties
-        Labels(
-            tensor  property
-              0        0
-              0        1
-              0        2
-              1        0
-              1        1
-              1        2
-        )
+    >>> joined_tensor = mts.join([tensor_1, tensor_4], axis="properties")
+    >>> joined_tensor[0].properties
+    Labels(
+        joined_index  property
+             0           0
+             0           1
+             0           2
+             1           0
+             1           1
+             1           2
+    )
     """
     if not torch_jit_is_scripting():
         if not isinstance(tensors, (list, tuple)):
-            raise TypeError(f"`tensor` must be a list or a tuple, not {type(tensors)}")
+            raise TypeError(f"`tensors` must be a list or a tuple, not {type(tensors)}")
 
         for tensor in tensors:
             if not isinstance_metatensor(tensor, "TensorMap"):
@@ -359,7 +560,7 @@ def join(
                     f"not {type(tensor)}"
                 )
 
-    if len(tensors) < 1:
+    if len(tensors) == 0:
         raise ValueError("provide at least one `TensorMap` for joining")
 
     if axis not in ("samples", "properties"):
@@ -388,90 +589,101 @@ def join(
     # If this is not the case we have to change unify the corresponding labels later.
     if axis == "samples":
         names_list = [tensor.sample_names for tensor in tensors]
-    else:
-        names_list = [tensor.property_names for tensor in tensors]
 
-    names_list_flattened: List[str] = []
-    for names in names_list:
-        names_list_flattened += names
+        names_list_flattened: List[str] = []
+        for names in names_list:
+            names_list_flattened += names
 
-    unique_names = _unique_str(names_list_flattened)
-    length_equal = [len(unique_names) == len(names) for names in names_list]
-    names_are_same = sum(length_equal) == len(length_equal)
+        unique_names = _unique_str(names_list_flattened)
+        length_equal = [len(unique_names) == len(names) for names in names_list]
+        sample_names_are_same = sum(length_equal) == len(length_equal)
 
-    # It's fine to lose metadata on the property axis, less so on the sample axis!
-    if axis == "samples" and not names_are_same:
-        raise ValueError(
-            "Sample names are not the same! Joining along samples with different "
-            "sample names will loose information and is not supported."
-        )
-
-    keys = tensors[0].keys
-    n_tensors = len(tensors)
-    n_keys_dimensions = 1 + keys.values.shape[1]
-    new_keys_values = _dispatch.empty_like(
-        array=keys.values,
-        shape=[n_tensors, keys.values.shape[0], n_keys_dimensions],
-    )
-
-    for i, tensor in enumerate(tensors):
-        for j, value in enumerate(tensor.keys.values):
-            new_keys_values[i, j, 0] = i
-            new_keys_values[i, j, 1:] = value
-
-    keys = Labels(
-        names=["tensor"] + keys.names,
-        values=new_keys_values.reshape(-1, n_keys_dimensions),
-    )
-
-    blocks: List[TensorBlock] = []
-    for tensor in tensors:
-        for block in tensor.blocks():
-            # We would already raised an error if `axis == "samples"`. Therefore, we can
-            # neglect the check for `axis == "properties"`.
-            if names_are_same:
-                properties = block.properties
-            else:
-                properties = Labels(
-                    names=["property"],
-                    values=_dispatch.int_array_like(
-                        list(range(len(block.properties))), block.properties.values
-                    ).reshape(-1, 1),
-                )
-
-            new_block = TensorBlock(
-                values=block.values,
-                samples=block.samples,
-                components=block.components,
-                properties=properties,
+        if not sample_names_are_same:
+            # It's fine to lose metadata for the properties, less so for the samples
+            raise ValueError(
+                "Different tensor have different sample names in `join`. "
+                "Joining along samples with different sample names will lose "
+                "information and is not supported."
             )
 
-            for parameter, gradient in block.gradients():
-                if len(gradient.gradients_list()) != 0:
-                    raise NotImplementedError(
-                        "gradients of gradients are not supported"
-                    )
+    keys = tensors[0].keys
+    blocks: List[TensorBlock] = []
 
-                new_block.add_gradient(
-                    parameter=parameter,
-                    gradient=TensorBlock(
-                        values=gradient.values,
-                        samples=gradient.samples,
-                        components=gradient.components,
-                        properties=new_block.properties,
-                    ),
+    for i in range(len(keys)):
+        key = keys[i]
+        blocks_to_join: List[TensorBlock] = []
+        for tensor in tensors:
+            blocks_to_join.append(tensor.block(key))
+
+        if axis == "samples":
+            blocks.append(_join_block_samples(blocks_to_join, "join", add_dimension))
+        else:
+            blocks.append(_join_block_properties(blocks_to_join, "join", add_dimension))
+
+    return TensorMap(keys=keys, blocks=blocks)
+
+
+@torch_jit_script
+def join_blocks(
+    blocks: List[TensorBlock],
+    axis: str,
+    add_dimension: Optional[str] = None,
+) -> TensorBlock:
+    """Join a sequence of :py:class:`TensorBlock` along an axis.
+
+    The ``axis`` parameter specifies the type of joining: with ``axis='properties'`` the
+    ``blocks`` will be joined along the ``properties`` and for ``axis='samples'`` they
+    will be joined along the ``samples``.
+
+    :param tensors: sequence of :py:class:`TensorMap` to join
+    :param axis: Along which axis the blocks should be joined. This can be either
+        ``'properties'`` or ``'samples'``.
+    :param add_dimension: Add an the extra dimension to the joined labels with the given
+        name. The dimension forms the last dimension of the joined labels.
+    :return: The joined :py:class:`TensorBlock` with more properties or samples than the
+        inputs.
+
+    .. seealso::
+
+        The examples for :py:func:`join`.
+    """
+    if not torch_jit_is_scripting():
+        if not isinstance(blocks, (list, tuple)):
+            raise TypeError(f"`blocks` must be a list or a tuple, not {type(blocks)}")
+
+        for block in blocks:
+            if not isinstance_metatensor(block, "TensorBlock"):
+                raise TypeError(
+                    "`blocks` elements must be metatensor TensorBlock, "
+                    f"not {type(block)}"
                 )
 
-            blocks.append(new_block)
+    if len(blocks) == 0:
+        raise ValueError("provide at least one `TensorBlock` for joining")
 
-    tensor = TensorMap(keys=keys, blocks=blocks)
+    if axis not in ("samples", "properties"):
+        raise ValueError(
+            "Only `'properties'` or `'samples'` are valid values for the `axis` "
+            "parameter"
+        )
 
     if axis == "samples":
-        tensor_joined = tensor.keys_to_samples("tensor", sort_samples=sort_samples)
-    else:
-        tensor_joined = tensor.keys_to_properties("tensor", sort_samples=sort_samples)
+        names_list = [block.samples.names for block in blocks]
+        names_list_flattened: List[str] = []
+        for names in names_list:
+            names_list_flattened += names
 
-    if remove_tensor_name and _disjoint_tensor_labels(tensors, axis):
-        return remove_dimension(tensor_joined, name="tensor", axis=axis)
+        unique_names = _unique_str(names_list_flattened)
+        length_equal = [len(unique_names) == len(names) for names in names_list]
+        samples_names_are_same = sum(length_equal) == len(length_equal)
+
+        if not samples_names_are_same:
+            # It's fine to lose metadata for the properties, less so for the samples!
+            raise ValueError(
+                "Different blocks have different sample names in `join_blocks`. "
+                "Joining along samples with different sample names will lose "
+                "information and is not supported."
+            )
+        return _join_block_samples(blocks, "join_blocks", add_dimension)
     else:
-        return tensor_joined
+        return _join_block_properties(blocks, "join_blocks", add_dimension)

--- a/python/metatensor_operations/tests/add.py
+++ b/python/metatensor_operations/tests/add.py
@@ -270,25 +270,18 @@ def test_self_add_error():
         mts.add(tensor, np.ones((3, 4)))
 
 
-def test_add_finite_difference():
+def test_finite_difference():
     def function(array):
-        tensor_1 = _gradcheck.cartesian_linear(array)
-        tensor_2 = _gradcheck.cartesian_cubic(array)
+        tensor_1 = _gradcheck.tensor_with_grad_a(array, parameter="g")
+        tensor_2 = _gradcheck.tensor_with_grad_b(array, parameter="g")
         return mts.add(tensor_1, tensor_2)
 
     rng = np.random.default_rng(seed=123456)
-    array = rng.random((5, 3))
+    array = rng.random((50, 3))
     _gradcheck.check_finite_differences(function, array, parameter="g")
 
-
-@pytest.mark.skipif(not HAS_TORCH, reason="requires torch")
-def test_torch_add_finite_difference():
-    def function(array):
-        tensor_1 = _gradcheck.cartesian_linear(array)
-        tensor_2 = _gradcheck.cartesian_cubic(array)
-        return mts.add(tensor_1, tensor_2)
-
-    rng = torch.Generator()
-    rng.manual_seed(123456)
-    array = torch.rand(5, 3, dtype=torch.float64, generator=rng)
-    _gradcheck.check_finite_differences(function, array, parameter="g")
+    if HAS_TORCH:
+        rng = torch.Generator()
+        rng.manual_seed(123456)
+        array = torch.rand(50, 3, dtype=torch.float64, generator=rng)
+        _gradcheck.check_finite_differences(function, array, parameter="g")

--- a/python/metatensor_torch/tests/operations/join.py
+++ b/python/metatensor_torch/tests/operations/join.py
@@ -20,7 +20,10 @@ def test_join():
             "qm7-power-spectrum.mts",
         )
     )
-    joined_tensor = mts.join([tensor, tensor], axis="properties")
+
+    joined_tensor = mts.join(
+        [tensor, tensor], axis="properties", add_dimension="tensor"
+    )
 
     assert isinstance(joined_tensor, torch.ScriptObject)
     assert joined_tensor._type().name() == "TensorMap"
@@ -30,7 +33,7 @@ def test_join():
 
     # test property names
     names = tensor.block(0).properties.names
-    assert joined_tensor.block(0).properties.names == ["tensor"] + names
+    assert joined_tensor.block(0).properties.names == names + ["tensor"]
 
     # test samples
     assert joined_tensor.block(0).samples == tensor.block(0).samples


### PR DESCRIPTION
We previously had to add an extra "tensor" dimension in the keys, and the check to know whether we could or not remove this extra dimension was accidentally quadratic, taking a lot of time when using join to batch data when training ML models.

This is a breaking change since the API for `mts.join` will change. Instead of always adding a dimension, the user can now pick if they want to add a dimension tracking the origin of joined samples/properties with `add_dimension`. The `sort_samples` option was also removed.

Some benchmarks, batching the MAD training set. The two options with v0.3.4 where to either set `remove_tensor_name=True`, or to set it to `False` and manually call `mts.remove_dimension` after the fact.

<details>

```py
import time

import ase.io
import torch

import metatensor.torch as mts


def frame_to_tensor(frame, index):
    e = torch.tensor(frame.get_potential_energy())
    f = torch.tensor(frame.get_forces())

    block = mts.TensorBlock(
        values=e.reshape(1, 1),
        samples=mts.Labels("system", torch.tensor([[index]])),
        components=[],
        properties=mts.Labels("energy", torch.tensor([[0]])),
    )

    grad_samples = torch.zeros((len(f), 3), dtype=torch.int32)
    grad_samples[:, 0] = 0
    grad_samples[:, 1] = index
    grad_samples[:, 2] = torch.tensor(list(range(len(f))))
    gradient = mts.TensorBlock(
        values=-f.reshape(-1, 3, 1),
        samples=mts.Labels(["sample", "system", "atom"], grad_samples),
        components=[mts.Labels("xyz", torch.tensor([[0], [1], [2]]))],
        properties=mts.Labels("energy", torch.tensor([[0]])),
    )

    block.add_gradient("positions", gradient)
    return mts.TensorMap(mts.Labels("_", torch.tensor([[0]])), [block])


frames = ase.io.read("mad-train.xyz", ":")
print("done loading")

tensors = []
for i, frame in enumerate(frames):
    tensors.append(frame_to_tensor(frame, i))
print("done converting")


def batch_join(tensors, batch_size):
    start = 0
    while start < len(tensors):
        # # old
        # _ = mts.join(
        #     tensors[start : start + batch_size],
        #     axis="samples",
        #     remove_tensor_name=True,
        # )

        # # old manual remove
        # tensor = mts.join(tensors[start : start + batch_size], axis="samples")
        # _ = mts.remove_dimension(tensor, axis="samples", name="tensor")

        # new
        _ = mts.join(tensors[start : start + batch_size], axis="samples")
        start += batch_size


for batch_size in [8, 16, 32, 64, 128]:
    print(f"============ BATCH SIZE {batch_size}")

    # warmup
    start = time.time()
    _ = batch_join(tensors[: 3 * batch_size], batch_size=batch_size)
    stop = time.time()

    n_iters = 2
    n_batches = len(frames) // batch_size
    print(f"estimated benchmark time: {(stop - start) / 3 * n_batches * n_iters} s")

    start = time.time()
    for _ in range(n_iters):
        _ = batch_join(tensors, batch_size=batch_size)
    stop = time.time()

    print(f"{(stop - start) / n_iters * 1e3} ms")
    print(f"{(stop - start) / (n_batches * n_iters) * 1e3} ms/batch")

```

</details>

<img width="570" height="433" alt="timing" src="https://github.com/user-attachments/assets/a2d21313-499c-4db6-961b-c7d818f5f366" />
<img width="562" height="433" alt="timing-per-batch" src="https://github.com/user-attachments/assets/9a3b8d0c-14bc-4d3f-b54f-727d1c76f5e9" />



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?
