### PR TITLE
Implementation of `reduce_over_properties`

### DIFF
--- a/python/metatensor_operations/metatensor/operations/__init__.py
+++ b/python/metatensor_operations/metatensor/operations/__init__.py
@@ -53,6 +53,16 @@ from ._one_hot import one_hot  # noqa: F401
 from ._ones_like import ones_like, ones_like_block  # noqa: F401
 from ._pow import pow  # noqa: F401
 from ._random_like import random_uniform_like, random_uniform_like_block  # noqa: F401
+from ._reduce_over_properties import (  # noqa: F401
+    mean_over_properties,
+    mean_over_properties_block,
+    std_over_properties,
+    std_over_properties_block,
+    sum_over_properties,
+    sum_over_properties_block,
+    var_over_properties,
+    var_over_properties_block,
+)
 from ._reduce_over_samples import (  # noqa: F401
     mean_over_samples,
     mean_over_samples_block,

--- a/python/metatensor_operations/metatensor/operations/_reduce_over_properties.py
+++ b/python/metatensor_operations/metatensor/operations/_reduce_over_properties.py
@@ -1,0 +1,674 @@
+from typing import List, Optional, Union
+
+import numpy as np
+
+from . import _dispatch
+from ._backend import (
+    Labels,
+    TensorBlock,
+    TensorMap,
+    torch_jit_is_scripting,
+    torch_jit_script,
+)
+
+
+def _reduce_over_properties_block(
+    block: TensorBlock,
+    property_names: Union[List[str], str],
+    reduction: str,
+    remaining_properties: Optional[List[str]] = None,
+) -> TensorBlock:
+    """
+    Create a new :py:class:`TensorBlock` reducing the ``properties`` among the
+    selected ``properties``.
+
+    The output :py:class:`TensorBlocks` have the same components as the input.
+    "sum", "mean", "std" or "var" reductions can be performed.
+
+    :param block:
+        input block
+    :param property_names:
+        names of properties to reduce over. it is ignored if remaining_properties is
+        given
+    :param remaining_properties:
+        names of properties that should remain after reducing reduce over.
+        it is computed automatically from property_names if missing or set to None
+    :param reduction:
+        how to reduce, only available values are "mean", "sum", "std" or "var"
+    """
+    if isinstance(property_names, str):
+        property_names_list = [property_names]
+    else:
+        property_names_list = property_names
+
+    block_properties = block.properties
+
+    remaining_properties = None
+    if remaining_properties is None:
+        remaining_property_names: List[str] = []
+        for p_name in block_properties.names:
+            if p_name in property_names_list:
+                continue
+            remaining_property_names.append(p_name)
+    else:
+        remaining_property_names = remaining_properties
+
+    for sample in remaining_property_names:
+        assert sample in block_properties.names
+
+    assert reduction in ["sum", "mean", "var", "std"]
+    # get the indices of the selected property
+    remaining_property_columns = [
+        block_properties.names.index(prop) for prop in remaining_property_names
+    ]
+
+    if len(block.properties) == 0:
+        properties = Labels(
+            remaining_property_names,
+            _dispatch.zeros_like(block.values, [0, len(remaining_property_names)]),
+        )
+
+        result_block = TensorBlock(
+            values=block.values,
+            samples=block.samples,
+            components=block.components,
+            properties=properties,
+        )
+
+        # The gradient does not change because the only thing that matters for
+        # the gradients are the samples to which they are connected, but in this
+        # case there are no samples in the TensorBlock
+        for parameter, gradient in block.gradients():
+            if len(gradient.gradients_list()) != 0:
+                raise NotImplementedError("gradients of gradients are not supported")
+
+            result_block.add_gradient(
+                parameter=parameter,
+                gradient=TensorBlock(
+                    values=gradient.values,
+                    samples=gradient.samples,
+                    components=gradient.components,
+                    properties=gradient.properties,
+                ),
+            )
+
+        return result_block
+
+    # get which properties will still be there after reduction
+    if len(remaining_property_names) == 0:
+        new_properties = _dispatch.zeros_like(block_properties.values, shape=(1, 0))
+        index = _dispatch.zeros_like(
+            block_properties.values, shape=(block_properties.values.shape[0],)
+        )
+    else:
+        new_properties, index = _dispatch.unique_with_inverse(
+            block_properties.values[:, remaining_property_columns], axis=0
+        )
+        index = index.reshape(-1)
+
+    block_values = block.values
+    shape = (block_values.shape)[:-1] + (new_properties.shape[0],)
+    values_sum = _dispatch.zeros_like(block_values, shape=shape)
+
+    _dispatch.columns_add(values_sum, block_values, index)
+
+    values_mean = _dispatch.empty_like(values_sum, [0])
+    values_result = _dispatch.empty_like(values_sum, [0])
+
+    if reduction == "mean" or reduction == "std" or reduction == "var":
+        bincount = _dispatch.make_like(_dispatch.bincount(index), values_sum)
+        bin_shape = list(block_values.shape)
+        bin_shape = [(-1 if i == 1 else 1) for i in range(len(shape))]
+        bincount = bincount.reshape(bin_shape)
+        values_mean = values_sum / bincount
+
+        if reduction == "std" or reduction == "var":
+            values_var = _dispatch.zeros_like(block_values, shape=shape)
+            _dispatch.columns_add(
+                values_var,
+                (block_values - _dispatch.slice_last_dim(values_mean, index)) ** 2,
+                index,
+            )
+            values_var = values_var / bincount
+
+            if reduction == "std":
+                values_result = _dispatch.sqrt(values_var)
+            elif reduction == "var":
+                values_result = values_var
+
+        elif reduction == "mean":
+            values_result = values_mean
+    elif reduction == "sum":
+        values_result = values_sum
+
+    if len(remaining_property_names) == 0:
+        properties_label = Labels(
+            names="_",
+            values=_dispatch.zeros_like(block_properties.values, shape=(1, 1)),
+        )
+    else:
+        properties_label = Labels(
+            remaining_property_names,
+            new_properties,
+        )
+
+    result_block = TensorBlock(
+        values=values_result,
+        samples=block.samples,
+        components=block.components,
+        properties=properties_label,
+    )
+
+    for parameter, gradient in block.gradients():
+        if len(gradient.gradients_list()) != 0:
+            raise NotImplementedError("gradients of gradients are not supported")
+
+        # check if all gradients are zeros
+        if len(gradient.properties) == 0:
+            # The gradients does not change because, if they are all zeros, the
+            # gradients after reducing operation is still zero.
+
+            # For any function of the TensorBlock values x(t):
+            # f(x(t))-> df(x(t))/dx * dx/dt
+            # and dx/dt == 0.
+            result_block.add_gradient(
+                parameter=parameter,
+                gradient=TensorBlock(
+                    values=gradient.values,
+                    samples=gradient.samples,
+                    components=gradient.components,
+                    properties=gradient.properties,
+                ),
+            )
+            continue
+
+        new_gradient_properties, index_gradient = result_block.properties.values, index
+        index_gradient = index_gradient.reshape(-1)
+
+        gradient_values = gradient.values
+        other_shape = gradient_values.shape[:-1]
+        gradient_values_result = _dispatch.zeros_like(
+            gradient_values,
+            shape=other_shape + (new_gradient_properties.shape[0],),
+        )
+        _dispatch.columns_add(gradient_values_result, gradient_values, index_gradient)
+
+        if reduction == "mean" or reduction == "var" or reduction == "std":
+            bincount = _dispatch.bincount(index_gradient)
+            bincount = bincount.reshape((1,) * len(other_shape) + (-1,))
+            gradient_values_result = gradient_values_result / bincount
+            if reduction == "std" or reduction == "var":
+                values_times_gradient_values = _dispatch.zeros_like(gradient_values)
+
+                for i in range(gradient.samples.values.shape[0]):
+                    s = gradient.samples.entry(i)
+                    values_times_gradient_values[i] = (
+                        gradient_values[i] * block_values[int(s[0])]
+                    )
+
+                values_grad_result = _dispatch.zeros_like(
+                    gradient_values,
+                    shape=other_shape + (new_gradient_properties.shape[0],),
+                )
+                _dispatch.columns_add(
+                    values_grad_result,
+                    values_times_gradient_values,
+                    index_gradient,
+                )
+
+                values_grad_result = values_grad_result / bincount
+                sample_indices = gradient.samples.values[:, 0]
+                if reduction == "var":
+                    for i, _ in enumerate(new_gradient_properties):
+                        shape = (-1,) + (1,) * (gradient_values_result.ndim - 2)
+                        gradient_values_result = _dispatch.scatter_last_dim(
+                            gradient_values_result,
+                            i,
+                            _dispatch.slice_last_dim(gradient_values_result, i)
+                            * _dispatch.slice_last_dim(values_mean, i)[
+                                sample_indices
+                            ].reshape(shape),
+                        )
+                    gradient_values_result = 2 * (
+                        values_grad_result - gradient_values_result
+                    )
+                else:  # std
+                    for i, _ in enumerate(new_gradient_properties):
+                        shape = (-1,) + (1,) * (gradient_values_result.ndim - 2)
+                        if torch_jit_is_scripting():
+                            gradient_values_result = _dispatch.scatter_last_dim(
+                                gradient_values_result,
+                                i,
+                                _dispatch.slice_last_dim(gradient_values_result, i)
+                                * _dispatch.slice_last_dim(values_mean, i)[
+                                    sample_indices
+                                ].reshape(shape)
+                                / _dispatch.slice_last_dim(values_result, i)[
+                                    sample_indices
+                                ].reshape(shape),
+                            )
+                        else:
+                            # no need to be torchscript compatible, let's keep it simple
+                            # only numpy raise a warning for division by zero
+                            with np.errstate(divide="ignore", invalid="ignore"):
+                                gradient_values_result[..., i] = (
+                                    values_grad_result[..., i]
+                                    - (
+                                        gradient_values_result[..., i]
+                                        * values_mean[..., i][sample_indices].reshape(
+                                            shape
+                                        )
+                                    )
+                                ) / values_result[..., i][sample_indices].reshape(shape)
+                        gradient_values_result = _dispatch.scatter_last_dim(
+                            gradient_values_result,
+                            i,
+                            _dispatch.nan_to_num(
+                                _dispatch.slice_last_dim(gradient_values_result, i),
+                                nan=0.0,
+                                posinf=0.0,
+                                neginf=0.0,
+                            ),
+                        )
+                        gradient_values_result[..., i] = _dispatch.nan_to_num(
+                            gradient_values_result[..., i],
+                            nan=0.0,
+                            posinf=0.0,
+                            neginf=0.0,
+                        )
+
+        # no check for the len of the gradient sample is needed because there
+        # always will be at least one sample in the gradient
+        result_block.add_gradient(
+            parameter=parameter,
+            gradient=TensorBlock(
+                values=gradient_values_result,
+                samples=gradient.samples,
+                components=gradient.components,
+                properties=result_block.properties,
+            ),
+        )
+
+    return result_block
+
+
+def _reduce_over_properties(
+    tensor: TensorMap, property_names: Union[List[str], str], reduction: str
+) -> TensorMap:
+    """
+    Create a new :py:class:`TensorMap` with the same keys as as the input
+    ``tensor``, and each :py:class:`TensorBlock` is obtained summing the
+    corresponding input :py:class:`TensorBlock` over the ``property_names``
+    indices.
+
+    "sum", "mean", "std" or "var" reductions can be performed.
+
+    :param tensor: input :py:class:`TensorMap`
+    :param property_names: names of properties to reduce over
+    :param reduction: how to reduce, only available values are "mean", "sum",
+    "std" or "var"
+    """
+    if isinstance(property_names, str):
+        property_names_list = [property_names]
+    else:
+        property_names_list = property_names
+
+    for property in property_names_list:
+        if property not in tensor.property_names:
+            raise ValueError(
+                f"one of the requested property name ({property}) is not part of "
+                "this TensorMap"
+            )
+
+    remaining_properties: List[str] = []
+    for p_name in tensor.property_names:
+        if p_name in property_names_list:
+            continue
+        remaining_properties.append(p_name)
+
+    blocks: List[TensorBlock] = []
+    for block in tensor.blocks():
+        blocks.append(
+            _reduce_over_properties_block(
+                block=block,
+                property_names=property_names_list,
+                reduction=reduction,
+                remaining_properties=remaining_properties,
+            )
+        )
+    return TensorMap(tensor.keys, blocks)
+
+
+@torch_jit_script
+def sum_over_properties_block(
+    block: TensorBlock, property_names: Union[List[str], str]
+) -> TensorBlock:
+    """
+    Sum a :py:class:`TensorBlock`, combining the properties according to
+    ``property_names``.
+
+    This function creates a new :py:class:`TensorBlock` in which each property is
+    obtained summing over the ``property_names`` indices, so that the resulting
+    :py:class:`TensorBlock` does not have those indices.
+
+    ``property_names`` indicates over which dimensions in the properties the sum is
+    performed. It accept either a single string or a list of the string with the
+    property names corresponding to the directions along which the sum is performed. A
+    single string is equivalent to a list with a single element: ``property_names =
+    "i"`` is the same as ``property_names = ["i"]``.
+
+    :param block:
+        input :py:class:`TensorBlock`
+    :param property_names:
+        names of properties to sum over
+
+    :returns:
+        a :py:class:`TensorBlock` containing the reduced values and property labels
+
+    >>> from metatensor import Labels, TensorBlock, TensorMap
+    >>> block = TensorBlock(
+    ...     values=np.array(
+    ...         [
+    ...             [1, 3, 7, 10],
+    ...             [2, 5, 8, 11],
+    ...             [4, 6, 9, 12],
+    ...         ]
+    ...     ),
+    ...     samples=Labels(
+    ...         ["system", "atom"],
+    ...         np.array(
+    ...             [
+    ...                 [0, 0],
+    ...                 [0, 1],
+    ...                 [1, 0],
+    ...             ]
+    ...         ),
+    ...     ),
+    ...     components=[],
+    ...     properties=Labels(
+    ...         ["i", "j"],
+    ...         np.array(
+    ...             [
+    ...                 [0, 0],
+    ...                 [0, 1],
+    ...                 [1, 0],
+    ...                 [1, 1],
+    ...             ]
+    ...         ),
+    ...     ),
+    ... )
+    >>> block_sum = sum_over_properties_block(block, property_names="j")
+    >>> print(block_sum.properties)
+    Labels(
+        i
+        0
+        1
+    )
+    >>> print(block_sum.values)
+    [[ 4 17]
+     [ 7 19]
+     [10 21]]
+    """
+
+    return _reduce_over_properties_block(
+        block=block, property_names=property_names, reduction="sum"
+    )
+
+
+@torch_jit_script
+def sum_over_properties(
+    tensor: TensorMap, property_names: Union[List[str], str]
+) -> TensorMap:
+    """
+    Sum a :py:class:`TensorMap`, combining the properties according to
+    ``property_names``.
+
+    This function creates a new :py:class:`TensorMap` with the same keys
+    as as the input ``tensor``. Each :py:class:`TensorBlock` is obtained summing the
+    corresponding input :py:class:`TensorBlock` over the ``property_names``
+    indices, essentially calling :py:func:`sum_over_properties_block` over each
+    block in ``tensor``.
+
+    ``property_names`` indicates over which dimensions in the properties the sum is
+    performed. It accept either a single string or a list of the string with the
+    property names corresponding to the directions along which the sum is
+    performed. A single string is equivalent to a list with a single element:
+    ``property_names = "atom"`` is the same as ``property_names = ["atom"]``.
+
+    :param tensor:
+        input :py:class:`TensorMap`
+    :param property_names:
+        names of properties to sum over
+
+    :returns:
+        a :py:class:`TensorMap` containing the reduced values and property labels
+
+    >>> from metatensor import Labels, TensorBlock, TensorMap
+    >>> block = TensorBlock(
+    ...     values=np.array(
+    ...         [
+    ...             [1, 3, 7, 10],
+    ...             [2, 5, 8, 11],
+    ...             [4, 6, 9, 12],
+    ...         ]
+    ...     ),
+    ...     samples=Labels(
+    ...         ["system", "atom"],
+    ...         np.array(
+    ...             [
+    ...                 [0, 0],
+    ...                 [0, 1],
+    ...                 [1, 0],
+    ...             ]
+    ...         ),
+    ...     ),
+    ...     components=[],
+    ...     properties=Labels(
+    ...         ["i", "j"],
+    ...         np.array(
+    ...             [
+    ...                 [0, 0],
+    ...                 [0, 1],
+    ...                 [1, 0],
+    ...                 [1, 1],
+    ...             ]
+    ...         ),
+    ...     ),
+    ... )
+    >>> keys = Labels(names=["key"], values=np.array([[0]]))
+    >>> tensor = TensorMap(keys, [block])
+    >>> tensor_sum = sum_over_properties(tensor, property_names="j")
+    >>> # only 'i' is left as a property
+    >>> print(tensor_sum.block(0))
+    TensorBlock
+        samples (3): ['system', 'atom']
+        components (): []
+        properties (2): ['i']
+        gradients: None
+    >>> print(tensor_sum.block(0).properties)
+    Labels(
+        i
+        0
+        1
+    )
+    >>> print(tensor_sum.block(0).values)
+    [[ 4 17]
+     [ 7 19]
+     [10 21]]
+    """
+
+    return _reduce_over_properties(
+        tensor=tensor, property_names=property_names, reduction="sum"
+    )
+
+
+@torch_jit_script
+def mean_over_properties_block(
+    block: TensorBlock, property_names: Union[List[str], str]
+) -> TensorBlock:
+    """Averages a :py:class:`TensorBlock`, combining the properties according
+    to ``property_names``.
+
+    See also :py:func:`sum_over_properties_block` and :py:func:`mean_over_properties`
+
+    :param block:
+        input :py:class:`TensorBlock`
+    :param property_names:
+        names of properties to average over
+
+    :returns:
+        a :py:class:`TensorBlock` containing the reduced values and property labels
+    """
+
+    return _reduce_over_properties_block(
+        block=block, property_names=property_names, reduction="mean"
+    )
+
+
+@torch_jit_script
+def mean_over_properties(
+    tensor: TensorMap, property_names: Union[str, List[str]]
+) -> TensorMap:
+    """Compute the mean of a :py:class:`TensorMap`, combining the properties according
+    to ``property_names``.
+
+    This function creates a new :py:class:`TensorMap` with the same keys as
+    the input ``tensor``, and each :py:class:`TensorBlock` is obtained
+    averaging the corresponding input :py:class:`TensorBlock` over the
+    ``property_names`` indices.
+
+    ``property_names`` indicates over which dimensions in the properties the mean is
+    performed. It accept either a single string or a list of the string with the
+    property names corresponding to the directions along which the mean is performed.
+    A single string is equivalent to a list with a single element:
+    ``property_names = "atom"`` is the same as ``property_names = ["atom"]``.
+
+    For a general discussion of reduction operations and a usage example see the
+    doc for :py:func:`sum_over_properties`.
+
+    :param tensor: input :py:class:`TensorMap`
+    :param property_names: names of properties to average over
+    """
+
+    return _reduce_over_properties(
+        tensor=tensor, property_names=property_names, reduction="mean"
+    )
+
+
+@torch_jit_script
+def std_over_properties_block(
+    block: TensorBlock, property_names: Union[List[str], str]
+) -> TensorBlock:
+    """Computes the standard deviation for a :py:class:`TensorBlock`,
+    combining the properties according to ``property_names``.
+
+    See also :py:func:`sum_over_properties_block` and :py:func:`std_over_properties`
+
+    :param block:
+        input :py:class:`TensorBlock`
+    :param property_names:
+        names of properties to compute the standard deviation for
+
+    :returns:
+        a :py:class:`TensorBlock` containing the reduced values and property labels
+    """
+
+    return _reduce_over_properties_block(
+        block=block, property_names=property_names, reduction="std"
+    )
+
+
+@torch_jit_script
+def std_over_properties(
+    tensor: TensorMap, property_names: Union[str, List[str]]
+) -> TensorMap:
+    r"""Compute the standard deviation of a :py:class:`TensorMap`, combining the
+    properties according to ``property_names``.
+
+    This function creates a new :py:class:`TensorMap` with the same keys as
+    as the input ``tensor``, and each :py:class:`TensorBlock` is obtained
+    performing the std deviation of the corresponding input :py:class:`TensorBlock`
+    over the ``property_names`` indices.
+
+    ``property_names`` indicates over which dimensions in the properties the mean is
+    performed. It accept either a single string or a list of the string with the
+    property names corresponding to the directions along which the mean is performed.
+    A single string is equivalent to a list with a single element:
+    ``property_names = "i"`` is the same as ``property_names = ["i"]``.
+
+    For a general discussion of reduction operations and a usage example see the
+    doc for :py:func:`sum_over_properties()`.
+
+    The gradient is implemented as follows:
+
+    .. math::
+
+        \nabla[Std(X)] = 0.5(\nabla[Var(X)])/Std(X)
+        = (E[X \nabla X] - E[X]E[\nabla X])/Std(X)
+
+    :param tensor: input :py:class:`TensorMap`
+    :param property_names: names of properties to perform the standart deviation over
+    """
+
+    return _reduce_over_properties(
+        tensor=tensor, property_names=property_names, reduction="std"
+    )
+
+
+@torch_jit_script
+def var_over_properties_block(
+    block: TensorBlock, property_names: Union[List[str], str]
+) -> TensorBlock:
+    """Computes the variance for a :py:class:`TensorBlock`,
+    combining the properties according to ``property_names``.
+
+    See also :py:func:`sum_over_properties_block` and :py:func:`std_over_properties`
+
+    :param block:
+        input :py:class:`TensorBlock`
+    :param property_names:
+        names of properties to compute the variance for
+
+    :returns:
+        a :py:class:`TensorBlock` containing the reduced values and property labels
+    """
+
+    return _reduce_over_properties_block(
+        block=block, property_names=property_names, reduction="var"
+    )
+
+
+@torch_jit_script
+def var_over_properties(
+    tensor: TensorMap, property_names: Union[str, List[str]]
+) -> TensorMap:
+    r"""Compute the variance of a :py:class:`TensorMap`, combining the
+    properties according to ``property_names``.
+
+    This function creates a new :py:class:`TensorMap` with the same keys as
+    as the input ``tensor``, and each :py:class:`TensorBlock` is obtained
+    performing the variance of the corresponding input :py:class:`TensorBlock`
+    over the ``property_names`` indices.
+
+    ``property_names`` indicates over which dimensions in the properties the mean is
+    performed. It accept either a single string or a list of the string with the
+    property names corresponding to the directions along which the mean is performed.
+    A single string is equivalent to a list with a single element:
+    ``property_names = "i"`` is the same as ``property_names = ["i"]``.
+
+    For a general discussion of reduction operations and a usage example see the
+    doc for :py:func:`sum_over_properties`.
+
+    The gradient is implemented as follow:
+
+    .. math::
+
+        \nabla[Var(X)] = 2(E[X \nabla X] - E[X]E[\nabla X])
+
+    :param tensor: input :py:class:`TensorMap`
+    :param property_names: names of properties to perform the variance over
+    """
+
+    return _reduce_over_properties(
+        tensor=tensor, property_names=property_names, reduction="var"
+    )

--- a/python/metatensor_operations/metatensor/operations/_reduce_over_samples.py
+++ b/python/metatensor_operations/metatensor/operations/_reduce_over_samples.py
@@ -131,11 +131,7 @@ def _reduce_over_samples_block(
         block_values, shape=(new_samples.shape[0],) + other_shape
     )
 
-    _dispatch.index_add(
-        values_sum,
-        block_values,
-        index,
-    )
+    _dispatch.rows_add(values_sum, block_values, index)
 
     # pre-declare variables that we'll need to use outside of the if block below
     values_mean = _dispatch.empty_like(values_sum, [0])
@@ -151,10 +147,8 @@ def _reduce_over_samples_block(
                 block_values, shape=(new_samples.shape[0],) + other_shape
             )
 
-            _dispatch.index_add(
-                values_var,
-                (block_values - values_mean[index]) ** 2,
-                index,
+            _dispatch.rows_add(
+                values_var, (block_values - values_mean[index]) ** 2, index
             )
             values_var = values_var / bincount
 
@@ -223,7 +217,7 @@ def _reduce_over_samples_block(
             gradient_values,
             shape=(new_gradient_samples.shape[0],) + other_shape,
         )
-        _dispatch.index_add(gradient_values_result, gradient_values, index_gradient)
+        _dispatch.rows_add(gradient_values_result, gradient_values, index_gradient)
 
         if reduction == "mean" or reduction == "var" or reduction == "std":
             bincount = _dispatch.bincount(index_gradient)
@@ -242,10 +236,8 @@ def _reduce_over_samples_block(
                     gradient_values,
                     shape=(new_gradient_samples.shape[0],) + other_shape,
                 )
-                _dispatch.index_add(
-                    values_grad_result,
-                    values_times_gradient_values,
-                    index_gradient,
+                _dispatch.rows_add(
+                    values_grad_result, values_times_gradient_values, index_gradient
                 )
 
                 values_grad_result = values_grad_result / bincount

--- a/python/metatensor_operations/tests/_gradcheck.py
+++ b/python/metatensor_operations/tests/_gradcheck.py
@@ -24,7 +24,12 @@ def check_finite_differences(
     other dimensions of the ``array``.
     """
     n_samples = array.shape[0]
-    n_grad_components = array.shape[1:]
+    if len(array.shape) == 2:
+        n_grad_components = array.shape[1:]
+    elif len(array.shape) == 3:
+        n_grad_components = array.shape[1:-1]
+    else:
+        raise NotImplementedError
 
     reference = function(array)
 

--- a/python/metatensor_operations/tests/reduce_mean.py
+++ b/python/metatensor_operations/tests/reduce_mean.py
@@ -105,7 +105,73 @@ def test_mean_samples_block():
         )
 
 
-def test_reduction_block_two_samples():
+def test_mean_properties_block():
+    tensor_se = mts.load(os.path.join(DATA_ROOT, "qm7-spherical-expansion.mts"))
+    tensor_ps = mts.load(os.path.join(DATA_ROOT, "qm7-power-spectrum.mts"))
+    bl1 = tensor_ps[0]
+
+    # check both passing a list and a single string for sample_names
+    reduce_tensor_se = mts.mean_over_properties(tensor_se, property_names="n")
+    reduce_tensor_ps = mts.mean_over_properties(tensor_ps, property_names=["l"])
+
+    assert np.allclose(
+        np.mean(bl1.values[..., ::16], axis=-1),
+        reduce_tensor_ps.block(0).values[..., 0],
+    )
+
+    assert np.allclose(
+        np.mean(bl1.values[..., 1::16], axis=-1),
+        reduce_tensor_ps.block(0).values[..., 1],
+    )
+
+    assert np.allclose(
+        np.mean(bl1.values[..., 5::16], axis=-1),
+        reduce_tensor_ps.block(0).values[..., 5],
+    )
+
+    assert np.allclose(
+        np.mean(bl1.values[..., 8::16], axis=-1),
+        reduce_tensor_ps.block(0).values[..., 8],
+    )
+
+    assert np.allclose(
+        np.mean(bl1.values[..., 9::16], axis=-1),
+        reduce_tensor_ps.block(0).values[..., 9],
+    )
+
+    # Test the gradients
+    gradient = tensor_ps[0].gradient("positions").values
+
+    assert np.allclose(
+        np.mean(gradient[..., ::16], axis=-1),
+        reduce_tensor_ps.block(0).gradient("positions").values[..., 0],
+        rtol=1e-13,
+    )
+    assert np.allclose(
+        np.mean(gradient[..., 2::16], axis=-1),
+        reduce_tensor_ps.block(0).gradient("positions").values[..., 2],
+    )
+
+    assert np.all(
+        np.mean(gradient[..., 3::16], axis=-1)
+        == reduce_tensor_ps.block(0).gradient("positions").values[..., 3]
+    )
+
+    assert np.allclose(
+        np.mean(gradient[..., 15::16], axis=-1),
+        reduce_tensor_ps.block(0).gradient("positions").values[..., 15],
+        rtol=1e-13,
+    )
+
+    for ii, bl2 in enumerate([tensor_se[0], tensor_se[1], tensor_se[2], tensor_se[3]]):
+        assert np.all(
+            np.mean(bl2.values, axis=-1, keepdims=True)[..., 0]
+            == reduce_tensor_se.block(ii).values[..., 0]
+        )
+
+
+def test_reduction_block_multi_samples():
+    """Test mean over samples for multiple dimensions simultaneously"""
     block_1 = TensorBlock(
         values=np.array(
             [
@@ -120,7 +186,7 @@ def test_reduction_block_two_samples():
             ]
         ),
         samples=Labels(
-            ["samples1", "samples2", "samples3"],
+            ["s1", "s2", "s3"],
             np.array(
                 [
                     [0, 0, 0],
@@ -141,9 +207,9 @@ def test_reduction_block_two_samples():
     keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
     X = TensorMap(keys, [block_1])
 
-    reduce_X_12 = mts.mean_over_samples(X, sample_names=["samples3"])
-    reduce_X_23 = mts.mean_over_samples(X, sample_names="samples1")
-    reduce_X_2 = mts.mean_over_samples(X, sample_names=["samples1", "samples3"])
+    reduce_X_12 = mts.mean_over_samples(X, sample_names=["s3"])
+    reduce_X_23 = mts.mean_over_samples(X, sample_names="s1")
+    reduce_X_2 = mts.mean_over_samples(X, sample_names=["s1", "s3"])
 
     assert np.allclose(
         np.mean(X.block(0).values[:3], axis=0),
@@ -185,17 +251,111 @@ def test_reduction_block_two_samples():
     assert reduce_X_2.block(0).properties == X.block(0).properties
 
     samples_12 = Labels(
-        names=["samples1", "samples2"],
+        names=["s1", "s2"],
         values=np.array([[0, 0], [0, 1], [1, 0], [1, 1], [2, 1]]),
     )
     samples_23 = Labels(
-        names=["samples2", "samples3"],
+        names=["s2", "s3"],
         values=np.array([[0, 0], [0, 1], [0, 2], [1, 0], [1, 1]]),
     )
-    samples_2 = Labels(
-        names=["samples2"],
-        values=np.array([[0], [1]]),
-    )
+    samples_2 = Labels(names=["s2"], values=np.array([[0], [1]]))
     assert reduce_X_12.block(0).samples == samples_12
     assert reduce_X_23.block(0).samples == samples_23
     assert reduce_X_2.block(0).samples == samples_2
+
+
+def test_reduction_block_multi_properties():
+    """Test mean over properties for multiple dimensions simultaneously"""
+    block_1 = TensorBlock(
+        values=np.array(
+            [
+                [1, 2, 4],
+                [3, 5, 6],
+                [-1.3, 26.7, 4.54],
+                [3.5, 5.3, 6.87],
+                [6.1, 35.2, 44.5],
+                [7.3, -7.65, 6.45],
+                [11, 276.0, 4.09],
+                [33, 55.5, -5.6],
+            ]
+        ).T,
+        samples=Labels(["s"], np.array([[0], [1], [5]])),
+        components=[],
+        properties=Labels(
+            ["p1", "p2", "p3"],
+            np.array(
+                [
+                    [0, 0, 0],
+                    [0, 0, 1],
+                    [0, 0, 2],
+                    [0, 1, 1],
+                    [0, 1, 0],
+                    [2, 1, 1],
+                    [1, 1, 1],
+                    [1, 0, 0],
+                ],
+            ),
+        ),
+    )
+
+    keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
+    X = TensorMap(keys, [block_1])
+
+    reduce_X_12 = mts.mean_over_properties(X, property_names=["p3"])
+    reduce_X_23 = mts.mean_over_properties(X, property_names="p1")
+    reduce_X_2 = mts.mean_over_properties(X, property_names=["p1", "p3"])
+
+    assert np.allclose(
+        np.mean(X.block(0).values[..., :3], axis=-1),
+        reduce_X_12.block(0).values[..., 0],
+        rtol=1e-13,
+    )
+
+    assert np.all(
+        np.mean(X.block(0).values[..., 3:5], axis=-1)
+        == reduce_X_12.block(0).values[..., 1]
+    )
+    assert np.all(X.block(0).values[..., 5] == reduce_X_12.block(0).values[..., 4])
+    assert np.all(X.block(0).values[..., 6] == reduce_X_12.block(0).values[..., 3])
+    assert np.all(X.block(0).values[..., 7] == reduce_X_12.block(0).values[..., 2])
+
+    assert np.all(
+        np.mean(X.block(0).values[..., [0, 7]], axis=-1)
+        == reduce_X_23.block(0).values[..., 0]
+    )
+    assert np.allclose(
+        np.mean(X.block(0).values[..., [3, 5, 6]], axis=-1),
+        reduce_X_23.block(0).values[..., 4],
+        rtol=1e-13,
+    )
+
+    assert np.all(X.block(0).values[..., 1] == reduce_X_23.block(0).values[..., 1])
+    assert np.all(X.block(0).values[..., 2] == reduce_X_23.block(0).values[..., 2])
+    assert np.all(X.block(0).values[..., 4] == reduce_X_23.block(0).values[..., 3])
+
+    assert np.all(
+        np.mean(X.block(0).values[..., [0, 1, 2, 7]], axis=-1)
+        == reduce_X_2.block(0).values[..., 0]
+    )
+    assert np.all(
+        np.mean(X.block(0).values[..., 3:7], axis=-1)
+        == reduce_X_2.block(0).values[..., 1]
+    )
+
+    # check metadata
+    assert reduce_X_12.block(0).samples == X.block(0).samples
+    assert reduce_X_23.block(0).samples == X.block(0).samples
+    assert reduce_X_2.block(0).samples == X.block(0).samples
+
+    properties_12 = Labels(
+        names=["p1", "p2"],
+        values=np.array([[0, 0], [0, 1], [1, 0], [1, 1], [2, 1]]),
+    )
+    properties_23 = Labels(
+        names=["p2", "p3"],
+        values=np.array([[0, 0], [0, 1], [0, 2], [1, 0], [1, 1]]),
+    )
+    properties_2 = Labels(names=["p2"], values=np.array([[0], [1]]))
+    assert reduce_X_12.block(0).properties == properties_12
+    assert reduce_X_23.block(0).properties == properties_23
+    assert reduce_X_2.block(0).properties == properties_2

--- a/python/metatensor_operations/tests/reduce_mean_block.py
+++ b/python/metatensor_operations/tests/reduce_mean_block.py
@@ -87,7 +87,71 @@ def test_mean_samples_block():
         )
 
 
-def test_reduction_block_two_samples():
+def test_mean_properties_block():
+    tensor_se = mts.load(os.path.join(DATA_ROOT, "qm7-spherical-expansion.mts"))
+    tensor_ps = mts.load(os.path.join(DATA_ROOT, "qm7-power-spectrum.mts"))
+    bl1 = tensor_ps[0]
+
+    reduce_block_ps = mts.mean_over_properties_block(bl1, property_names=["l"])
+
+    assert np.allclose(
+        np.mean(bl1.values[..., ::16], axis=-1), reduce_block_ps.values[..., 0]
+    )
+
+    assert np.allclose(
+        np.mean(bl1.values[..., 1::16], axis=-1),
+        reduce_block_ps.values[..., 1],
+    )
+
+    assert np.allclose(
+        np.mean(bl1.values[..., 5::16], axis=-1),
+        reduce_block_ps.values[..., 5],
+    )
+
+    assert np.allclose(
+        np.mean(bl1.values[..., 8::16], axis=-1),
+        reduce_block_ps.values[..., 8],
+    )
+
+    assert np.allclose(
+        np.mean(bl1.values[..., 9::16], axis=-1),
+        reduce_block_ps.values[..., 9],
+    )
+
+    # Test the gradients
+    gradient = bl1.gradient("positions").values
+
+    assert np.allclose(
+        np.mean(gradient[..., ::16], axis=-1),
+        reduce_block_ps.gradient("positions").values[..., 0],
+        rtol=1e-13,
+    )
+    assert np.allclose(
+        np.mean(gradient[..., 2::16], axis=-1),
+        reduce_block_ps.gradient("positions").values[..., 2],
+    )
+
+    assert np.all(
+        np.mean(gradient[..., 3::16], axis=-1)
+        == reduce_block_ps.gradient("positions").values[..., 3]
+    )
+
+    assert np.allclose(
+        np.mean(gradient[..., 15::16], axis=-1),
+        reduce_block_ps.gradient("positions").values[..., 15],
+        rtol=1e-13,
+    )
+
+    for _, bl2 in enumerate([tensor_se[0], tensor_se[1], tensor_se[2], tensor_se[3]]):
+        reduce_block_se = mts.mean_over_properties_block(bl2, property_names="n")
+        assert np.all(
+            np.mean(bl2.values, axis=-1, keepdims=True)[..., 0]
+            == reduce_block_se.values[..., 0]
+        )
+
+
+def test_reduction_block_multi_samples():
+    """Test mean over samples for multiple dimensions simultaneously"""
     block_1 = TensorBlock(
         values=np.array(
             [
@@ -102,7 +166,7 @@ def test_reduction_block_two_samples():
             ]
         ),
         samples=Labels(
-            ["samples1", "samples2", "samples3"],
+            ["s1", "s2", "s3"],
             np.array(
                 [
                     [0, 0, 0],
@@ -120,11 +184,9 @@ def test_reduction_block_two_samples():
         properties=Labels(["p"], np.array([[0], [1], [5]])),
     )
 
-    reduce_block_12 = mts.mean_over_samples_block(block_1, sample_names=["samples3"])
-    reduce_block_23 = mts.mean_over_samples_block(block_1, sample_names="samples1")
-    reduce_block_2 = mts.mean_over_samples_block(
-        block_1, sample_names=["samples1", "samples3"]
-    )
+    reduce_block_12 = mts.mean_over_samples_block(block_1, sample_names=["s3"])
+    reduce_block_23 = mts.mean_over_samples_block(block_1, sample_names="s1")
+    reduce_block_2 = mts.mean_over_samples_block(block_1, sample_names=["s1", "s3"])
 
     assert np.allclose(
         np.mean(block_1.values[:3], axis=0),
@@ -159,17 +221,110 @@ def test_reduction_block_two_samples():
     assert reduce_block_2.properties == block_1.properties
 
     samples_12 = Labels(
-        names=["samples1", "samples2"],
+        names=["s1", "s2"],
         values=np.array([[0, 0], [0, 1], [1, 0], [1, 1], [2, 1]]),
     )
     samples_23 = Labels(
-        names=["samples2", "samples3"],
+        names=["s2", "s3"],
         values=np.array([[0, 0], [0, 1], [0, 2], [1, 0], [1, 1]]),
     )
     samples_2 = Labels(
-        names=["samples2"],
+        names=["s2"],
         values=np.array([[0], [1]]),
     )
     assert reduce_block_12.samples == samples_12
     assert reduce_block_23.samples == samples_23
     assert reduce_block_2.samples == samples_2
+
+
+def test_reduction_block_multi_properties():
+    """Test mean over properties for multiple dimensions simultaneously"""
+    block_1 = TensorBlock(
+        values=np.array(
+            [
+                [1, 2, 4],
+                [3, 5, 6],
+                [-1.3, 26.7, 4.54],
+                [3.5, 5.3, 6.87],
+                [6.1, 35.2, 44.5],
+                [7.3, -7.65, 6.45],
+                [11, 276.0, 4.09],
+                [33, 55.5, -5.6],
+            ]
+        ).T,
+        samples=Labels(["s"], np.array([[0], [1], [5]])),
+        components=[],
+        properties=Labels(
+            ["p1", "p2", "p3"],
+            np.array(
+                [
+                    [0, 0, 0],
+                    [0, 0, 1],
+                    [0, 0, 2],
+                    [0, 1, 1],
+                    [0, 1, 0],
+                    [2, 1, 1],
+                    [1, 1, 1],
+                    [1, 0, 0],
+                ],
+            ),
+        ),
+    )
+
+    reduce_block_12 = mts.mean_over_properties_block(block_1, property_names=["p3"])
+    reduce_block_23 = mts.mean_over_properties_block(block_1, property_names="p1")
+    reduce_block_2 = mts.mean_over_properties_block(
+        block_1, property_names=["p1", "p3"]
+    )
+
+    assert np.allclose(
+        np.mean(block_1.values[..., :3], axis=-1),
+        reduce_block_12.values[..., 0],
+        rtol=1e-13,
+    )
+
+    assert np.all(
+        np.mean(block_1.values[..., 3:5], axis=-1) == reduce_block_12.values[..., 1]
+    )
+    assert np.all(block_1.values[..., 5] == reduce_block_12.values[..., 4])
+    assert np.all(block_1.values[..., 6] == reduce_block_12.values[..., 3])
+    assert np.all(block_1.values[..., 7] == reduce_block_12.values[..., 2])
+
+    assert np.all(
+        np.mean(block_1.values[..., [0, 7]], axis=-1) == reduce_block_23.values[..., 0]
+    )
+    assert np.allclose(
+        np.mean(block_1.values[..., [3, 5, 6]], axis=-1),
+        reduce_block_23.values[..., 4],
+        rtol=1e-13,
+    )
+
+    assert np.all(block_1.values[..., 1] == reduce_block_23.values[..., 1])
+    assert np.all(block_1.values[..., 2] == reduce_block_23.values[..., 2])
+    assert np.all(block_1.values[..., 4] == reduce_block_23.values[..., 3])
+
+    assert np.all(
+        np.mean(block_1.values[..., [0, 1, 2, 7]], axis=-1)
+        == reduce_block_2.values[..., 0]
+    )
+    assert np.all(
+        np.mean(block_1.values[..., 3:7], axis=-1) == reduce_block_2.values[..., 1]
+    )
+
+    # check metadata
+    assert reduce_block_12.samples == block_1.samples
+    assert reduce_block_23.samples == block_1.samples
+    assert reduce_block_2.samples == block_1.samples
+
+    properties_12 = Labels(
+        names=["p1", "p2"],
+        values=np.array([[0, 0], [0, 1], [1, 0], [1, 1], [2, 1]]),
+    )
+    properties_23 = Labels(
+        names=["p2", "p3"],
+        values=np.array([[0, 0], [0, 1], [0, 2], [1, 0], [1, 1]]),
+    )
+    properties_2 = Labels(names=["p2"], values=np.array([[0], [1]]))
+    assert reduce_block_12.properties == properties_12
+    assert reduce_block_23.properties == properties_23
+    assert reduce_block_2.properties == properties_2

--- a/python/metatensor_operations/tests/reduce_special_cases.py
+++ b/python/metatensor_operations/tests/reduce_special_cases.py
@@ -12,6 +12,9 @@ except ImportError:
 
 import metatensor as mts
 from metatensor import Labels, TensorBlock, TensorMap
+from metatensor.operations import _dispatch
+
+from . import _gradcheck
 
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
@@ -71,6 +74,64 @@ def test_reduction_all_samples():
         )
 
 
+def test_reduction_all_properties():
+    block_1 = TensorBlock(
+        values=np.array(
+            [
+                [1, 2, 4],
+                [3, 5, 6],
+                [-1.3, 26.7, 4.54],
+            ]
+        ),
+        samples=Labels.range("s", 3),
+        components=[],
+        properties=Labels(["p"], np.array([[0], [1], [5]])),
+    )
+    keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
+    X = TensorMap(keys, [block_1])
+
+    sum_X = mts.sum_over_properties(X, property_names=["p"])
+    mean_X = mts.mean_over_properties(X, property_names=["p"])
+    var_X = mts.var_over_properties(X, property_names=["p"])
+    std_X = mts.std_over_properties(X, property_names=["p"])
+
+    assert sum_X[0].properties == Labels.single()
+    assert mts.equal_metadata(sum_X, mean_X)
+    assert mts.equal_metadata(sum_X, std_X)
+    assert mts.equal_metadata(mean_X, var_X)
+
+    assert np.all(sum_X[0].values == np.sum(X[0].values, axis=1, keepdims=True))
+    assert np.all(mean_X[0].values == np.mean(X[0].values, axis=1, keepdims=True))
+    assert np.allclose(std_X[0].values, np.std(X[0].values, axis=1, keepdims=True))
+    assert np.allclose(var_X[0].values, np.var(X[0].values, axis=1, keepdims=True))
+
+    if HAS_TORCH:
+        X = X.to(arrays="torch")
+
+        sum_X = mts.sum_over_properties(X, property_names=["p"])
+        mean_X = mts.mean_over_properties(X, property_names=["p"])
+        var_X = mts.var_over_properties(X, property_names=["p"])
+        std_X = mts.std_over_properties(X, property_names=["p"])
+
+        assert sum_X[0].properties == Labels.single()
+        assert mts.equal_metadata(sum_X, mean_X)
+        assert mts.equal_metadata(sum_X, std_X)
+        assert mts.equal_metadata(mean_X, var_X)
+
+        assert torch.all(
+            sum_X[0].values == torch.sum(X[0].values, axis=1, keepdims=True)
+        )
+        assert torch.all(
+            mean_X[0].values == torch.mean(X[0].values, axis=1, keepdims=True)
+        )
+        assert torch.allclose(
+            std_X[0].values, torch.std(X[0].values, correction=0, axis=1, keepdims=True)
+        )
+        assert torch.allclose(
+            var_X[0].values, torch.var(X[0].values, correction=0, axis=1, keepdims=True)
+        )
+
+
 def test_zeros_sample_block():
     block = TensorBlock(
         values=np.zeros([0, 1]),
@@ -120,6 +181,62 @@ def test_zeros_sample_block():
     tensor_mean = mts.mean_over_samples(tensor, "s_1")
     tensor_std = mts.std_over_samples(tensor, "s_1")
     tensor_var = mts.var_over_samples(tensor, "s_1")
+
+    assert mts.equal(result_tensor, tensor_sum)
+    assert mts.equal(result_tensor, tensor_mean)
+    assert mts.equal(result_tensor, tensor_var)
+    assert mts.equal(result_tensor, tensor_std)
+
+
+def test_zeros_property_block():
+    block = TensorBlock(
+        values=np.zeros([1, 0]),
+        properties=Labels(["p"], np.empty((0, 1))),
+        samples=Labels(["s"], np.zeros([1, 1], dtype=int)),
+        components=[],
+    )
+
+    result_block = TensorBlock(
+        values=np.zeros([1, 0]),
+        properties=Labels([], np.empty((0, 0))),
+        samples=Labels(["s"], np.zeros([1, 1], dtype=int)),
+        components=[],
+    )
+
+    tensor = TensorMap(Labels.single(), [block])
+    result_tensor = TensorMap(Labels.single(), [result_block])
+
+    tensor_sum = mts.sum_over_properties(tensor, "p")
+    tensor_mean = mts.mean_over_properties(tensor, "p")
+    tensor_std = mts.std_over_properties(tensor, "p")
+    tensor_var = mts.var_over_properties(tensor, "p")
+
+    assert mts.equal(result_tensor, tensor_sum)
+    assert mts.equal(result_tensor, tensor_mean)
+    assert mts.equal(result_tensor, tensor_var)
+    assert mts.equal(result_tensor, tensor_std)
+
+    block = TensorBlock(
+        values=np.zeros([1, 0]),
+        properties=Labels(["p_1", "p_2"], np.empty((0, 1))),
+        samples=Labels(["s"], np.zeros([1, 1], dtype=int)),
+        components=[],
+    )
+
+    result_block = TensorBlock(
+        values=np.zeros([1, 0]),
+        properties=Labels(["p_2"], np.empty((0, 1))),
+        samples=Labels(["s"], np.zeros([1, 1], dtype=int)),
+        components=[],
+    )
+
+    tensor = TensorMap(Labels.single(), [block])
+    result_tensor = TensorMap(Labels.single(), [result_block])
+
+    tensor_sum = mts.sum_over_properties(tensor, "p_1")
+    tensor_mean = mts.mean_over_properties(tensor, "p_1")
+    tensor_std = mts.std_over_properties(tensor, "p_1")
+    tensor_var = mts.var_over_properties(tensor, "p_1")
 
     assert mts.equal(result_tensor, tensor_sum)
     assert mts.equal(result_tensor, tensor_mean)
@@ -177,3 +294,120 @@ def test_zeros_sample_block_gradient():
     assert mts.equal_metadata(tensor_sum, tensor_mean)
     assert mts.equal_metadata(tensor_sum, tensor_var)
     assert mts.equal_metadata(tensor_sum, tensor_std)
+
+
+def test_zeros_property_block_gradient():
+    block = TensorBlock(
+        values=np.array([[1, 2, 4], [3, 5, 6], [-1.3, 26.7, 4.54], [3.5, 5.3, 6.87]]).T,
+        samples=Labels(["s"], np.array([[0], [1], [5]])),
+        components=[],
+        properties=Labels(
+            ["p_1", "p_2"],
+            np.array([[0, 0], [0, 1], [1, 0], [1, 1]]),
+        ),
+    )
+
+    block.add_gradient(
+        parameter="g",
+        gradient=TensorBlock(
+            values=np.zeros((0, 4)),
+            samples=Labels(["sample", "g"], np.empty((0, 2))),
+            components=[],
+            properties=block.properties,
+        ),
+    )
+
+    sum_block = TensorBlock(
+        values=np.array([[-0.3, 28.7, 8.54], [6.5, 10.3, 12.87]]).T,
+        samples=Labels(["s"], np.array([[0], [1], [5]])),
+        components=[],
+        properties=Labels.range("p_2", 2),
+    )
+
+    sum_block.add_gradient(
+        parameter="g",
+        gradient=TensorBlock(
+            values=np.zeros((0, 2)),
+            samples=Labels(["sample", "g"], np.empty((0, 2))),
+            components=[],
+            properties=sum_block.properties,
+        ),
+    )
+
+    tensor = TensorMap(Labels.single(), [block])
+    tensor_sum_result = TensorMap(Labels.single(), [sum_block])
+
+    tensor_sum = mts.sum_over_properties(tensor, "p_1")
+    tensor_mean = mts.mean_over_properties(tensor, "p_1")
+    tensor_std = mts.std_over_properties(tensor, "p_1")
+    tensor_var = mts.var_over_properties(tensor, "p_1")
+
+    assert mts.allclose(tensor_sum_result, tensor_sum, atol=1e-14)
+    assert mts.equal_metadata(tensor_sum, tensor_mean)
+    assert mts.equal_metadata(tensor_sum, tensor_var)
+    assert mts.equal_metadata(tensor_sum, tensor_std)
+
+
+def tensor_for_finite_differences(array, parameter) -> TensorMap:
+    """
+    Creates a TensorMap from a set of cartesian vectors according to the function:
+
+    .. math::
+
+        f(x, y, z) = x^3 + y^3 + z^3
+
+        \\nabla f = (3x^2, 3y^2, 3z^2)
+
+    The gradients are stored with the given ``parameter`` name.
+    """
+    n_samples = array.shape[0]
+    n_properties = array.shape[-1]
+    assert array.shape == (n_samples, 3, n_properties)
+
+    values = _dispatch.sum(array**3, axis=1)
+    values_grad = 3 * array**2
+
+    block = mts.TensorBlock(
+        values,
+        Labels.range("s", 10),
+        [],
+        Labels(
+            ["p_1", "p_2"], np.array([[0, 0], [0, 1], [1, 0], [1, 1], [2, 0], [2, 1]])
+        ),
+    )
+    block.add_gradient(
+        parameter=parameter,
+        gradient=TensorBlock(
+            values=values_grad.reshape(n_samples, 3, n_properties),
+            samples=Labels.range("sample", len(values)),
+            components=[Labels.range("xyz", 3)],
+            properties=block.properties,
+        ),
+    )
+
+    return TensorMap(Labels.range("_", 1), [block])
+
+
+def test_finite_difference():
+    def sum(array):
+        tensor = tensor_for_finite_differences(array, parameter="g")
+        return mts.sum_over_properties(tensor, "p_1")
+
+    def mean(array):
+        tensor = tensor_for_finite_differences(array, parameter="g")
+        return mts.mean_over_properties(tensor, "p_1")
+
+    def var(array):
+        tensor = tensor_for_finite_differences(array, parameter="g")
+        return mts.var_over_properties(tensor, "p_1")
+
+    def std(array):
+        tensor = tensor_for_finite_differences(array, parameter="g")
+        return mts.std_over_properties(tensor, "p_1")
+
+    rng = np.random.default_rng(seed=123456)
+    array = rng.random((10, 3, 6))
+    _gradcheck.check_finite_differences(sum, array, parameter="g")
+    _gradcheck.check_finite_differences(mean, array, parameter="g")
+    _gradcheck.check_finite_differences(var, array, parameter="g")
+    _gradcheck.check_finite_differences(std, array, parameter="g")

--- a/python/metatensor_operations/tests/reduce_std.py
+++ b/python/metatensor_operations/tests/reduce_std.py
@@ -134,7 +134,117 @@ def test_std_samples_block():
         )
 
 
-def test_reduction_block_two_samples():
+def test_std_properties_block():
+    tensor_se = mts.load(os.path.join(DATA_ROOT, "qm7-spherical-expansion.mts"))
+    tensor_ps = mts.load(os.path.join(DATA_ROOT, "qm7-power-spectrum.mts"))
+    tensor_se = mts.remove_gradients(tensor_se)
+
+    bl1 = tensor_ps[0]
+
+    # check both passing a list and a single string for property_names
+    reduce_tensor_se = mts.std_over_properties(tensor_se, property_names="n")
+    reduce_tensor_ps = mts.std_over_properties(tensor_ps, property_names=["l"])
+
+    assert np.allclose(
+        np.std(bl1.values[..., ::16], axis=-1),
+        reduce_tensor_ps.block(0).values[..., 0],
+        rtol=1e-13,
+    )
+
+    assert np.allclose(
+        np.std(bl1.values[..., 1::16], axis=-1),
+        reduce_tensor_ps.block(0).values[..., 1],
+        rtol=1e-13,
+    )
+    assert np.allclose(
+        np.std(bl1.values[..., 5::16], axis=-1),
+        reduce_tensor_ps.block(0).values[..., 5],
+        rtol=1e-13,
+    )
+    assert np.allclose(
+        np.std(bl1.values[..., 8::16], axis=-1),
+        reduce_tensor_ps.block(0).values[..., 8],
+        rtol=1e-13,
+    )
+    assert np.allclose(
+        np.std(bl1.values[..., 15::16], axis=-1),
+        reduce_tensor_ps.block(0).values[..., 15],
+        rtol=1e-13,
+    )
+
+    # Test the gradients
+    gr1 = tensor_ps[0].gradient("positions")
+    sample_idx = gr1.samples["sample"]
+    other_dims = len(gr1.values.shape) - 2
+    assert np.allclose(
+        (
+            (
+                gr1.values[..., ::16]
+                * bl1.values[:, ::16][sample_idx].reshape(
+                    (len(sample_idx),) + (1,) * other_dims + (-1,)
+                )
+            ).mean(axis=-1)
+            - gr1.values[..., ::16].mean(axis=-1)
+            * bl1.values[:, ::16].mean(axis=-1)[sample_idx][:, None]
+        )
+        / bl1.values[:, ::16].std(axis=-1)[sample_idx][:, None],
+        reduce_tensor_ps[0].gradient("positions").values[..., 0],
+    )
+
+    assert np.allclose(
+        (
+            (
+                gr1.values[..., 1::16]
+                * bl1.values[:, 1::16][sample_idx].reshape(
+                    (len(sample_idx),) + (1,) * other_dims + (-1,)
+                )
+            ).mean(axis=-1)
+            - gr1.values[..., 1::16].mean(axis=-1)
+            * bl1.values[:, 1::16].mean(axis=-1)[sample_idx][:, None]
+        )
+        / bl1.values[:, 1::16].std(axis=-1)[sample_idx][:, None],
+        reduce_tensor_ps[0].gradient("positions").values[..., 1],
+    )
+    assert np.allclose(
+        (
+            (
+                gr1.values[..., 5::16]
+                * bl1.values[:, 5::16][sample_idx].reshape(
+                    (len(sample_idx),) + (1,) * other_dims + (-1,)
+                )
+            ).mean(axis=-1)
+            - gr1.values[..., 5::16].mean(axis=-1)
+            * bl1.values[:, 5::16].mean(axis=-1)[sample_idx][:, None]
+        )
+        / bl1.values[:, 5::16].std(axis=-1)[sample_idx][:, None],
+        reduce_tensor_ps[0].gradient("positions").values[..., 5],
+    )
+
+    assert np.allclose(
+        (
+            (
+                gr1.values[..., 15::16]
+                * bl1.values[:, 15::16][sample_idx].reshape(
+                    (len(sample_idx),) + (1,) * other_dims + (-1,)
+                )
+            ).mean(axis=-1)
+            - gr1.values[..., 15::16].mean(axis=-1)
+            * bl1.values[:, 15::16].mean(axis=-1)[sample_idx][:, None]
+        )
+        / bl1.values[:, 15::16].std(axis=-1)[sample_idx][:, None],
+        reduce_tensor_ps[0].gradient("positions").values[..., 15],
+    )
+
+    for ii, bl2 in enumerate([tensor_se[0], tensor_se[1], tensor_se[2], tensor_se[3]]):
+        assert np.allclose(
+            np.std(bl2.values, axis=-1, keepdims=True),
+            reduce_tensor_se.block(ii).values,
+            rtol=1e-13,
+        )
+
+
+def test_reduction_block_multi_samples():
+    """Test std over samples for multiple dimensions simultaneously"""
     block_1 = TensorBlock(
         values=np.array(
             [
@@ -149,7 +259,7 @@ def test_reduction_block_two_samples():
             ]
         ),
         samples=Labels(
-            ["s_1", "s_2", "s_3"],
+            ["s1", "s2", "s3"],
             np.array(
                 [
                     [0, 0, 0],
@@ -170,9 +280,9 @@ def test_reduction_block_two_samples():
     keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
     X = TensorMap(keys, [block_1])
 
-    reduce_X_12 = mts.std_over_samples(X, sample_names=["s_3"])
-    reduce_X_23 = mts.std_over_samples(X, sample_names="s_1")
-    reduce_X_2 = mts.std_over_samples(X, sample_names=["s_1", "s_3"])
+    reduce_X_12 = mts.std_over_samples(X, sample_names=["s3"])
+    reduce_X_23 = mts.std_over_samples(X, sample_names="s1")
+    reduce_X_2 = mts.std_over_samples(X, sample_names=["s1", "s3"])
 
     assert np.allclose(
         np.std(X.block(0).values[:3], axis=0),
@@ -215,27 +325,121 @@ def test_reduction_block_two_samples():
     assert reduce_X_23.block(0).properties == X.block(0).properties
     assert reduce_X_2.block(0).properties == X.block(0).properties
 
-    samples_12 = Labels(
-        names=["s_1", "s_2"],
+    samples12 = Labels(
+        names=["s1", "s2"],
         values=np.array([[0, 0], [0, 1], [1, 0], [1, 1], [2, 1]]),
     )
-    samples_23 = Labels(
-        names=["s_2", "s_3"],
+    samples23 = Labels(
+        names=["s2", "s3"],
         values=np.array([[0, 0], [0, 1], [0, 2], [1, 0], [1, 1]]),
     )
-    samples_2 = Labels(
-        names=["s_2"],
-        values=np.array([[0], [1]]),
+    samples2 = Labels(names=["s2"], values=np.array([[0], [1]]))
+    assert reduce_X_12.block(0).samples == samples12
+    assert reduce_X_23.block(0).samples == samples23
+    assert reduce_X_2.block(0).samples == samples2
+
+
+def test_reduction_block_multi_properties():
+    """Test std over properties for multiple dimensions simultaneously"""
+    block_1 = TensorBlock(
+        values=np.array(
+            [
+                [1.0, 3.0, -1.3, 3.5, 6.1, 7.3, 11.0, 33.0],
+                [2.0, 5.0, 26.7, 5.3, 35.2, -7.65, 276.0, 55.5],
+                [4.0, 6.0, 4.54, 6.87, 44.5, 6.45, 4.09, -5.6],
+            ]
+        ),
+        samples=Labels(["s"], np.array([[0], [1], [5]])),
+        components=[],
+        properties=Labels(
+            ["p1", "p2", "p3"],
+            np.array(
+                [
+                    [0, 0, 0],
+                    [0, 0, 1],
+                    [0, 0, 2],
+                    [0, 1, 1],
+                    [0, 1, 0],
+                    [2, 1, 1],
+                    [1, 1, 1],
+                    [1, 0, 0],
+                ],
+            ),
+        ),
     )
-    assert reduce_X_12.block(0).samples == samples_12
-    assert reduce_X_23.block(0).samples == samples_23
-    assert reduce_X_2.block(0).samples == samples_2
+
+    keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
+    X = TensorMap(keys, [block_1])
+
+    reduce_X_12 = mts.std_over_properties(X, property_names=["p3"])
+    reduce_X_23 = mts.std_over_properties(X, property_names="p1")
+    reduce_X_2 = mts.std_over_properties(X, property_names=["p1", "p3"])
+
+    assert np.allclose(
+        np.std(X.block(0).values[..., :3], axis=-1),
+        reduce_X_12.block(0).values[..., 0],
+        rtol=1e-13,
+    )
+    assert np.allclose(
+        np.std(X.block(0).values[..., 3:5], axis=-1),
+        reduce_X_12.block(0).values[..., 1],
+        rtol=1e-13,
+    )
+    assert np.all(np.array([0.0]) == reduce_X_12.block(0).values[..., 4])
+    assert np.all(np.array([0.0]) == reduce_X_12.block(0).values[..., 3])
+    assert np.all(np.array([0.0]) == reduce_X_12.block(0).values[..., 2])
+
+    assert np.all(
+        np.std(X.block(0).values[..., [0, 7]], axis=-1)
+        == reduce_X_23.block(0).values[..., 0]
+    )
+    assert np.allclose(
+        np.std(X.block(0).values[..., [3, 5, 6]], axis=-1),
+        reduce_X_23.block(0).values[..., 4],
+        rtol=1e-13,
+    )
+
+    assert np.all(np.array([0.0]) == reduce_X_23.block(0).values[..., 1])
+    assert np.all(np.array([0.0]) == reduce_X_23.block(0).values[..., 2])
+    assert np.all(np.array([0.0]) == reduce_X_23.block(0).values[..., 3])
+
+    assert np.allclose(
+        np.std(X.block(0).values[..., [0, 1, 2, 7]], axis=-1),
+        reduce_X_2.block(0).values[..., 0],
+        rtol=1e-13,
+    )
+    assert np.all(
+        np.std(X.block(0).values[..., 3:7], axis=-1)
+        == reduce_X_2.block(0).values[..., 1]
+    )
+
+    # check metadata
+    assert reduce_X_12.block(0).samples == X.block(0).samples
+    assert reduce_X_23.block(0).samples == X.block(0).samples
+    assert reduce_X_2.block(0).samples == X.block(0).samples
+
+    properties12 = Labels(
+        names=["p1", "p2"],
+        values=np.array([[0, 0], [0, 1], [1, 0], [1, 1], [2, 1]]),
+    )
+    properties23 = Labels(
+        names=["p2", "p3"],
+        values=np.array([[0, 0], [0, 1], [0, 2], [1, 0], [1, 1]]),
+    )
+    properties2 = Labels(names=["p2"], values=np.array([[0], [1]]))
+    assert reduce_X_12.block(0).properties == properties12
+    assert reduce_X_23.block(0).properties == properties23
+    assert reduce_X_2.block(0).properties == properties2
 
 
-def test_reduction_of_one_element():
+def test_reduction_samples_single():
+    """
+    Test std_over_samples when there is only one element per sample class being
+    reduced (i.e. each sample is treated independently)
+    """
     block_1 = TensorBlock(
         values=np.array([[1, 2, 4], [3, 5, 6], [-1.3, 26.7, 4.54]]),
-        samples=Labels(["s_1", "s_2"], np.array([[0, 0], [1, 1], [2, 2]])),
+        samples=Labels(["s1", "s2"], np.array([[0, 0], [1, 1], [2, 2]])),
         components=[],
         properties=Labels(["p"], np.array([[0], [1], [5]])),
     )
@@ -253,13 +457,11 @@ def test_reduction_of_one_element():
     keys = Labels(names=["key_1"], values=np.array([[0]]))
     X = TensorMap(keys, [block_1])
 
-    add_X = mts.sum_over_samples(X, sample_names=["s_1"])
-    mean_X = mts.mean_over_samples(X, sample_names=["s_1"])
-    var_X = mts.var_over_samples(X, sample_names=["s_1"])
-    std_X = mts.std_over_samples(X, sample_names=["s_1"])
+    add_X = mts.sum_over_samples(X, sample_names=["s1"])
+    mean_X = mts.mean_over_samples(X, sample_names=["s1"])
+    var_X = mts.var_over_samples(X, sample_names=["s1"])
+    std_X = mts.std_over_samples(X, sample_names=["s1"])
 
-    # print(add_X[0])
-    # print(X[0].values, add_X[0].values)
     assert np.all(X[0].values == add_X[0].values)
     assert np.all(X[0].values == mean_X[0].values)
     assert mts.equal(add_X, mean_X)
@@ -276,6 +478,55 @@ def test_reduction_of_one_element():
     )
 
     assert std_X[0].gradient("g").samples == grad_sample_label
+    assert np.all(X[0].gradient("g").values == add_X[0].gradient("g").values)
+    assert np.all(X[0].gradient("g").values == mean_X[0].gradient("g").values)
+    assert np.all(np.zeros((3, 3)) == std_X[0].gradient("g").values)
+    assert np.all(np.zeros((3, 3)) == var_X[0].gradient("g").values)
+
+
+def test_reduction_properties_single():
+    """
+    Test std_over_properties when there is only one element per property class being
+    reduced (i.e. each property is treated independently)
+    """
+    block_1 = TensorBlock(
+        values=np.array([[1, 2, 4], [3, 5, 6], [-1.3, 26.7, 4.54]]).T,
+        samples=Labels(["p"], np.array([[0], [1], [5]])),
+        components=[],
+        properties=Labels(["s1", "s2"], np.array([[0, 0], [1, 1], [2, 2]])),
+    )
+
+    block_1.add_gradient(
+        parameter="g",
+        gradient=TensorBlock(
+            values=np.array([[1, 2, 3], [3, 4, 5], [5, 6, 7.8]]).T,
+            samples=Labels(["sample"], np.array([[0], [1], [2]])),
+            components=[],
+            properties=block_1.properties,
+        ),
+    )
+
+    keys = Labels(names=["key_1"], values=np.array([[0]]))
+    X = TensorMap(keys, [block_1])
+
+    add_X = mts.sum_over_properties(X, property_names=["s1"])
+    mean_X = mts.mean_over_properties(X, property_names=["s1"])
+    var_X = mts.var_over_properties(X, property_names=["s1"])
+    std_X = mts.std_over_properties(X, property_names=["s1"])
+
+    assert np.all(X[0].values == add_X[0].values)
+    assert np.all(X[0].values == mean_X[0].values)
+    assert mts.equal(add_X, mean_X)
+    assert mts.equal_metadata(add_X, var_X)
+    assert mts.equal_metadata(mean_X, std_X)
+
+    assert np.all(np.zeros((3, 3)) == std_X[0].values)
+    assert mts.equal(var_X, std_X)
+
+    # Gradients
+    grad_properties_label = Labels(["s2"], np.array([[0], [1], [2]]))
+
+    assert std_X[0].gradient("g").properties == grad_properties_label
     assert np.all(X[0].gradient("g").values == add_X[0].gradient("g").values)
     assert np.all(X[0].gradient("g").values == mean_X[0].gradient("g").values)
     assert np.all(np.zeros((3, 3)) == std_X[0].gradient("g").values)

--- a/python/metatensor_operations/tests/reduce_sum_block.py
+++ b/python/metatensor_operations/tests/reduce_sum_block.py
@@ -86,7 +86,52 @@ def test_sum_samples_block():
         )
 
 
-def test_reduction_block_two_samples():
+def test_sum_properties_block():
+    tensor_se = mts.load(os.path.join(DATA_ROOT, "qm7-spherical-expansion.mts"))
+    tensor_ps = mts.load(os.path.join(DATA_ROOT, "qm7-power-spectrum.mts"))
+    bl1 = tensor_ps[0]
+
+    # check both passing a list and a single string for property names
+    reduce_block_ps = mts.sum_over_properties_block(bl1, property_names="l")
+
+    assert np.all(np.sum(bl1.values[:, ::16], axis=-1) == reduce_block_ps.values[:, 0])
+    assert np.all(np.sum(bl1.values[:, 2::16], axis=-1) == reduce_block_ps.values[:, 2])
+    assert np.all(np.sum(bl1.values[:, 5::16], axis=-1) == reduce_block_ps.values[:, 5])
+    assert np.all(np.sum(bl1.values[:, 8::16], axis=-1) == reduce_block_ps.values[:, 8])
+    assert np.all(np.sum(bl1.values[:, 9::16], axis=-1) == reduce_block_ps.values[:, 9])
+
+    # Test the gradients
+    gr1 = tensor_ps[0].gradient("positions").values
+
+    assert np.all(
+        np.sum(gr1[..., ::16], axis=-1)
+        == reduce_block_ps.gradient("positions").values[..., 0]
+    )
+    assert np.all(
+        np.sum(gr1[..., 2::16], axis=-1)
+        == reduce_block_ps.gradient("positions").values[..., 2]
+    )
+
+    assert np.all(
+        np.sum(gr1[..., 3::16], axis=-1)
+        == reduce_block_ps.gradient("positions").values[..., 3]
+    )
+
+    assert np.all(
+        np.sum(gr1[..., 14::16], axis=-1)
+        == reduce_block_ps.gradient("positions").values[..., 14]
+    )
+
+    for _, bl2 in enumerate([tensor_se[0], tensor_se[1], tensor_se[2], tensor_se[3]]):
+        reduce_block_se = mts.sum_over_properties_block(bl2, property_names=["n"])
+        assert np.all(
+            np.sum(bl2.values, axis=-1, keepdims=True)[..., 0]
+            == reduce_block_se.values[..., 0]
+        )
+
+
+def test_reduction_block_multi_samples():
+    """Test sum over samples for multiple dimensions simultaneously"""
     block_1 = TensorBlock(
         values=np.array(
             [
@@ -101,7 +146,7 @@ def test_reduction_block_two_samples():
             ]
         ),
         samples=Labels(
-            ["samples1", "samples2", "samples3"],
+            ["s1", "s2", "s3"],
             np.array(
                 [
                     [0, 0, 0],
@@ -119,11 +164,9 @@ def test_reduction_block_two_samples():
         properties=Labels(["p"], np.array([[0], [1], [5]])),
     )
 
-    reduce_block_12 = mts.sum_over_samples_block(block_1, sample_names=["samples3"])
-    reduce_block_23 = mts.sum_over_samples_block(block_1, sample_names="samples1")
-    reduce_block_2 = mts.sum_over_samples_block(
-        block_1, sample_names=["samples1", "samples3"]
-    )
+    reduce_block_12 = mts.sum_over_samples_block(block_1, sample_names=["s3"])
+    reduce_block_23 = mts.sum_over_samples_block(block_1, sample_names="s1")
+    reduce_block_2 = mts.sum_over_samples_block(block_1, sample_names=["s1", "s3"])
 
     assert np.allclose(
         np.sum(block_1.values[:3], axis=0),
@@ -158,17 +201,106 @@ def test_reduction_block_two_samples():
     assert reduce_block_2.properties == block_1.properties
 
     samples_12 = Labels(
-        names=["samples1", "samples2"],
+        names=["s1", "s2"],
         values=np.array([[0, 0], [0, 1], [1, 0], [1, 1], [2, 1]]),
     )
     samples_23 = Labels(
-        names=["samples2", "samples3"],
+        names=["s2", "s3"],
         values=np.array([[0, 0], [0, 1], [0, 2], [1, 0], [1, 1]]),
     )
     samples_2 = Labels(
-        names=["samples2"],
+        names=["s2"],
         values=np.array([[0], [1]]),
     )
     assert reduce_block_12.samples == samples_12
     assert reduce_block_23.samples == samples_23
     assert reduce_block_2.samples == samples_2
+
+
+def test_reduction_block_multi_properties():
+    """Test sum over properties for multiple dimensions simultaneously"""
+    block_1 = TensorBlock(
+        values=np.array(
+            [
+                [1, 2, 4],
+                [3, 5, 6],
+                [-1.3, 26.7, 4.54],
+                [3.5, 5.3, 6.87],
+                [6.1, 35.2, 44.5],
+                [7.3, -7.65, 6.45],
+                [11, 276.0, 4.09],
+                [33, 55.5, -5.6],
+            ]
+        ).T,
+        samples=Labels(["s"], np.array([[0], [1], [5]])),
+        components=[],
+        properties=Labels(
+            ["p1", "p2", "p3"],
+            np.array(
+                [
+                    [0, 0, 0],
+                    [0, 0, 1],
+                    [0, 0, 2],
+                    [0, 1, 1],
+                    [0, 1, 0],
+                    [2, 1, 1],
+                    [1, 1, 1],
+                    [1, 0, 0],
+                ],
+            ),
+        ),
+    )
+
+    reduce_block_12 = mts.sum_over_properties_block(block_1, property_names="p3")
+    reduce_block_23 = mts.sum_over_properties_block(block_1, property_names=["p1"])
+    reduce_block_2 = mts.sum_over_properties_block(block_1, property_names=["p1", "p3"])
+
+    assert np.all(
+        np.sum(block_1.values[..., :3], axis=-1) == reduce_block_12.values[..., 0]
+    )
+    assert np.all(
+        np.sum(block_1.values[..., 3:5], axis=-1) == reduce_block_12.values[..., 1]
+    )
+    assert np.all(block_1.values[..., 5] == reduce_block_12.values[..., 4])
+    assert np.all(block_1.values[..., 6] == reduce_block_12.values[..., 3])
+    assert np.all(block_1.values[..., 7] == reduce_block_12.values[..., 2])
+
+    assert np.all(
+        np.sum(block_1.values[..., [0, 7]], axis=-1) == reduce_block_23.values[..., 0]
+    )
+    assert np.all(
+        np.sum(block_1.values[..., [3, 5, 6]], axis=-1)
+        == reduce_block_23.values[..., 4]
+    )
+
+    assert np.all(block_1.values[..., 1] == reduce_block_23.values[..., 1])
+    assert np.all(block_1.values[..., 2] == reduce_block_23.values[..., 2])
+    assert np.all(block_1.values[..., 4] == reduce_block_23.values[..., 3])
+
+    assert np.all(
+        np.sum(block_1.values[..., [0, 1, 2, 7]], axis=-1)
+        == reduce_block_2.values[..., 0]
+    )
+    assert np.all(
+        np.sum(block_1.values[..., 3:7], axis=-1) == reduce_block_2.values[..., 1]
+    )
+    # check metadata
+    assert reduce_block_12.samples == block_1.samples
+    assert reduce_block_23.samples == block_1.samples
+    assert reduce_block_2.samples == block_1.samples
+
+    properties_12 = Labels(
+        names=["p1", "p2"],
+        values=np.array([[0, 0], [0, 1], [1, 0], [1, 1], [2, 1]]),
+    )
+    properties_23 = Labels(
+        names=["p2", "p3"],
+        values=np.array([[0, 0], [0, 1], [0, 2], [1, 0], [1, 1]]),
+    )
+    properties_2 = Labels(
+        names=["p2"],
+        values=np.array([[0], [1]]),
+    )
+    assert reduce_block_12.properties == properties_12
+    assert reduce_block_23.properties == properties_23
+    assert reduce_block_2.properties == properties_2


### PR DESCRIPTION
Closes #992. This PR aims at implementing the current `xxx_over_samples` functions for the property axis. Currently the scope is the same as the `samples` functions, supporting `sum`, `mean`, `var`, and `std`. The tests are crafted by reusing/adapting the current tests of `xxx_over_samples` in the context of `properties`.



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
