### PR TITLE
Bump the minimal supported ubuntu to 22.04, and cmake to 3.22

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,11 +33,11 @@ jobs:
       matrix:
         include:
           - name: x86_64 Linux
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             rust-target: x86_64-unknown-linux-gnu
             cibw-arch: x86_64
           - name: arm64 Linux
-            os: ubuntu-22.04-arm
+            os: ubuntu-24.04-arm
             rust-target: aarch64-unknown-linux-gnu
             cibw-arch: aarch64
           - name: x86_64 macOS
@@ -72,7 +72,7 @@ jobs:
         run: python -m pip install cibuildwheel twine
 
       - name: build manylinux with rust docker image
-        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'ubuntu-22.04-arm'
+        if: matrix.os == 'ubuntu-24.04' || matrix.os == 'ubuntu-24.04-arm'
         run: docker build -t rustc-manylinux2014_${{ matrix.cibw-arch }} python/scripts/rustc-manylinux2014_${{ matrix.cibw-arch }}
 
       - name: build metatensor-core wheel
@@ -104,14 +104,14 @@ jobs:
       matrix:
         torch-version: ['2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '2.8']
         arch: ['arm64', 'x86_64']
-        os: ['ubuntu-22.04', 'ubuntu-22.04-arm', 'macos-13', 'macos-14', 'windows-2022']
+        os: ['ubuntu-24.04', 'ubuntu-24.04-arm', 'macos-13', 'macos-14', 'windows-2022']
         exclude:
           # remove mismatched arch-os combinations
           - {os: macos-13, arch: arm64}
           - {os: windows-2022, arch: arm64}
-          - {os: ubuntu-22.04, arch: arm64}
+          - {os: ubuntu-24.04, arch: arm64}
           - {os: macos-14, arch: x86_64}
-          - {os: ubuntu-22.04-arm, arch: x86_64}
+          - {os: ubuntu-24.04-arm, arch: x86_64}
           # arch x86_64 on macos is only supported for torch <2.3
           - {os: macos-13, arch: x86_64, torch-version: '2.3'}
           - {os: macos-13, arch: x86_64, torch-version: '2.4'}
@@ -122,12 +122,12 @@ jobs:
         include:
           # add `cibw-arch` and `rust-target` to the different configurations
           - name: x86_64 Linux
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             arch: x86_64
             rust-target: x86_64-unknown-linux-gnu
             cibw-arch: x86_64
           - name: arm64 Linux
-            os: ubuntu-22.04-arm
+            os: ubuntu-24.04-arm
             arch: arm64
             rust-target: aarch64-unknown-linux-gnu
             cibw-arch: aarch64
@@ -175,7 +175,7 @@ jobs:
         run: python -m pip install cibuildwheel
 
       - name: build manylinux with rust docker image
-        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'ubuntu-22.04-arm'
+        if: matrix.os == 'ubuntu-24.04' || matrix.os == 'ubuntu-24.04-arm'
         run: |
           docker buildx build \
               -t rustc-manylinux_2_28_${{ matrix.cibw-arch }} \
@@ -217,16 +217,16 @@ jobs:
 
   merge-torch-wheels:
     needs: build-torch-wheels
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: merge metatensor-torch ${{ matrix.name }}
     strategy:
       matrix:
         include:
           - name: x86_64 Linux
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             arch: x86_64
           - name: arm64 Linux
-            os: ubuntu-22.04-arm
+            os: ubuntu-24.04-arm
             arch: arm64
           - name: x86_64 macOS
             os: macos-13
@@ -290,7 +290,7 @@ jobs:
 
   build-others:
     name: Build other wheels/sdists
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       METATENSOR_NO_LOCAL_DEPS: "1"
     steps:
@@ -340,7 +340,7 @@ jobs:
   merge-and-release:
     name: Merge and release wheels/sdists
     needs: [build-core-wheels, merge-torch-wheels, build-others]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write
@@ -444,7 +444,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             rust-target: x86_64-unknown-linux-gnu
             libtorch-url: https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-2.8.0%2Bcpu.zip
           - os: macos-14

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   coverage:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: collect code coverage
     # Adapted from https://www.scivision.dev/github-actions-latest-llvm-clang-flang/
     strategy:
@@ -101,4 +101,3 @@ jobs:
           fail_ci_if_error: true
           files: coverage.xml,rust_codecov.json
           token: ${{ secrets.CODECOV_TOKEN }}
-

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.9"
             torch-version: "2.1"
             numpy-version-pin: "<2.0"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.9"
             torch-version: "2.8"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.13"
             torch-version: "2.8"
           - os: macos-14

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         include:
           # test without any feature (i.e shared build)
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             rust-version: stable
             rust-target: x86_64-unknown-linux-gnu
             extra-name: ", no features"
@@ -35,7 +35,7 @@ jobs:
             cmake-generator: Unix Makefiles
 
           # test with all features (i.e static build + ndarray)
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             rust-version: stable
             rust-target: x86_64-unknown-linux-gnu
             cargo-test-flags: --release --all-features
@@ -45,14 +45,14 @@ jobs:
             cc: gcc
             cmake-generator: Unix Makefiles
 
-          # check the build on a stock Ubuntu 20.04, which uses cmake 3.16, and
+          # check the build on a stock Ubuntu 22.04, which uses cmake 3.22, and
           # with our minimal supported rust version
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             rust-version: 1.74
-            container: ubuntu:20.04
+            container: ubuntu:22.04
             rust-target: x86_64-unknown-linux-gnu
             cargo-build-flags: --features=rayon
-            extra-name: ", cmake 3.16"
+            extra-name: ", cmake 3.22"
             cxx: g++
             cc: gcc
             cmake-generator: Unix Makefiles
@@ -85,7 +85,7 @@ jobs:
             cmake-generator: MinGW Makefiles
     steps:
       - name: install dependencies in container
-        if: matrix.container == 'ubuntu:20.04'
+        if: matrix.container == 'ubuntu:22.04'
         run: |
           apt update
           apt install -y software-properties-common
@@ -96,7 +96,7 @@ jobs:
           fetch-depth: 0
 
       - name: Configure git safe directory
-        if: matrix.container == 'ubuntu:20.04'
+        if: matrix.container == 'ubuntu:22.04'
         run: git config --global --add safe.directory /__w/metatensor/metatensor
 
       - name: setup rust
@@ -136,7 +136,7 @@ jobs:
 
   # check that the C API declarations are correctly used by Rust and Python
   prevent-bitrot:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: check C API declarations
     steps:
       - uses: actions/checkout@v5
@@ -173,7 +173,7 @@ jobs:
 
   # make sure no debug print stays in the code
   check-debug-prints:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: check leftover debug print
 
     steps:

--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -18,15 +18,16 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             torch-version: "2.8"
             python-version: "3.13"
             cargo-test-flags: --release
             do-valgrind: true
 
-          - os: ubuntu-22.04
-            container: ubuntu:20.04
-            extra-name: ", cmake 3.16"
+          # check the build on a stock Ubuntu 22.04, which uses cmake 3.22
+          - os: ubuntu-24.04
+            container: ubuntu:22.04
+            extra-name: ", cmake 3.22"
             torch-version: "2.1"
             cargo-test-flags: ""
             cxx-flags: -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -g
@@ -42,7 +43,7 @@ jobs:
             cargo-test-flags: --release
     steps:
       - name: install dependencies in container
-        if: matrix.container == 'ubuntu:20.04'
+        if: matrix.container == 'ubuntu:22.04'
         run: |
           apt update
           apt install -y software-properties-common
@@ -56,7 +57,7 @@ jobs:
           fetch-depth: 0
 
       - name: Configure git safe directory
-        if: matrix.container == 'ubuntu:20.04'
+        if: matrix.container == 'ubuntu:22.04'
         run: git config --global --add safe.directory /__w/metatensor/metatensor
 
       - name: setup rust
@@ -66,7 +67,7 @@ jobs:
 
       # we get torch from pip to run the C++ test
       - name: setup Python
-        if: matrix.container != 'ubuntu:20.04'
+        if: matrix.container != 'ubuntu:22.04'
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 # This file is here to serve as a minimal CMakeLists.txt at the root of the
 # metatensor repository, allowing to easily include it inside other projects as

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -28,8 +28,9 @@ on metatensor:
 Additionally, you will need to install the following software, but you should
 not have to interact with them directly:
 
-- **CMake**: we need a CMake version of at least 3.16.
-- **a C++ compiler** we need a compiler supporting C++17. GCC >= 7, clang >= 5 and MSVC >= 19 should all work.
+- **CMake**: we need a CMake version of at least 3.22.
+- **a C++ compiler** we need a compiler supporting C++17. GCC >= 7, clang >= 5
+  and MSVC >= 19 should all work.
 
 .. _rustup: https://rustup.rs
 .. _tox: https://tox.readthedocs.io/en/latest

--- a/docs/src/core/reference/c/index.rst
+++ b/docs/src/core/reference/c/index.rst
@@ -41,7 +41,7 @@ Alternatively, we provide a ``cmake`` configuration file, allowing you to use
 
 .. code-block:: cmake
 
-    cmake_minimum_required(VERSION 3.16)
+    cmake_minimum_required(VERSION 3.22)
     project(my-project C)
 
     find_package(metatensor)

--- a/docs/src/core/reference/cxx/index.rst
+++ b/docs/src/core/reference/cxx/index.rst
@@ -36,7 +36,7 @@ a ``cmake`` configuration file, allowing you to use ``metatensor`` like this
 
 .. code-block:: cmake
 
-    cmake_minimum_required(VERSION 3.16)
+    cmake_minimum_required(VERSION 3.22)
     project(my-project CXX)
 
     find_package(metatensor)

--- a/docs/src/torch/reference/cxx/index.rst
+++ b/docs/src/torch/reference/cxx/index.rst
@@ -13,7 +13,7 @@ CMake after :ref:`installing metatensor's C++ Torch interface <install-torch-cxx
 
 .. code-block:: cmake
 
-    cmake_minimum_required(VERSION 3.16)
+    cmake_minimum_required(VERSION 3.22)
     project(my-project CXX)
 
     find_package(metatensor_torch)

--- a/metatensor-core/CHANGELOG.md
+++ b/metatensor-core/CHANGELOG.md
@@ -17,6 +17,10 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 #### Removed
 -->
 
+### Changed
+
+- We now requires at least cmake v3.22 to compile metatensor
+
 ## [Version 0.1.17](https://github.com/metatensor/metatensor/releases/tag/metatensor-core-v0.1.17) - 2025-09-02
 
 ### Fixed

--- a/metatensor-core/CMakeLists.txt
+++ b/metatensor-core/CMakeLists.txt
@@ -3,7 +3,7 @@
 # This API is implemented in Rust, in the metatensor-core crate, but Rust users
 # of the API should use the metatensor crate instead, wrapping metatensor-core in
 # an easier to use, idiomatic Rust API.
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 # Is metatensor the main project configured by the user? Or is this being used
 # as a submodule/subdirectory?

--- a/metatensor-core/cmake/dev-versions.cmake
+++ b/metatensor-core/cmake/dev-versions.cmake
@@ -16,11 +16,6 @@ function(parse_version _version_ _major_ _minor_ _patch_ _rc_)
     set(${_patch_} ${CMAKE_MATCH_3} PARENT_SCOPE)
 endfunction()
 
-if (CMAKE_VERSION VERSION_LESS "3.17")
-    # CMAKE_CURRENT_FUNCTION_LIST_DIR was added in CMake 3.17
-    set(CMAKE_CURRENT_FUNCTION_LIST_DIR "${CMAKE_CURRENT_LIST_DIR}")
-endif()
-
 # Get the time of the last modification since the last tag/release, and a hash
 # of the latest commit/full state of a dirty repository
 function(git_version_info _tag_prefix_ _output_n_commits_ _output_git_hash_)

--- a/metatensor-core/cmake/metatensor-config.in.cmake
+++ b/metatensor-core/cmake/metatensor-config.in.cmake
@@ -1,6 +1,6 @@
 @PACKAGE_INIT@
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 include(FindPackageHandleStandardArgs)
 
@@ -71,14 +71,11 @@ if (@METATENSOR_INSTALL_BOTH_STATIC_SHARED@ OR NOT @BUILD_SHARED_LIBS@)
     target_compile_features(metatensor::static INTERFACE cxx_std_17)
 endif()
 
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18")
-    # Export either the shared or static library as the metatensor target
-    # This requires cmake 3.18+ to use ALIAS for non-GLOBAL IMPORTED targets
-    if (@BUILD_SHARED_LIBS@)
-        add_library(metatensor ALIAS metatensor::shared)
-    else()
-        add_library(metatensor ALIAS metatensor::static)
-    endif()
+# Export either the shared or static library as the metatensor target
+if (@BUILD_SHARED_LIBS@)
+    add_library(metatensor ALIAS metatensor::shared)
+else()
+    add_library(metatensor ALIAS metatensor::static)
 endif()
 
 

--- a/metatensor-core/cmake/version-defines.cmake
+++ b/metatensor-core/cmake/version-defines.cmake
@@ -3,34 +3,7 @@
 # build dir (instead of modifying the one in the source dir) to mimize git noise
 # (since the version changes for every git commit).
 
-cmake_minimum_required(VERSION 3.16)
-
-function(copy_if_different _src_ _dst_)
-    # file(COPY_FILE ...) was added in cmake 3.21, this emulates the same
-    # behavior on older versions
-    get_filename_component(_dst_dir_ ${_dst_} DIRECTORY)
-    get_filename_component(_src_name_ ${_src_} NAME)
-
-    if (EXISTS ${_dst_})
-        file(SHA1 ${_src_} new_hash)
-        file(SHA1 ${_dst_} old_hash)
-
-        if ("${new_hash}" STREQUAL "${old_hash}")
-            set(_do_copy_ FALSE)
-        else()
-            set(_do_copy_ TRUE)
-        endif()
-    else()
-        # The destination does not exist
-        set(_do_copy_ TRUE)
-    endif()
-
-    if (${_do_copy_})
-        file(COPY ${_src_} DESTINATION ${_dst_dir_})
-        file(RENAME ${_dst_dir_}/${_src_name_} ${_dst_})
-    endif()
-endfunction()
-
+cmake_minimum_required(VERSION 3.22)
 
 file(COPY ${MTS_SOURCE_DIR}/include/metatensor.hpp DESTINATION ${MTS_BINARY_DIR}/include)
 file(READ ${MTS_SOURCE_DIR}/include/metatensor.h _header_content_)
@@ -56,8 +29,5 @@ string(REPLACE ";" "\\;" _header_content_ "${_header_content_}")
 file(APPEND ${_path_} ${_header_content_})
 
 set(_destination_ "${MTS_BINARY_DIR}/include/metatensor.h")
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.21")
-    file(COPY_FILE ${_path_} ${_destination_} ONLY_IF_DIFFERENT)
-else()
-    copy_if_different(${_path_} ${_destination_})
-endif()
+
+file(COPY_FILE ${_path_} ${_destination_} ONLY_IF_DIFFERENT)

--- a/metatensor-core/tests/cmake-project/CMakeLists.txt
+++ b/metatensor-core/tests/cmake-project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 message(STATUS "Running with CMake version ${CMAKE_VERSION}")
 

--- a/metatensor-core/tests/cpp/CMakeLists.txt
+++ b/metatensor-core/tests/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 project(metatensor-tests)
 
 if (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})

--- a/metatensor-torch/CHANGELOG.md
+++ b/metatensor-torch/CHANGELOG.md
@@ -17,6 +17,10 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 ### Removed
 -->
 
+### Changed
+
+- We now requires at least cmake v3.22 to compile metatensor-torch
+
 ## [Version 0.8.1](https://github.com/metatensor/metatensor/releases/tag/metatensor-torch-v0.8.1) - 2025-09-24
 
 ### Fixed

--- a/metatensor-torch/CMakeLists.txt
+++ b/metatensor-torch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 if (POLICY CMP0135)
     # Use download time as timestamp when extracting files from archives
@@ -160,38 +160,8 @@ file(APPEND ${_path_} "#define METATENSOR_TORCH_VERSION_MINOR ${PROJECT_VERSION_
 file(APPEND ${_path_} "/** Patch version number of metatensor-torch as an integer */\n")
 file(APPEND ${_path_} "#define METATENSOR_TORCH_VERSION_PATCH ${PROJECT_VERSION_PATCH}\n")
 
-function(copy_if_different _src_ _dst_)
-    # file(COPY_FILE ...) was added in cmake 3.21, this emulates the same
-    # behavior on older versions
-    get_filename_component(_dst_dir_ ${_dst_} DIRECTORY)
-    get_filename_component(_src_name_ ${_src_} NAME)
-
-    if (EXISTS ${_dst_})
-        file(SHA1 ${_src_} new_hash)
-        file(SHA1 ${_dst_} old_hash)
-
-        if ("${new_hash}" STREQUAL "${old_hash}")
-            set(_do_copy_ FALSE)
-        else()
-            set(_do_copy_ TRUE)
-        endif()
-    else()
-        # The destination does not exist
-        set(_do_copy_ TRUE)
-    endif()
-
-    if (${_do_copy_})
-        file(COPY ${_src_} DESTINATION ${_dst_dir_})
-        file(RENAME ${_dst_dir_}/${_src_name_} ${_dst_})
-    endif()
-endfunction()
-
 set(_destination_ "${CMAKE_CURRENT_BINARY_DIR}/include/metatensor/torch/version.h")
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.21")
-    file(COPY_FILE ${_path_} ${_destination_} ONLY_IF_DIFFERENT)
-else()
-    copy_if_different(${_path_} ${_destination_})
-endif()
+file(COPY_FILE ${_path_} ${_destination_} ONLY_IF_DIFFERENT)
 
 if (METATENSOR_TORCH_TESTS)
     enable_testing()

--- a/metatensor-torch/cmake/dev-versions.cmake
+++ b/metatensor-torch/cmake/dev-versions.cmake
@@ -16,11 +16,6 @@ function(parse_version _version_ _major_ _minor_ _patch_ _rc_)
     set(${_patch_} ${CMAKE_MATCH_3} PARENT_SCOPE)
 endfunction()
 
-if (CMAKE_VERSION VERSION_LESS "3.17")
-    # CMAKE_CURRENT_FUNCTION_LIST_DIR was added in CMake 3.17
-    set(CMAKE_CURRENT_FUNCTION_LIST_DIR "${CMAKE_CURRENT_LIST_DIR}")
-endif()
-
 # Get the time of the last modification since the last tag/release, and a hash
 # of the latest commit/full state of a dirty repository
 function(git_version_info _tag_prefix_ _output_n_commits_ _output_git_hash_)

--- a/metatensor-torch/tests/cmake-project/CMakeLists.txt
+++ b/metatensor-torch/tests/cmake-project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 message(STATUS "Running with CMake version ${CMAKE_VERSION}")
 

--- a/python/metatensor_core/CMakeLists.txt
+++ b/python/metatensor_core/CMakeLists.txt
@@ -6,7 +6,7 @@
 # separate libmetatensor package), the second one is used everywhere else (for
 # local development builds and for the PyPI distribution).
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 project(metatensor-python NONE)
 
 option(METATENSOR_CORE_PYTHON_USE_EXTERNAL_LIB "Force the usage of an external version of metatensor-core" OFF)

--- a/python/metatensor_torch/CMakeLists.txt
+++ b/python/metatensor_torch/CMakeLists.txt
@@ -6,7 +6,7 @@
 # separate libmetatensor package), the second one is used everywhere else (for
 # local development builds and for the PyPI distribution).
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 project(metatensor-torch-python CXX)
 
 option(METATENSOR_TORCH_PYTHON_USE_EXTERNAL_LIB "Force the usage of an external version of metatensor-torch" OFF)

--- a/python/scripts/rustc-manylinux_2_28_aarch64/Dockerfile
+++ b/python/scripts/rustc-manylinux_2_28_aarch64/Dockerfile
@@ -11,7 +11,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 ENV RUST_BUILD_TARGET="aarch64-unknown-linux-gnu"
 
 # Install an older C++ compiler. The default compiler (gcc-14) introduces calls
-# to `__cxa_call_terminate` which is not available in ubuntu-22.04 libstdc++
+# to `__cxa_call_terminate` which is not available in ubuntu 22.04 libstdc++
 ARG DEVTOOLSET_VERSION=11
 RUN yum install -y gcc-toolset-${DEVTOOLSET_VERSION}-toolchain
 ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH

--- a/python/scripts/rustc-manylinux_2_28_x86_64/Dockerfile
+++ b/python/scripts/rustc-manylinux_2_28_x86_64/Dockerfile
@@ -11,7 +11,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 ENV RUST_BUILD_TARGET="x86_64-unknown-linux-gnu"
 
 # Install an older C++ compiler. The default compiler (gcc-14) introduces calls
-# to `__cxa_call_terminate` which is not available in ubuntu-22.04 libstdc++
+# to `__cxa_call_terminate` which is not available in ubuntu 22.04 libstdc++
 ARG DEVTOOLSET_VERSION=11
 RUN yum install -y gcc-toolset-${DEVTOOLSET_VERSION}-toolchain
 ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH


### PR DESCRIPTION
Ubuntu 20.04 was our previous minimal version, but is EOL since May 2025.


# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [x] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?
