### PR TITLE
Allow type hints of `torch` functions and classes to be read

### DIFF
--- a/python/metatensor_torch/metatensor/torch/__init__.py
+++ b/python/metatensor_torch/metatensor/torch/__init__.py
@@ -1,4 +1,5 @@
 import os
+from typing import TYPE_CHECKING
 
 import torch
 
@@ -7,7 +8,7 @@ from ._c_lib import _load_library
 from .version import __version__  # noqa: F401
 
 
-if os.environ.get("METATENSOR_IMPORT_FOR_SPHINX", "0") != "0":
+if os.environ.get("METATENSOR_IMPORT_FOR_SPHINX", "0") != "0" or TYPE_CHECKING:
     from .documentation import (
         Labels,
         LabelsEntry,


### PR DESCRIPTION
A small change but makes it possible to show type hints in editors like vscode. The same thing can also be done for `metatomic.torch`

Effect:
<img width="729" height="405" alt="image" src="https://github.com/user-attachments/assets/fd72321a-e66a-416d-8e02-b0d4a57c4e3f" />



# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
