### PR TITLE
Switch to Arc<RwLock<ArrayD>> as the main array type in metatensor Rust

### DIFF
--- a/metatensor-core/Cargo.toml
+++ b/metatensor-core/Cargo.toml
@@ -31,7 +31,7 @@ byteorder = {version = "1"}
 num-traits = {version = "0.2", default-features = false}
 zip = {version = "0.6", default-features = false, features = ["deflate"]}
 jzon = "0.12"
-dlpk = {version = "=0.1.4", features = ["ndarray", "half"]}
+dlpk = { version = "0.1.5", features = ["ndarray", "half"]}
 ndarray = {version = "0.17"}
 half = { version = "<2.5"}
 

--- a/python/metatensor_core/metatensor/_c_lib.py
+++ b/python/metatensor_core/metatensor/_c_lib.py
@@ -60,7 +60,7 @@ class LibraryFinder(object):
                 )
 
             # Register the origin used by the Rust API as an external CPU array
-            register_external_data_wrapper("rust.Box<dyn Array>", ExternalCpuArray)
+            register_external_data_wrapper("RustArray", ExternalCpuArray)
 
         return self._cached_dll
 

--- a/rust/metatensor-sys/Cargo.toml
+++ b/rust/metatensor-sys/Cargo.toml
@@ -26,7 +26,7 @@ default = []
 static = []
 
 [dependencies]
-dlpk = "=0.1.4"
+dlpk = "0.1.5"
 
 [build-dependencies]
 cmake = "0.1"

--- a/rust/metatensor/Cargo.toml
+++ b/rust/metatensor/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 
 [dependencies]
 metatensor-sys = {version = "0.1.18", path="../metatensor-sys"}
-dlpk = {version = "=0.1.4", features = ["ndarray", "half"]}
+dlpk = { version = "0.1.5", features = ["ndarray", "half", "sync"]}
 half = "<2.5"
 
 once_cell = "1"
@@ -39,7 +39,7 @@ bench = ["dep:criterion"]
 # pin for compatibility with rustc 1.74
 tempfile = "=3.24.0"
 half = "<2.5"
-dlpk = {version = "=0.1.4", features = ["ndarray", "half"]}
+dlpk = { version = "0.1.5", features = ["ndarray", "half", "sync"]}
 
 
 [[bench]]

--- a/rust/metatensor/benches/tensor_map.rs
+++ b/rust/metatensor/benches/tensor_map.rs
@@ -5,9 +5,7 @@ compile_error!("the bench feature is required for bencharks, use `cargo bench --
 mod benchmarks {
     use criterion::{BatchSize, BenchmarkId, Criterion};
     pub use criterion::{criterion_group, criterion_main};
-    use metatensor::{Array, Labels, LabelsBuilder, TensorBlock, TensorMap};
-    use metatensor::c_api::mts_array_t;
-    use ndarray::ArcArray;
+    use metatensor::{Labels, LabelsBuilder, MtsArray, TensorBlock, TensorMap};
 
     fn tensor_map(n_blocks: usize, n_samples: usize, n_properties: usize) -> TensorMap {
         let mut keys = LabelsBuilder::new(vec!["key_1", "key_2"]);
@@ -35,7 +33,7 @@ mod benchmarks {
             let properties = properties.finish();
 
             let shape = vec![samples.count(), components[0].count(), properties.count()];
-            let data = ArcArray::from_elem(shape, 1.0);
+            let data = ndarray::Array::from_elem(shape, 1.0);
 
             blocks.push(TensorBlock::new(data, &samples, &components, &properties).unwrap());
         }
@@ -43,9 +41,8 @@ mod benchmarks {
         TensorMap::new(keys, blocks).unwrap()
     }
 
-    fn make_fill_value(scalar: f64) -> mts_array_t {
-        let data: Box<dyn Array> = Box::new(ArcArray::from_elem(vec![], scalar));
-        mts_array_t::from(data)
+    fn make_fill_value(scalar: f64) -> MtsArray {
+        MtsArray::from(ndarray::Array::from_elem(vec![], scalar))
     }
 
     pub fn keys_to_samples(c: &mut Criterion) {

--- a/rust/metatensor/src/block/block_mut.rs
+++ b/rust/metatensor/src/block/block_mut.rs
@@ -238,27 +238,33 @@ mod tests {
     fn gradients() {
         let properties = Labels::new(["p"], &[[-2], [0], [1]]);
         let mut block = TensorBlock::new(
-            ndarray::ArcArray::from_elem(vec![2, 3], 1.0),
+            ndarray::Array::from_elem(vec![2, 3], 1.0),
             &Labels::new(["s"], &[[0], [1]]), &[], &properties,
         ).unwrap();
 
         block.add_gradient("g", TensorBlock::new(
-            ndarray::ArcArray::from_elem(vec![2, 3], -1.0),
+            ndarray::Array::from_elem(vec![2, 3], -1.0),
             &Labels::new(["sample"], &[[0], [1]]), &[], &properties,
         ).unwrap()).unwrap();
 
         block.add_gradient("f", TensorBlock::new(
-            ndarray::ArcArray::from_elem(vec![2, 3], -2.0),
+            ndarray::Array::from_elem(vec![2, 3], -2.0),
             &Labels::new(["sample"], &[[0], [1]]), &[], &properties,
         ).unwrap()).unwrap();
 
 
         let mut block = block.as_ref_mut();
-        let gradient = block.gradient_mut("g").unwrap();
-        assert_eq!(gradient.values().as_ndarray()[[0, 0]], -1.0);
+        {
+            let gradient = block.gradient_mut("g").unwrap();
+            let values = gradient.values().to_ndarray_lock::<f64>().read().unwrap();
+            assert_eq!(values[[0, 0]], -1.0);
+        }
 
-        let gradient = block.gradient_mut("f").unwrap();
-        assert_eq!(gradient.values().as_ndarray()[[0, 0]], -2.0);
+        {
+            let gradient = block.gradient_mut("f").unwrap();
+            let values = gradient.values().to_ndarray_lock::<f64>().read().unwrap();
+            assert_eq!(values[[0, 0]], -2.0);
+        }
 
         assert!(block.gradient_mut("h").is_none());
 
@@ -273,20 +279,24 @@ mod tests {
     #[test]
     fn block_data() {
         let mut block = TensorBlock::new(
-            ndarray::ArcArray::from_elem(vec![2, 1, 3], 1.0),
+            ndarray::Array::from_elem(vec![2, 1, 3], 1.0),
             &Labels::new(["samples"], &[[0], [1]]),
             &[Labels::new(["component"], &[[0]])],
             &Labels::new(["properties"], &[[-2], [0], [1]]),
         ).unwrap();
         let mut block = block.as_ref_mut();
 
-        assert_eq!(block.values().as_ndarray(), ndarray::ArcArray::from_elem(vec![2, 1, 3], 1.0));
-        assert_eq!(block.samples(), Labels::new(["samples"], &[[0], [1]]));
-        assert_eq!(block.components(), [Labels::new(["component"], &[[0]])]);
-        assert_eq!(block.properties(), Labels::new(["properties"], &[[-2], [0], [1]]));
+        {
+            let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
+            assert_eq!(*values, ndarray::Array::from_elem(vec![2, 1, 3], 1.0));
+            assert_eq!(block.samples(), Labels::new(["samples"], &[[0], [1]]));
+            assert_eq!(block.components(), [Labels::new(["component"], &[[0]])]);
+            assert_eq!(block.properties(), Labels::new(["properties"], &[[-2], [0], [1]]));
+        }
 
         let block = block.data_mut();
-        assert_eq!(block.values.as_ndarray(), ndarray::ArcArray::from_elem(vec![2, 1, 3], 1.0));
+        let values = block.values.to_ndarray_lock::<f64>().read().unwrap();
+        assert_eq!(*values, ndarray::Array::from_elem(vec![2, 1, 3], 1.0));
         assert_eq!(*block.samples, Labels::new(["samples"], &[[0], [1]]));
         assert_eq!(*block.components, [Labels::new(["component"], &[[0]])]);
         assert_eq!(*block.properties, Labels::new(["properties"], &[[-2], [0], [1]]));

--- a/rust/metatensor/src/block/block_ref.rs
+++ b/rust/metatensor/src/block/block_ref.rs
@@ -307,27 +307,29 @@ mod tests {
     fn gradients() {
         let properties = Labels::new(["p"], &[[-2], [0], [1]]);
         let mut block = TensorBlock::new(
-            ndarray::ArcArray::from_elem(vec![2, 3], 1.0),
+            ndarray::Array::from_elem(vec![2, 3], 1.0),
             &Labels::new(["s"], &[[0], [1]]), &[], &properties,
         ).unwrap();
 
         block.add_gradient("g", TensorBlock::new(
-            ndarray::ArcArray::from_elem(vec![2, 3], -1.0),
+            ndarray::Array::from_elem(vec![2, 3], -1.0),
             &Labels::new(["sample"], &[[0], [1]]), &[], &properties,
         ).unwrap()).unwrap();
 
         block.add_gradient("f", TensorBlock::new(
-            ndarray::ArcArray::from_elem(vec![2, 3], -2.0),
+            ndarray::Array::from_elem(vec![2, 3], -2.0),
             &Labels::new(["sample"], &[[0], [1]]), &[], &properties,
         ).unwrap()).unwrap();
 
 
         let block = block.as_ref();
         let gradient = block.gradient("g").unwrap();
-        assert_eq!(gradient.values().as_ndarray()[[0, 0]], -1.0);
+        let values = gradient.values().to_ndarray_lock::<f64>().read().unwrap();
+        assert_eq!(values[[0, 0]], -1.0);
 
         let gradient = block.gradient("f").unwrap();
-        assert_eq!(gradient.values().as_ndarray()[[0, 0]], -2.0);
+        let values = gradient.values().to_ndarray_lock::<f64>().read().unwrap();
+        assert_eq!(values[[0, 0]], -2.0);
 
         assert!(block.gradient("h").is_none());
 
@@ -342,20 +344,22 @@ mod tests {
     #[test]
     fn block_data() {
         let block = TensorBlock::new(
-            ndarray::ArcArray::from_elem(vec![2, 1, 3], 1.0),
+            ndarray::Array::from_elem(vec![2, 1, 3], 1.0),
             &Labels::new(["samples"], &[[0], [1]]),
             &[Labels::new(["component"], &[[0]])],
             &Labels::new(["properties"], &[[-2], [0], [1]]),
         ).unwrap();
         let block = block.as_ref();
 
-        assert_eq!(block.values().as_ndarray(), ndarray::ArcArray::from_elem(vec![2, 1, 3], 1.0));
+        let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
+        assert_eq!(*values, ndarray::Array::from_elem(vec![2, 1, 3], 1.0));
         assert_eq!(block.samples(), Labels::new(["samples"], &[[0], [1]]));
         assert_eq!(block.components(), [Labels::new(["component"], &[[0]])]);
         assert_eq!(block.properties(), Labels::new(["properties"], &[[-2], [0], [1]]));
 
         let block = block.data();
-        assert_eq!(block.values.as_ndarray(), ndarray::ArcArray::from_elem(vec![2, 1, 3], 1.0));
+        let values = block.values.to_ndarray_lock::<f64>().read().unwrap();
+        assert_eq!(*values, ndarray::Array::from_elem(vec![2, 1, 3], 1.0));
         assert_eq!(*block.samples, Labels::new(["samples"], &[[0], [1]]));
         assert_eq!(*block.components, [Labels::new(["component"], &[[0]])]);
         assert_eq!(*block.properties, Labels::new(["properties"], &[[-2], [0], [1]]));

--- a/rust/metatensor/src/block/owned.rs
+++ b/rust/metatensor/src/block/owned.rs
@@ -1,6 +1,6 @@
 use crate::c_api::mts_block_t;
 use crate::errors::check_status;
-use crate::{Array, ArrayRef, Labels, Error};
+use crate::{ArrayRef, Error, Labels, MtsArray};
 
 use super::{TensorBlockRef, TensorBlockRefMut};
 
@@ -99,7 +99,7 @@ impl TensorBlock {
     /// initialized without any gradients.
     #[inline]
     pub fn new(
-        data: impl Array,
+        values: impl Into<MtsArray>,
         samples: &Labels,
         components: &[Labels],
         properties: &Labels
@@ -111,7 +111,7 @@ impl TensorBlock {
 
         let ptr = unsafe {
             crate::c_api::mts_block(
-                (Box::new(data) as Box<dyn Array>).into(),
+                values.into().into_raw(),
                 samples.as_mts_labels_t(),
                 c_components.as_ptr(),
                 c_components.len(),
@@ -194,13 +194,14 @@ mod tests {
     #[test]
     fn block() {
         let block = TensorBlock::new(
-            ndarray::ArcArray::from_elem(vec![2, 1, 3], 1.0),
+            ndarray::Array::from_elem(vec![2, 1, 3], 1.0),
             &Labels::new(["samples"], &[[0], [1]]),
             &[Labels::new(["component"], &[[0]])],
             &Labels::new(["properties"], &[[-2], [0], [1]]),
         ).unwrap();
 
-        assert_eq!(block.values().as_ndarray(), ndarray::ArcArray::from_elem(vec![2, 1, 3], 1.0));
+        let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
+        assert_eq!(*values, ndarray::Array::from_elem(vec![2, 1, 3], 1.0));
         assert_eq!(block.samples(), Labels::new(["samples"], &[[0], [1]]));
         assert_eq!(block.components(), [Labels::new(["component"], &[[0]])]);
         assert_eq!(block.properties(), Labels::new(["properties"], &[[-2], [0], [1]]));

--- a/rust/metatensor/src/data/array.rs
+++ b/rust/metatensor/src/data/array.rs
@@ -38,7 +38,7 @@ pub trait Array: std::any::Any + Send + Sync {
 
     /// Get the shape of the array. This can be empty if the array has no shape
     /// (e.g. a scalar).
-    fn shape(&self) -> &[usize];
+    fn shape(&self) -> Vec<usize>;
 
     /// Change the shape of the array to the given `shape`
     fn reshape(&mut self, shape: &[usize]);
@@ -88,15 +88,35 @@ pub trait Array: std::any::Any + Send + Sync {
     ) -> Result<DLPackTensor, Error>;
 }
 
-impl From<Box<dyn Array>> for mts_array_t {
-    fn from(array: Box<dyn Array>) -> Self {
-        // We need to box the box to make sure the pointer is a normal 1-word
-        // pointer (`Box<dyn Trait>` contains a 2-words, *fat* pointer which can
-        // not be casted to `*mut c_void`)
-        let array = Box::new(array);
+pub (super) struct RustArray {
+    impl_: Box<dyn Array>,
+    shape: Vec<usize>,
+}
 
-        return mts_array_t {
-            ptr: Box::into_raw(array).cast(),
+impl std::ops::Deref for RustArray {
+    type Target = dyn Array;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.impl_
+    }
+}
+
+impl std::ops::DerefMut for RustArray {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.impl_
+    }
+}
+
+impl From<Box<dyn Array>> for MtsArray {
+    fn from(value: Box<dyn Array>) -> Self {
+        let shape = value.shape();
+        let array = RustArray {
+            impl_: value,
+            shape,
+        };
+
+        let raw = mts_array_t {
+            ptr: Box::into_raw(Box::new(array)).cast(),
             origin: Some(rust_array_origin),
             device: Some(rust_array_device),
             dtype: Some(rust_array_dtype),
@@ -108,7 +128,16 @@ impl From<Box<dyn Array>> for mts_array_t {
             copy: Some(rust_array_copy),
             destroy: Some(rust_array_destroy),
             move_data: Some(rust_array_move_data),
-        }
+        };
+
+        return MtsArray::from_raw(raw);
+    }
+}
+
+impl<T> From<T> for MtsArray where T: Array + 'static {
+    fn from(value: T) -> Self {
+        let boxed = Box::new(value) as Box<dyn Array>;
+        return MtsArray::from(boxed);
     }
 }
 
@@ -127,11 +156,11 @@ macro_rules! check_pointers {
 }
 
 pub(super) static RUST_DATA_ORIGIN: Lazy<mts_data_origin_t> = Lazy::new(|| {
-    super::origin::register_data_origin("rust.Box<dyn Array>".into()).expect("failed to register a new origin")
+    super::origin::register_data_origin("RustArray".into()).expect("failed to register a new origin")
 });
 
 /******************************************************************************/
-/// Implementation of `mts_array_t.origin` using `Box<dyn Array>`
+/// Implementation of `mts_array_t.origin` using `RustArray`
 unsafe extern "C" fn rust_array_origin(
     array: *const c_void,
     origin: *mut mts_data_origin_t
@@ -144,35 +173,35 @@ unsafe extern "C" fn rust_array_origin(
     })
 }
 
-/// Implementation of `mts_array_t.device` using `Box<dyn Array>`
+/// Implementation of `mts_array_t.device` using `RustArray`
 unsafe extern "C" fn rust_array_device(
     array: *const c_void,
     device: *mut DLDevice,
 ) -> mts_status_t {
     crate::errors::catch_unwind(|| {
         check_pointers!(array, device);
-        let array = array.cast::<Box<dyn Array>>();
-        *device = (*array).device();
+        let array = array.cast::<RustArray>();
+        *device = (*array).impl_.device();
 
         Ok(())
     })
 }
 
-/// Implementation of `mts_array_t.dtype` using `Box<dyn Array>`
+/// Implementation of `mts_array_t.dtype` using `RustArray`
 unsafe extern "C" fn rust_array_dtype(
     array: *const c_void,
     dtype: *mut DLDataType,
 ) -> mts_status_t {
     crate::errors::catch_unwind(|| {
         check_pointers!(array, dtype);
-        let array = array.cast::<Box<dyn Array>>();
-        *dtype = (*array).dtype();
+        let array = array.cast::<RustArray>();
+        *dtype = (*array).impl_.dtype();
 
         Ok(())
     })
 }
 
-/// Implementation of `mts_array_t.shape` using `Box<dyn Array>`
+/// Implementation of `mts_array_t.shape` using `RustArray`
 unsafe extern "C" fn rust_array_shape(
     array: *const c_void,
     shape: *mut *const usize,
@@ -180,8 +209,8 @@ unsafe extern "C" fn rust_array_shape(
 ) -> mts_status_t {
     crate::errors::catch_unwind(|| {
         check_pointers!(array, shape, shape_count);
-        let array = array.cast::<Box<dyn Array>>();
-        let rust_shape = (*array).shape();
+        let array = array.cast::<RustArray>();
+        let rust_shape = &(*array).shape;
 
         *shape = rust_shape.as_ptr();
         *shape_count = rust_shape.len();
@@ -190,7 +219,7 @@ unsafe extern "C" fn rust_array_shape(
     })
 }
 
-/// Implementation of `mts_array_t.reshape` using `Box<dyn Array>`
+/// Implementation of `mts_array_t.reshape` using `RustArray`
 #[allow(clippy::cast_possible_truncation)]
 unsafe extern "C" fn rust_array_reshape(
     array: *mut c_void,
@@ -199,7 +228,7 @@ unsafe extern "C" fn rust_array_reshape(
 ) -> mts_status_t {
     crate::errors::catch_unwind(|| {
         check_pointers!(array);
-        let array = array.cast::<Box<dyn Array>>();
+        let array = array.cast::<RustArray>();
 
         let shape = if shape_count == 0 {
             &[]
@@ -208,13 +237,14 @@ unsafe extern "C" fn rust_array_reshape(
             std::slice::from_raw_parts(shape, shape_count)
         };
 
-        (*array).reshape(shape);
+        (*array).impl_.reshape(shape);
+        (*array).shape = shape.to_vec();
 
         Ok(())
     })
 }
 
-/// Implementation of `mts_array_t.swap_axes` using `Box<dyn Array>`
+/// Implementation of `mts_array_t.swap_axes` using `RustArray`
 #[allow(clippy::cast_possible_truncation)]
 unsafe extern "C" fn rust_array_swap_axes(
     array: *mut c_void,
@@ -223,14 +253,15 @@ unsafe extern "C" fn rust_array_swap_axes(
 ) -> mts_status_t {
     crate::errors::catch_unwind(|| {
         check_pointers!(array);
-        let array = array.cast::<Box<dyn Array>>();
-        (*array).swap_axes(axis_1, axis_2);
+        let array = array.cast::<RustArray>();
+        (*array).impl_.swap_axes(axis_1, axis_2);
+        (*array).shape.swap(axis_1, axis_2);
 
         Ok(())
     })
 }
 
-/// Implementation of `mts_array_t.create` using `Box<dyn Array>`
+/// Implementation of `mts_array_t.create` using `RustArray`
 #[allow(clippy::cast_possible_truncation)]
 unsafe extern "C" fn rust_array_create(
     array: *const c_void,
@@ -241,7 +272,7 @@ unsafe extern "C" fn rust_array_create(
 ) -> mts_status_t {
     crate::errors::catch_unwind(|| {
         check_pointers!(array, array_storage);
-        let array = array.cast::<Box<dyn Array>>();
+        let array = array.cast::<RustArray>();
 
         let shape = if shape_count == 0 {
             &[]
@@ -250,40 +281,44 @@ unsafe extern "C" fn rust_array_create(
             std::slice::from_raw_parts(shape, shape_count)
         };
 
-        let new_array = (*array).create(shape, MtsArray::from_raw(fill_value));
+        let new_array = (*array).impl_.create(shape, MtsArray::from_raw(fill_value));
+        let new_array = MtsArray::from(new_array);
 
-        *array_storage = new_array.into();
+        *array_storage = new_array.into_raw();
 
         Ok(())
     })
 }
 
-/// Implementation of `mts_array_t.copy` using `Box<dyn Array>`
+/// Implementation of `mts_array_t.copy` using `RustArray`
 unsafe extern "C" fn rust_array_copy(
     array: *const c_void,
     array_storage: *mut mts_array_t,
 ) -> mts_status_t {
     crate::errors::catch_unwind(|| {
         check_pointers!(array, array_storage);
-        let array = array.cast::<Box<dyn Array>>();
-        *array_storage = (*array).copy().into();
+        let array = array.cast::<RustArray>();
+
+        let new_array = (*array).impl_.copy();
+        let new_array = MtsArray::from(new_array);
+        *array_storage = new_array.into_raw();
 
         Ok(())
     })
 }
 
-/// Implementation of `mts_array_t.destroy` for `Box<dyn Array>`
+/// Implementation of `mts_array_t.destroy` for `RustArray`
 unsafe extern "C" fn rust_array_destroy(
     array: *mut c_void,
 ) {
     if !array.is_null() {
-        let array = array.cast::<Box<dyn Array>>();
+        let array = array.cast::<RustArray>();
         let boxed = Box::from_raw(array);
         std::mem::drop(boxed);
     }
 }
 
-/// Implementation of `mts_array_t.move_sample` using `Box<dyn Array>`
+/// Implementation of `mts_array_t.move_sample` using `RustArray`
 #[allow(clippy::cast_possible_truncation)]
 unsafe extern "C" fn rust_array_move_data(
     output: *mut c_void,
@@ -293,8 +328,8 @@ unsafe extern "C" fn rust_array_move_data(
 ) -> mts_status_t {
     crate::errors::catch_unwind(|| {
         check_pointers!(output, input);
-        let output = output.cast::<Box<dyn Array>>();
-        let input = input.cast::<Box<dyn Array>>();
+        let output = output.cast::<RustArray>();
+        let input = input.cast::<RustArray>();
 
         let movements = if movements_count == 0 {
             &[]
@@ -303,13 +338,13 @@ unsafe extern "C" fn rust_array_move_data(
             std::slice::from_raw_parts(movements, movements_count)
         };
 
-        (*output).move_data(&**input, movements);
+        (*output).impl_.move_data(&*(*input).impl_, movements);
 
         Ok(())
     })
 }
 
-/// Implementation of `mts_array_t.as_dlpack` using `Box<dyn Array>`
+/// Implementation of `mts_array_t.as_dlpack` using `RustArray`
 unsafe extern "C" fn rust_array_as_dlpack(
     array: *mut c_void,
     out: *mut *mut DLManagedTensorVersioned,
@@ -319,12 +354,11 @@ unsafe extern "C" fn rust_array_as_dlpack(
 ) -> mts_status_t {
     crate::errors::catch_unwind(|| {
         check_pointers!(array, out);
-        let array = array.cast::<Box<dyn Array>>();
+        let array = array.cast::<RustArray>();
         let stream_opt = stream.as_ref().copied();
-        let tensor = (*array).as_dlpack(device, stream_opt, max_version)?;
+        let tensor = (*array).impl_.as_dlpack(device, stream_opt, max_version)?;
 
-        let raw_ptr = tensor.into_raw();
-        *out = raw_ptr.as_ptr();
+        *out = tensor.into_raw().as_ptr();
 
         Ok(())
     })

--- a/rust/metatensor/src/data/array_ref.rs
+++ b/rust/metatensor/src/data/array_ref.rs
@@ -1,13 +1,13 @@
 use std::ptr::NonNull;
+use std::sync::{Arc, RwLock};
 
-use ndarray::{ArcArray, IxDyn};
+use ndarray::ArrayD;
 
 use dlpk::sys::DLDevice;
 
 use crate::c_api::{mts_array_t, mts_data_origin_t, mts_data_movement_t};
 use crate::Error;
 
-use super::Array;
 use super::external::{check_status_external, MtsArray};
 use super::origin::get_data_origin;
 
@@ -55,7 +55,7 @@ impl<'a> ArrayRef<'a> {
             get_data_origin(origin).unwrap_or_else(|_| "unknown".into())
         );
 
-        let array = self.array.ptr.cast::<Box<dyn Array>>();
+        let array = self.array.ptr.cast::<super::array::RustArray>();
         unsafe {
             return (*array).as_any();
         }
@@ -75,27 +75,30 @@ impl<'a> ArrayRef<'a> {
             get_data_origin(origin).unwrap_or_else(|_| "unknown".into())
         );
 
-        let array = self.array.ptr.cast::<Box<dyn Array>>();
+        let array = self.array.ptr.cast::<super::array::RustArray>();
         unsafe {
             return (*array).as_any();
         }
     }
 
-    /// Get the data in this `ArrayRef` as a `ndarray::ArcArray`. This function
-    /// will panic if the data in this `mts_array_t` is not a `ndarray::ArcArray`.
+    /// Extract the `Arc<RwLock<ArrayD<T>>>` from this `ArrayRef`, if it
+    /// contains one.
+    ///
+    /// This function will panic if the data in the `mts_array_t` in this
+    /// `ArrayRef` is a different kind of array.
     #[inline]
-    pub fn as_ndarray(&self) -> &ArcArray<f64, IxDyn> {
-        self.as_any().downcast_ref().expect("this is not a ndarray::ArcArray")
+    pub fn as_ndarray_lock<T>(&self) -> &Arc<RwLock<ArrayD<T>>> where T: 'static {
+        self.as_any().downcast_ref().expect("this is not an Arc<RwLock<ArrayD>>")
     }
 
-    /// Transform this `ArrayRef` into a reference to an `ndarray::ArcArray`,
-    /// keeping the lifetime of the `ArrayRef`.
+    /// Extract the `Arc<RwLock<ArrayD<T>>>` from this `ArrayRef`, if it
+    /// contains one, keeping the initial lifetime of the `ArrayRef`.
     ///
-    /// This function will panic if the data in this `mts_array_t` is not a
-    /// `ndarray::ArcArray`.
+    /// This function will panic if the data in the `mts_array_t` in this
+    /// `ArrayRef` is a different kind of array.
     #[inline]
-    pub fn to_ndarray(self) -> &'a ArcArray<f64, IxDyn> {
-        self.to_any().downcast_ref().expect("this is not a ndarray::ArcArray")
+    pub fn to_ndarray_lock<T>(self) -> &'a Arc<RwLock<ArrayD<T>>> where T: 'static {
+        self.to_any().downcast_ref().expect("this is not an Arc<RwLock<ArrayD>>")
     }
 
     /// Get the raw underlying `mts_array_t`
@@ -298,19 +301,19 @@ impl<'a> ArrayRefMut<'a> {
             get_data_origin(origin).unwrap_or_else(|_| "unknown".into())
         );
 
-        let array = self.array.ptr.cast::<Box<dyn Array>>();
+        let array = self.array.ptr.cast::<super::array::RustArray>();
         unsafe {
             return (*array).as_any();
         }
     }
 
-    /// Get the underlying array as an `&dyn Any` instance,
+    /// Get a reference to the underlying array as an `&dyn Any` instance,
     /// re-using the same lifetime as the `ArrayRefMut`.
     ///
     /// This function panics if the array was not created though this crate and
     /// the [`Array`] trait.
     #[inline]
-    pub fn to_any(&self) -> &'a dyn std::any::Any {
+    pub fn to_any(self) -> &'a dyn std::any::Any {
         let origin = self.origin().unwrap_or(0);
         assert_eq!(
             origin, *super::array::RUST_DATA_ORIGIN,
@@ -318,33 +321,13 @@ impl<'a> ArrayRefMut<'a> {
             get_data_origin(origin).unwrap_or_else(|_| "unknown".into())
         );
 
-        let array = self.array.ptr.cast::<Box<dyn Array>>();
+        let array = self.array.ptr.cast::<super::array::RustArray>();
         unsafe {
             return (*array).as_any();
         }
     }
 
     /// Get the underlying array as an `&mut dyn Any` instance.
-    ///
-    /// This function panics if the array was not created though this crate and
-    /// the [`Array`] trait.
-    #[inline]
-    pub fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
-        let origin = self.origin().unwrap_or(0);
-        assert_eq!(
-            origin, *super::array::RUST_DATA_ORIGIN,
-            "this array was not created as a rust Array (origin is '{}')",
-            get_data_origin(origin).unwrap_or_else(|_| "unknown".into())
-        );
-
-        let array = self.array.ptr.cast::<Box<dyn Array>>();
-        unsafe {
-            return (*array).as_any_mut();
-        }
-    }
-
-    /// Get the underlying array as an `&mut dyn Any` instance, re-using the
-    /// same lifetime as the `ArrayRefMut`.
     ///
     /// This function panics if the array was not created though this crate and
     /// the [`Array`] trait.
@@ -357,45 +340,47 @@ impl<'a> ArrayRefMut<'a> {
             get_data_origin(origin).unwrap_or_else(|_| "unknown".into())
         );
 
-        let array = self.array.ptr.cast::<Box<dyn Array>>();
+        let array = self.array.ptr.cast::<super::array::RustArray>();
         unsafe {
             return (*array).as_any_mut();
         }
     }
 
-    /// Get the data in this `ArrayRef` as a `ndarray::ArcArray`. This function
-    /// will panic if the data in this `mts_array_t` is not a `ndarray::ArcArray`.
-    #[inline]
-    pub fn as_ndarray(&self) -> &ArcArray<f64, IxDyn> {
-        self.as_any().downcast_ref().expect("this is not a ndarray::ArcArray")
-    }
-
-    /// Transform this `ArrayRefMut` into a reference to an `ndarray::ArcArray`,
-    /// keeping the lifetime of the `ArrayRefMut`.
+    /// Extract the `Arc<RwLock<ArrayD<T>>>` from this `ArrayRef`, if it
+    /// contains one.
     ///
-    /// This function will panic if the data in this `mts_array_t` is not a
-    /// `ndarray::ArcArray`.
+    /// This function will panic if the data in the `mts_array_t` in this
+    /// `ArrayRefMut` is a different kind of array.
     #[inline]
-    pub fn to_ndarray(&self) -> &ArcArray<f64, IxDyn> {
-        self.to_any().downcast_ref().expect("this is not a ndarray::ArcArray")
+    pub fn as_ndarray_lock<T>(&self) -> &Arc<RwLock<ArrayD<T>>> where T: 'static {
+        self.as_any().downcast_ref().expect("this is not an Arc<RwLock<ArrayD>>")
     }
 
-    /// Get the data in this `ArrayRef` as a mutable reference to an
-    /// `ndarray::ArcArray`. This function will panic if the data in this
-    /// `mts_array_t` is not a `ndarray::ArcArray`.
-    #[inline]
-    pub fn as_ndarray_mut(&mut self) -> &mut ArcArray<f64, IxDyn> {
-        self.as_any_mut().downcast_mut().expect("this is not a ndarray::ArcArray")
-    }
-
-    /// Transform this `ArrayRefMut` into a mutable reference to an
-    /// `ndarray::ArcArray`, keeping the lifetime of the `ArrayRefMut`.
+    /// Extract the `Arc<RwLock<ArrayD<T>>>` from this `ArrayRef`, if it
+    /// contains one, keeping the initial lifetime of the `ArrayRef`.
     ///
-    /// This function will panic if the data in this `mts_array_t` is not a
-    /// `ndarray::ArcArray`.
+    /// This function will panic if the data in the `mts_array_t` in this
+    /// `ArrayRefMut` is a different kind of array.
     #[inline]
-    pub fn to_ndarray_mut(self) -> &'a mut ArcArray<f64, IxDyn> {
-        self.to_any_mut().downcast_mut().expect("this is not a ndarray::ArcArray")
+    pub fn to_ndarray_lock<T>(self) -> &'a Arc<RwLock<ArrayD<T>>> where T: 'static {
+        self.to_any().downcast_ref().expect("this is not an Arc<RwLock<ArrayD>>")
+    }
+
+    /// Get a mutable reference to the underlying array, consuming this
+    /// `ArrayRefMut`.
+    ///
+    /// Since this array is already guaranteed to be unique through the mutable
+    /// borrow, we do not need to lock the `RwLock` to get access to the
+    /// `ArrayD`.
+    ///
+    /// This function will panic if the data in the `mts_array_t` in this
+    /// `ArrayRefMut` does not contain an `Arc<RwLock<ArrayD<T>>>`, or if the
+    /// `Arc` already has multiple strong references.
+    #[inline]
+    pub fn get_ndarray_mut<T>(self) -> &'a mut ArrayD<T> where T: 'static {
+        let arc = self.to_any_mut().downcast_mut::<Arc<RwLock<ArrayD<T>>>>().expect("this is not an Arc<RwLock<ArrayD>>");
+        let lock = Arc::get_mut(arc).expect("the outer Arc already has multiple owners");
+        return lock.get_mut().expect("lock was poisoned");
     }
 
     /// Get the raw underlying `mts_array_t`

--- a/rust/metatensor/src/data/empty.rs
+++ b/rust/metatensor/src/data/empty.rs
@@ -39,8 +39,8 @@ impl Array for EmptyArray {
         Box::new(EmptyArray { shape: self.shape.clone() })
     }
 
-    fn shape(&self) -> &[usize] {
-        &self.shape
+    fn shape(&self) -> Vec<usize> {
+        self.shape.clone()
     }
 
     fn reshape(&mut self, shape: &[usize]) {

--- a/rust/metatensor/src/data/external.rs
+++ b/rust/metatensor/src/data/external.rs
@@ -1,6 +1,7 @@
 use std::ptr::NonNull;
+use std::sync::{Arc, RwLock, RwLockReadGuard};
 
-use ndarray::{ArcArray, IxDyn};
+use ndarray::ArrayD;
 use dlpk::sys::DLDevice;
 
 use crate::c_api::{mts_array_t, mts_data_origin_t, mts_data_movement_t, mts_status_t};
@@ -9,7 +10,7 @@ use crate::c_api::{MTS_SUCCESS, mts_last_error};
 use crate::Error;
 use crate::errors::{LAST_RUST_ERROR, RUST_FUNCTION_FAILED_ERROR_CODE};
 
-use super::{Array, ArrayRef, ArrayRefMut};
+use super::{ArrayRef, ArrayRefMut};
 use super::origin::get_data_origin;
 
 /// Wrapper around `mts_array_t` that provides a more convenient API to use it
@@ -34,9 +35,14 @@ impl MtsArray {
         MtsArray { array }
     }
 
-    /// Create a new `MtsArray` from any type that implements the [`Array`] trait.
-    pub fn new(value: impl Array) -> MtsArray {
-        MtsArray { array: mts_array_t::from(Box::new(value) as Box<dyn Array>) }
+    /// Get the underlying `mts_array_t`, transferring ownership of the data to
+    /// the caller.
+    pub fn into_raw(self) -> mts_array_t {
+        let array = self.array;
+        // since mts_array_t is Copy, we need to forget self to avoid calling
+        // Drop when this function returns
+        std::mem::forget(self);
+        array
     }
 
     /// Get the underlying array as an `&dyn Any` instance.
@@ -52,17 +58,22 @@ impl MtsArray {
             get_data_origin(origin).unwrap_or_else(|_| "unknown".into())
         );
 
-        let array = self.array.ptr.cast::<Box<dyn Array>>();
+        let array = self.array.ptr.cast::<super::array::RustArray>();
         unsafe {
             return (*array).as_any();
         }
     }
 
+    #[inline]
+    fn as_lock<T>(&self) -> &Arc<RwLock<ArrayD<T>>> where T: 'static {
+        self.as_any().downcast_ref().expect("this is not an Arc<RwLock<ArrayD>>")
+    }
+
     /// Get the data in this `ArrayRef` as a `ndarray::ArcArray`. This function
     /// will panic if the data in this `mts_array_t` is not a `ndarray::ArcArray`.
     #[inline]
-    pub fn as_ndarray(&self) -> &ArcArray<f64, IxDyn> {
-        self.as_any().downcast_ref().expect("this is not a ndarray::ArcArray")
+    pub fn as_ndarray<T>(&self) -> RwLockReadGuard<'_, ArrayD<T>> where T: 'static {
+        return self.as_lock().read().expect("lock was poisoned");
     }
 
     /// Get the underlying `mts_array_t`.

--- a/rust/metatensor/src/data/mod.rs
+++ b/rust/metatensor/src/data/mod.rs
@@ -23,7 +23,7 @@ pub use metatensor_sys::mts_data_movement_t;
 
 #[cfg(test)]
 mod tests {
-    use ndarray::ArcArray;
+    use ndarray::Array;
     use crate::c_api::mts_data_movement_t;
 
     use super::*;
@@ -31,51 +31,49 @@ mod tests {
 
     #[test]
     fn shape() {
-        let mut array = MtsArray::new(ArcArray::from_elem(vec![3, 4, 2], 1.0));
+        let mut array = MtsArray::from(Array::from_elem(vec![3, 4, 2], 1.0));
 
         assert_eq!(array.shape().unwrap(), [3, 4, 2]);
         array.reshape(&[12, 2]).unwrap();
         assert_eq!(array.shape().unwrap(), [12, 2]);
-        assert_eq!(array.as_ndarray(), ArcArray::from_elem(vec![12, 2], 1.0));
+        assert_eq!(*array.as_ndarray::<f64>(), Array::from_elem(vec![12, 2], 1.0));
 
         array.swap_axes(0, 1).unwrap();
         assert_eq!(array.shape().unwrap(), [2, 12]);
 
         let array_ref = array.as_ref();
         assert_eq!(array_ref.shape().unwrap(), [2, 12]);
-        assert_eq!(array_ref.as_ndarray(), ArcArray::from_elem(vec![2, 12], 1.0));
-        assert_eq!(array_ref.to_ndarray(), ArcArray::from_elem(vec![2, 12], 1.0));
+        assert_eq!(*array_ref.as_ndarray_lock::<f64>().read().unwrap(), Array::from_elem(vec![2, 12], 1.0));
 
         let mut array_ref_mut = array.as_mut();
         assert_eq!(array_ref_mut.shape().unwrap(), [2, 12]);
 
         array_ref_mut.reshape(&[6, 4]).unwrap();
         assert_eq!(array_ref_mut.shape().unwrap(), [6, 4]);
-        assert_eq!(array_ref_mut.as_ndarray(), ArcArray::from_elem(vec![6, 4], 1.0));
-        assert_eq!(array_ref_mut.to_ndarray(), ArcArray::from_elem(vec![6, 4], 1.0));
+        assert_eq!(*array_ref_mut.as_ndarray_lock::<f64>().read().unwrap(), Array::from_elem(vec![6, 4], 1.0));
     }
 
     #[test]
     fn create() {
-        let array = MtsArray::new(ArcArray::from_elem(vec![4, 2], 1.0));
+        let array = MtsArray::from(Array::from_elem(vec![4, 2], 1.0));
 
-        assert_eq!(get_data_origin(array.origin().unwrap()).unwrap(), "rust.Box<dyn Array>");
-        assert_eq!(array.as_ndarray(), ArcArray::from_elem(vec![4, 2], 1.0));
+        assert_eq!(get_data_origin(array.origin().unwrap()).unwrap(), "RustArray");
+        assert_eq!(*array.as_ndarray::<f64>(), Array::from_elem(vec![4, 2], 1.0));
 
-        let fill_value = MtsArray::new(ArcArray::from_elem(vec![], 42.0));
+        let fill_value = MtsArray::from(Array::from_elem(vec![], 42.0));
         let other = array.create(&[5, 3, 7, 12], fill_value.as_ref()).unwrap();
         assert_eq!(other.shape().unwrap(), [5, 3, 7, 12]);
-        assert_eq!(get_data_origin(other.origin().unwrap()).unwrap(), "rust.Box<dyn Array>");
-        assert_eq!(other.as_ndarray(), ArcArray::from_elem(vec![5, 3, 7, 12], 42.0));
+        assert_eq!(get_data_origin(other.origin().unwrap()).unwrap(), "RustArray");
+        assert_eq!(*other.as_ndarray::<f64>(), Array::from_elem(vec![5, 3, 7, 12], 42.0));
     }
 
     #[test]
     fn move_data() {
-        let array = MtsArray::new(ArcArray::from_elem(vec![3, 2, 2, 4], 1.0));
+        let array = MtsArray::from(Array::from_elem(vec![3, 2, 2, 4], 1.0));
 
-        let fill_value = MtsArray::new(ArcArray::from_elem(vec![], 0.0));
+        let fill_value = MtsArray::from(Array::from_elem(vec![], 0.0));
         let mut other = array.create(&[1, 2, 2, 8], fill_value.as_ref()).unwrap();
-        assert_eq!(other.as_ndarray(), ArcArray::from_elem(vec![1, 2, 2, 8], 0.0));
+        assert_eq!(*other.as_ndarray::<f64>(), Array::from_elem(vec![1, 2, 2, 8], 0.0));
 
         let mapping = mts_data_movement_t {
             sample_in: 1,
@@ -85,12 +83,12 @@ mod tests {
             properties_length: 4,
         };
         other.move_data(&array, &[mapping]).unwrap();
-        let expected = ArcArray::from_shape_vec(vec![1, 2, 2, 8], vec![
+        let expected = Array::from_shape_vec(vec![1, 2, 2, 8], vec![
                 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0,
                 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0,
                 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0,
                 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0,
         ]).unwrap();
-        assert_eq!(other.as_ndarray(), expected);
+        assert_eq!(*other.as_ndarray::<f64>(), expected);
     }
 }

--- a/rust/metatensor/src/data/ndarray_array.rs
+++ b/rust/metatensor/src/data/ndarray_array.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, RwLock, TryLockError};
+
 use dlpk::sys::{DLDevice, DLPackVersion, DLDataType};
 use dlpk::{DLPackTensor, GetDLPackDataType, DLPackPointerCast};
 
@@ -6,7 +8,15 @@ use crate::c_api::mts_data_movement_t;
 
 use super::{Array, MtsArray};
 
-impl<T> Array for ndarray::ArcArray<T, ndarray::IxDyn>
+impl<T> From<ndarray::ArrayD<T>> for MtsArray where T: 'static + Clone + Send + Default + Sync + GetDLPackDataType + DLPackPointerCast {
+    fn from(value: ndarray::ArrayD<T>) -> Self {
+        let array = Arc::new(RwLock::new(value));
+        let boxed: Box<dyn Array> = Box::new(array);
+        return MtsArray::from(boxed);
+    }
+}
+
+impl<T> Array for Arc<RwLock<ndarray::ArrayD<T>>>
 where
     T: 'static + Send + Sync + Clone + Default + GetDLPackDataType + DLPackPointerCast,
 {
@@ -21,32 +31,49 @@ where
     fn create(&self, shape: &[usize], fill_value: MtsArray) -> Box<dyn Array> {
         let cpu_device = DLDevice::cpu();
         let max_version = DLPackVersion::current();
-        let fill_value_dlpack = fill_value.as_dlpack(cpu_device, None, max_version)
-            .expect("failed to extract fill_value as DLPack");
+        let fill_value_dlpack = fill_value.as_dlpack(cpu_device, None, max_version).expect("failed to extract fill_value as DLPack");
 
         // Validate fill_value shape from the DLPack tensor directly
-        assert!(fill_value_dlpack.shape().is_empty(), "`fill_value` must be a single scalar");
+        assert_eq!(fill_value_dlpack.shape(), [], "fill_value must have shape (1,)");
+        assert_eq!(fill_value_dlpack.device(), cpu_device, "fill_value must be on CPU");
 
         let fill_value_ptr = fill_value_dlpack.data_ptr::<T>().expect("dtype mismatch between array and fill_value");
         let fill_value_scalar = unsafe { std::ptr::read(fill_value_ptr) };
 
-        Box::new(ndarray::ArcArray::from_elem(shape, fill_value_scalar))
+        let array = ndarray::Array::from_elem(shape, fill_value_scalar);
+        return Box::new(Arc::new(RwLock::new(array)));
     }
 
     fn copy(&self) -> Box<dyn Array> {
         return Box::new(self.clone());
     }
 
-    fn shape(&self) -> &[usize] {
-        return self.shape();
+    fn shape(&self) -> Vec<usize> {
+        match self.try_read() {
+            Ok(lock) => lock.shape().to_vec(),
+            Err(TryLockError::Poisoned(_)) => panic!("array lock is poisoned"),
+            Err(TryLockError::WouldBlock) => panic!("array is already locked"),
+        }
     }
 
     fn reshape(&mut self, shape: &[usize]) {
-        *self = self.to_shape(shape).expect("invalid shape").to_shared();
+        let mut lock = match self.try_write() {
+            Ok(lock) => lock,
+            Err(TryLockError::Poisoned(_)) => panic!("array lock is poisoned"),
+            Err(TryLockError::WouldBlock) => panic!("array is already locked"),
+        };
+        let array = std::mem::take(&mut *lock);
+        let array = array.into_shape_clone(shape).expect("invalid shape");
+        let _ = std::mem::replace(&mut *lock, array);
     }
 
     fn swap_axes(&mut self, axis_1: usize, axis_2: usize) {
-        self.swap_axes(axis_1, axis_2);
+        let mut lock = match self.try_write() {
+            Ok(lock) => lock,
+            Err(TryLockError::Poisoned(_)) => panic!("array lock is poisoned"),
+            Err(TryLockError::WouldBlock) => panic!("array is already locked"),
+        };
+        lock.swap_axes(axis_1, axis_2);
     }
 
     fn move_data(
@@ -56,7 +83,18 @@ where
     ) {
         use ndarray::{Axis, Slice};
 
-        let input = input.as_any().downcast_ref::<ndarray::ArcArray<T, ndarray::IxDyn>>().expect("input must be a ndarray of the same type");
+        let input = input.as_any().downcast_ref::<Self>().expect("input must be a ndarray of the same type");
+        let input = match input.try_read() {
+            Ok(lock) => lock,
+            Err(TryLockError::Poisoned(_)) => panic!("input array lock is poisoned"),
+            Err(TryLockError::WouldBlock) => panic!("input array is already locked"),
+        };
+
+        let mut output = match self.try_write() {
+            Ok(lock) => lock,
+            Err(TryLockError::Poisoned(_)) => panic!("output array lock is poisoned"),
+            Err(TryLockError::WouldBlock) => panic!("output array is already locked"),
+        };
 
         if movements.is_empty() {
             return;
@@ -97,7 +135,7 @@ where
             }
         }
 
-        let property_axis = self.shape().len() - 1;
+        let property_axis = output.shape().len() - 1;
 
         if constant_properties {
             let input_slice_info = Slice::from(first_prop_start_in..(first_prop_start_in + first_prop_len));
@@ -112,7 +150,7 @@ where
                     Axis(0),
                     Slice::from(sample_start_in..(sample_start_in + sample_count))
                 );
-                let mut output_samples = self.slice_axis_mut(
+                let mut output_samples = output.slice_axis_mut(
                     Axis(0),
                     Slice::from(sample_start_out..(sample_start_out + sample_count))
                 );
@@ -124,7 +162,7 @@ where
             } else {
                 for move_item in movements {
                     let input_sample = input.index_axis(Axis(0), move_item.sample_in);
-                    let mut output_sample = self.index_axis_mut(Axis(0), move_item.sample_out);
+                    let mut output_sample = output.index_axis_mut(Axis(0), move_item.sample_out);
 
                     let value = input_sample.slice_axis(
                         // property_axis - 1 because we are slicing the sample
@@ -143,7 +181,7 @@ where
             // fallback to the general case
             for move_item in movements {
                 let input_sample = input.index_axis(Axis(0), move_item.sample_in);
-                let mut output_sample = self.index_axis_mut(Axis(0), move_item.sample_out);
+                let mut output_sample = output.index_axis_mut(Axis(0), move_item.sample_out);
 
                 let value = input_sample.slice_axis(
                     // see above for property_axis - 1 explanation
@@ -205,7 +243,7 @@ where
             });
         }
 
-        let tensor: DLPackTensor = self.try_into().map_err(|e| Error {
+        let tensor: DLPackTensor = Arc::clone(self).try_into().map_err(|e| Error {
             code: Some(crate::c_api::MTS_INVALID_PARAMETER_ERROR),
             message: format!("failed to convert ndarray to DLPack: {:?}", e),
         })?;
@@ -221,12 +259,12 @@ mod tests {
 
     #[test]
     fn ndarray_as_mts_array() {
-        let data = ndarray::ArcArray::<f64, _>::zeros(vec![2, 3, 4]);
-        let mts_array = MtsArray::new(data);
+        let data = ndarray::Array::<f64, _>::zeros(vec![2, 3, 4]);
+        let mts_array = MtsArray::from(data);
 
         assert_eq!(mts_array.shape().unwrap(), [2, 3, 4]);
 
-        let fill_value = MtsArray::new(ndarray::ArcArray::from_elem(vec![], 42.0));
+        let fill_value = MtsArray::from(ndarray::Array::from_elem(vec![], 42.0));
 
         let created = mts_array.create(&[2, 3, 4], fill_value.as_ref()).unwrap();
         assert_eq!(created.shape().unwrap(), [2, 3, 4]);
@@ -234,8 +272,8 @@ mod tests {
 
     #[test]
     fn ndarray_as_mts_array_dlpack() {
-        let data = ndarray::ArcArray::<f64, _>::zeros(vec![4, 5, 6]);
-        let mts_array = MtsArray::new(data);
+        let data = ndarray::Array::<f64, _>::zeros(vec![4, 5, 6]);
+        let mts_array = MtsArray::from(data);
 
         let dl_managed = mts_array.as_dlpack(DLDevice::cpu(), None, DLPackVersion::current()).unwrap();
 
@@ -250,8 +288,8 @@ mod tests {
     #[test]
     fn ndarray_all_dtypes() {
         fn test_for_dtype<T>(code: DLDataTypeCode, bits: u8) where T: Send + Sync + Clone + Default + GetDLPackDataType + DLPackPointerCast + 'static {
-            let data = ndarray::ArcArray::<T, _>::from_elem(vec![2, 2], T::default());
-            let mts_array = MtsArray::new(data);
+            let data = ndarray::Array::<T, _>::from_elem(vec![2, 2], T::default());
+            let mts_array = MtsArray::from(data);
 
             assert_eq!(mts_array.shape().unwrap(), [2, 2]);
 
@@ -263,7 +301,7 @@ mod tests {
 
 
             // And `create` should make an array of the same type (i32)
-            let fill_value = MtsArray::new(ndarray::ArcArray::from_elem(vec![], T::default()));
+            let fill_value = MtsArray::from(ndarray::Array::from_elem(vec![], T::default()));
 
             let created = mts_array.create(&[1, 1], fill_value.as_ref()).unwrap();
             let dl_managed = created.as_dlpack(DLDevice::cpu(), None, DLPackVersion::current()).unwrap();
@@ -288,16 +326,16 @@ mod tests {
 
     #[test]
     fn ndarray_device() {
-        let data = ndarray::ArcArray::<f64, _>::zeros(vec![2, 3]);
-        let mts_array = MtsArray::new(data);
+        let data = ndarray::Array::<f64, _>::zeros(vec![2, 3]);
+        let mts_array = MtsArray::from(data);
 
         assert_eq!(mts_array.device().unwrap(), DLDevice::cpu());
     }
 
     #[test]
     fn as_dlpack_rejects_stream() {
-        let data = ndarray::ArcArray::<f64, _>::zeros(vec![2, 3]);
-        let mts_array = MtsArray::new(data);
+        let data = ndarray::Array::<f64, _>::zeros(vec![2, 3]);
+        let mts_array = MtsArray::from(data);
         match mts_array.as_dlpack(DLDevice::cpu(), Some(42), DLPackVersion::current()) {
             Err(e) => assert!(e.message.contains("stream"), "{}", e.message),
             Ok(_) => panic!("expected error for non-null stream"),
@@ -306,8 +344,8 @@ mod tests {
 
     #[test]
     fn as_dlpack_rejects_wrong_device() {
-        let data = ndarray::ArcArray::<f64, _>::zeros(vec![2, 3]);
-        let mts_array = MtsArray::new(data);
+        let data = ndarray::Array::<f64, _>::zeros(vec![2, 3]);
+        let mts_array = MtsArray::from(data);
         let cuda = DLDevice {
             device_type: dlpk::sys::DLDeviceType::kDLCUDA,
             device_id: 0,
@@ -320,8 +358,8 @@ mod tests {
 
     #[test]
     fn as_dlpack_rejects_incompatible_version() {
-        let data = ndarray::ArcArray::<f64, _>::zeros(vec![2, 3]);
-        let mts_array = MtsArray::new(data);
+        let data = ndarray::Array::<f64, _>::zeros(vec![2, 3]);
+        let mts_array = MtsArray::from(data);
 
         let bad_version = DLPackVersion { major: 99, minor: 0 };
         match mts_array.as_dlpack(DLDevice::cpu(), None, bad_version) {

--- a/rust/metatensor/src/io/mod.rs
+++ b/rust/metatensor/src/io/mod.rs
@@ -6,7 +6,7 @@ use std::os::raw::c_void;
 use dlpk::sys::{DLDataType, DLDataTypeCode};
 
 use crate::c_api::{MTS_SUCCESS, mts_array_t, mts_status_t};
-use crate::Array;
+use crate::MtsArray;
 
 mod tensor;
 pub use self::tensor::{load, save, load_buffer, save_buffer};
@@ -42,11 +42,11 @@ unsafe extern "C" fn realloc_vec(user_data: *mut c_void, _ptr: *mut u8, new_size
     return result;
 }
 
-/// Create a typed `ndarray::ArcArray<T>` and box it as `dyn Array`.
+/// Create a typed `ndarray::Array<T>` and box it as `dyn Array`.
 macro_rules! create_typed_array {
     ($shape:expr, $c_array:expr, $T:ty) => {{
-        let array = ndarray::ArcArray::<$T, _>::from_elem($shape, <$T>::default());
-        *$c_array = (Box::new(array) as Box<dyn Array>).into();
+        let array = ndarray::Array::<$T, _>::from_elem($shape, <$T>::default());
+        std::convert::Into::<MtsArray>::into(array)
     }};
 }
 
@@ -71,7 +71,7 @@ unsafe extern "C" fn create_ndarray(
             });
         }
 
-        match (dtype.code, dtype.bits) {
+        let array = match (dtype.code, dtype.bits) {
             (DLDataTypeCode::kDLFloat, 32) => create_typed_array!(shape, c_array, f32),
             (DLDataTypeCode::kDLFloat, 64) => create_typed_array!(shape, c_array, f64),
             (DLDataTypeCode::kDLInt, 8) => create_typed_array!(shape, c_array, i8),
@@ -95,7 +95,9 @@ unsafe extern "C" fn create_ndarray(
                     ),
                 });
             }
-        }
+        };
+
+        *c_array = array.into_raw();
 
         Ok(())
     })

--- a/rust/metatensor/src/tensor.rs
+++ b/rust/metatensor/src/tensor.rs
@@ -2,10 +2,10 @@ use std::ffi::{CStr, CString};
 use std::iter::FusedIterator;
 
 use crate::block::TensorBlockRefMut;
-use crate::c_api::{mts_tensormap_t, mts_labels_t, mts_array_t};
+use crate::c_api::{mts_tensormap_t, mts_labels_t};
 
 use crate::errors::{check_status, check_ptr};
-use crate::{Error, TensorBlock, TensorBlockRef, Labels, LabelValue};
+use crate::{Error, LabelValue, Labels, MtsArray, TensorBlock, TensorBlockRef};
 
 /// [`TensorMap`] is the main user-facing struct of this library, and can
 /// store any kind of data used in atomistic machine learning.
@@ -327,12 +327,12 @@ impl TensorMap {
     /// This function is only implemented if all merged block have the same
     /// property labels.
     #[inline]
-    pub fn keys_to_samples(&self, keys_to_move: &Labels, fill_value: mts_array_t, sort_samples: bool) -> Result<TensorMap, Error> {
+    pub fn keys_to_samples(&self, keys_to_move: &Labels, fill_value: MtsArray, sort_samples: bool) -> Result<TensorMap, Error> {
         let ptr = unsafe {
             crate::c_api::mts_tensormap_keys_to_samples(
                 self.ptr,
                 keys_to_move.as_mts_labels_t(),
-                fill_value,
+                fill_value.into_raw(),
                 sort_samples,
             )
         };
@@ -368,12 +368,12 @@ impl TensorMap {
     /// lexicographically sorted. Otherwise they are kept in the order in which
     /// they appear in the blocks.
     #[inline]
-    pub fn keys_to_properties(&self, keys_to_move: &Labels, fill_value: mts_array_t, sort_samples: bool) -> Result<TensorMap, Error> {
+    pub fn keys_to_properties(&self, keys_to_move: &Labels, fill_value: MtsArray, sort_samples: bool) -> Result<TensorMap, Error> {
         let ptr = unsafe {
             crate::c_api::mts_tensormap_keys_to_properties(
                 self.ptr,
                 keys_to_move.as_mts_labels_t(),
-                fill_value,
+                fill_value.into_raw(),
                 sort_samples,
             )
         };
@@ -735,21 +735,21 @@ mod tests {
 
     fn test_tensor() -> TensorMap {
         let block_1 = TensorBlock::new(
-            ndarray::ArcArray::from_elem(vec![2, 3], 1.0),
+            ndarray::Array::from_elem(vec![2, 3], 1.0),
             &Labels::new(["samples"], &[[0], [1]]),
             &[],
             &Labels::new(["properties"], &[[-2], [0], [1]]),
         ).unwrap();
 
         let block_2 = TensorBlock::new(
-            ndarray::ArcArray::from_elem(vec![1, 1], 3.0),
+            ndarray::Array::from_elem(vec![1, 1], 3.0),
             &Labels::new(["samples"], &[[1]]),
             &[],
             &Labels::new(["properties"], &[[1]]),
         ).unwrap();
 
         let block_3 = TensorBlock::new(
-            ndarray::ArcArray::from_elem(vec![3, 2], -4.0),
+            ndarray::Array::from_elem(vec![3, 2], -4.0),
             &Labels::new(["samples"], &[[0], [1], [3]]),
             &[],
             &Labels::new(["properties"], &[[-2], [1]]),
@@ -776,7 +776,10 @@ mod tests {
         assert_eq!(tensor.blocks_matching(&selection).unwrap(), [0]);
 
         let block = tensor.block(&selection).unwrap();
-        assert_eq!(block.values().shape().unwrap(), [2, 3]);
+        {
+            let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
+            assert_eq!(values.shape(), [2, 3]);
+        }
 
         let selection = Labels::new(["other"], &[[0]]);
         assert!(tensor.block_matching(&selection).is_err());
@@ -799,12 +802,13 @@ mod tests {
 
         // iterate over keys & blocks
         for (key, block) in &tensor {
-            assert_eq!(block.values().to_ndarray()[[0, 0]], f64::from(key[0].i32()));
+            let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
+            assert_eq!(values[[0, 0]], f64::from(key[0].i32()));
         }
 
         // iterate over keys & blocks mutably
         for (key, mut block) in &mut tensor {
-            let array = block.values_mut().to_ndarray_mut();
+            let array = block.values_mut().get_ndarray_mut::<f64>();
             *array *= 2.0;
             assert_eq!(array[[0, 0]], 2.0 * f64::from(key[0].i32()));
         }
@@ -819,12 +823,13 @@ mod tests {
 
         // iterate over keys & blocks
         tensor.par_iter().for_each(|(key, block)| {
-            assert_eq!(block.values().to_ndarray()[[0, 0]], f64::from(key[0].i32()));
+            let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
+            assert_eq!(values[[0, 0]], f64::from(key[0].i32()));
         });
 
         // iterate over keys & blocks mutably
         tensor.par_iter_mut().for_each(|(key, mut block)| {
-            let array = block.values_mut().to_ndarray_mut();
+            let array = block.values_mut().get_ndarray_mut::<f64>();
             *array *= 2.0;
             assert_eq!(array[[0, 0]], 2.0 * f64::from(key[0].i32()));
         });

--- a/rust/metatensor/tests/components-to-properties.rs
+++ b/rust/metatensor/tests/components-to-properties.rs
@@ -1,21 +1,19 @@
 use metatensor::{TensorBlock, TensorMap, Labels};
 
-use ndarray::ArcArray;
-
 mod utils;
 use utils::example_labels;
 
 #[test]
 fn one_component() {
     let mut block = TensorBlock::new(
-        ArcArray::from_elem(vec![3, 2, 3], 1.0),
+        ndarray::Array::from_elem(vec![3, 2, 3], 1.0),
         &example_labels(vec!["samples"], vec![[0], [1], [2]]),
         &[example_labels(vec!["components"], vec![[0], [1]])],
         &example_labels(vec!["properties"], vec![[0], [1], [2]]),
     ).unwrap();
 
     let gradient = TensorBlock::new(
-        ArcArray::from_elem(vec![2, 2, 3], 11.0),
+        ndarray::Array::from_elem(vec![2, 2, 3], 11.0),
         &example_labels(vec!["sample", "parameter"], vec![[0, 2], [1, 2]]),
         &[example_labels(vec!["components"], vec![[0], [1]])],
         &example_labels(vec!["properties"], vec![[0], [1], [2]]),
@@ -43,7 +41,8 @@ fn one_component() {
     assert_eq!(block.properties()[4], [1, 1]);
     assert_eq!(block.properties()[5], [1, 2]);
 
-    assert_eq!(block.values().as_ndarray(), ArcArray::from_elem(vec![3, 6], 1.0));
+    let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, ndarray::Array::from_elem(vec![3, 6], 1.0));
 
     let gradient = block.gradient("parameter").unwrap();
     assert_eq!(gradient.samples().names(), ["sample", "parameter"]);
@@ -51,12 +50,13 @@ fn one_component() {
     assert_eq!(gradient.samples()[0], [0, 2]);
     assert_eq!(gradient.samples()[1], [1, 2]);
 
-    assert_eq!(gradient.values().as_ndarray(), ArcArray::from_elem(vec![2, 6], 11.0));
+    let values = gradient.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, ndarray::Array::from_elem(vec![2, 6], 11.0));
 }
 
 #[test]
 fn multiple_components() {
-    let data = ArcArray::from_shape_vec(vec![2, 2, 3, 2], vec![
+    let data = ndarray::Array::from_shape_vec(vec![2, 2, 3, 2], vec![
         1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 5.0, 5.0, 6.0, 6.0,
         -1.0, 1.0, -2.0, 2.0, -3.0, 3.0, -4.0, 4.0, -5.0, 5.0, -6.0, 6.0,
     ]).unwrap();
@@ -75,7 +75,7 @@ fn multiple_components() {
     ).unwrap();
 
     let gradient = TensorBlock::new(
-        ArcArray::from_elem(vec![3, 2, 3, 2], 11.0),
+        ndarray::Array::from_elem(vec![3, 2, 3, 2], 11.0),
         &example_labels(vec!["sample", "parameter"], vec![[0, 2], [0, 3], [1, 2]]),
         &components,
         &properties,
@@ -106,11 +106,12 @@ fn multiple_components() {
     assert_eq!(block.properties()[2], [1, 0]);
     assert_eq!(block.properties()[3], [1, 1]);
 
-    let expected = ArcArray::from_shape_vec(vec![2, 3, 4], vec![
+    let expected = ndarray::Array::from_shape_vec(vec![2, 3, 4], vec![
         1.0, 1.0, 4.0, 4.0, 2.0, 2.0, 5.0, 5.0, 3.0, 3.0, 6.0, 6.0,
         -1.0, 1.0, -4.0, 4.0, -2.0, 2.0, -5.0, 5.0, -3.0, 3.0, -6.0, 6.0,
     ]).unwrap();
-    assert_eq!(block.values().as_ndarray(), expected);
+    let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, expected);
 
     let gradient = block.gradient("parameter").unwrap();
     assert_eq!(gradient.samples().names(), ["sample", "parameter"]);
@@ -119,5 +120,6 @@ fn multiple_components() {
     assert_eq!(gradient.samples()[1], [0, 3]);
     assert_eq!(gradient.samples()[2], [1, 2]);
 
-    assert_eq!(gradient.values().as_ndarray(), ArcArray::from_elem(vec![3, 3, 4], 11.0));
+    let values = gradient.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, ndarray::Array::from_elem(vec![3, 3, 4], 11.0));
 }

--- a/rust/metatensor/tests/keys-to-properties.rs
+++ b/rust/metatensor/tests/keys-to-properties.rs
@@ -5,7 +5,6 @@ use metatensor::{Labels, TensorMap};
 mod utils;
 use utils::{example_tensor, example_block, example_labels, make_fill_value};
 
-use ndarray::ArrayD;
 
 #[test]
 fn sorted_samples() {
@@ -32,14 +31,15 @@ fn sorted_samples() {
         example_labels(vec!["key_1", "properties"], vec![[0, 0], [1, 3], [1, 4], [1, 5]])
     );
 
-    let expected = ArrayD::from_shape_vec(vec![5, 1, 4], vec![
+    let expected = ndarray::Array::from_shape_vec(vec![5, 1, 4], vec![
         1.0, 2.0, 2.0, 2.0,
         0.0, 2.0, 2.0, 2.0,
         1.0, 0.0, 0.0, 0.0,
         0.0, 2.0, 2.0, 2.0,
         1.0, 0.0, 0.0, 0.0,
     ]).unwrap();
-    assert_eq!(block.values().as_ndarray(), expected);
+    let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, expected);
 
     let gradient_1 = block.gradient("parameter").unwrap();
     assert_eq!(
@@ -47,17 +47,19 @@ fn sorted_samples() {
         example_labels(vec!["sample", "parameter"], vec![[0, -2], [0, 3], [3, -2], [4, 3]])
     );
 
-    let expected = ArrayD::from_shape_vec(vec![4, 1, 4], vec![
+    let expected = ndarray::Array::from_shape_vec(vec![4, 1, 4], vec![
         11.0, 12.0, 12.0, 12.0,
         0.0, 12.0, 12.0, 12.0,
         0.0, 12.0, 12.0, 12.0,
         11.0, 0.0, 0.0, 0.0,
     ]).unwrap();
-    assert_eq!(gradient_1.values().as_ndarray(), expected);
+    let values = gradient_1.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, expected);
 
     // The new second block contains the old third block
     let block = tensor.block_by_id(1);
-    assert_eq!(block.values().as_ndarray(), ArrayD::from_elem(vec![4, 3, 1], 3.0));
+    let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, ndarray::Array::from_elem(vec![4, 3, 1], 3.0));
 
     assert_eq!(
         block.properties(),
@@ -66,7 +68,8 @@ fn sorted_samples() {
 
     // The new third block contains the old fourth block
     let block = tensor.block_by_id(2);
-    assert_eq!(block.values().as_ndarray(), ArrayD::from_elem(vec![4, 3, 1], 4.0));
+    let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, ndarray::Array::from_elem(vec![4, 3, 1], 4.0));
     assert_eq!(
         block.properties(),
         example_labels(vec!["key_1", "properties"], vec![[2, 0]])
@@ -254,24 +257,26 @@ fn user_provided_entries() {
         ])
     );
 
-    let expected = ArrayD::from_shape_vec(vec![5, 1, 8], vec![
+    let expected = ndarray::Array::from_shape_vec(vec![5, 1, 8], vec![
         1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0,
         0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0,
         1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0,
         0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0,
         1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0,
     ]).unwrap();
-    assert_eq!(block.values().as_ndarray(), expected);
+    let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, expected);
 
     // second block also contains the new property chanel even if it was not
     // merged with another block
     let block = tensor.block_by_id(1);
-    let expected = ArrayD::from_shape_vec(vec![3, 1, 8], vec![
+    let expected = ndarray::Array::from_shape_vec(vec![3, 1, 8], vec![
         3.0, 3.0, 3.0, 3.0, 0.0, 0.0, 0.0, 0.0,
         3.0, 3.0, 3.0, 3.0, 0.0, 0.0, 0.0, 0.0,
         3.0, 3.0, 3.0, 3.0, 0.0, 0.0, 0.0, 0.0,
     ]).unwrap();
-    assert_eq!(block.values().as_ndarray(), expected);
+    let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, expected);
 
     assert_eq!(
         block.properties(),
@@ -307,18 +312,20 @@ fn user_provided_entries() {
     );
 
     // only data from the first block was kept
-    let expected = ArrayD::from_shape_vec(vec![5, 1, 4], vec![
+    let expected = ndarray::Array::from_shape_vec(vec![5, 1, 4], vec![
         1.0, 1.0, 1.0, 1.0,
         0.0, 0.0, 0.0, 0.0,
         1.0, 1.0, 1.0, 1.0,
         0.0, 0.0, 0.0, 0.0,
         1.0, 1.0, 1.0, 1.0,
     ]).unwrap();
-    assert_eq!(block.values().as_ndarray(), expected);
+    let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, expected);
 
     // second block stayed the same, only properties labels changed
     let block = tensor.block_by_id(1);
-    assert_eq!(block.values().as_ndarray(), ArrayD::from_elem(vec![3, 1, 4], 3.0));
+    let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, ndarray::Array::from_elem(vec![3, 1, 4], 3.0));
 
     assert_eq!(
         block.properties(),
@@ -353,23 +360,25 @@ fn user_provided_entries() {
         ])
     );
 
-    let expected = ArrayD::from_shape_vec(vec![5, 1, 12], vec![
+    let expected = ndarray::Array::from_shape_vec(vec![5, 1, 12], vec![
         1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 0.0, 0.0, 0.0, 0.0,
         0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0, 0.0, 0.0, 0.0, 0.0,
         1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
         0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0, 0.0, 0.0, 0.0, 0.0,
         1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
     ]).unwrap();
-    assert_eq!(block.values().as_ndarray(), expected);
+    let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, expected);
 
     // Second block
     let block = tensor.block_by_id(1);
-    let expected = ArrayD::from_shape_vec(vec![3, 1, 12], vec![
+    let expected = ndarray::Array::from_shape_vec(vec![3, 1, 12], vec![
         3.0, 3.0, 3.0, 3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
         3.0, 3.0, 3.0, 3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
         3.0, 3.0, 3.0, 3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
     ]).unwrap();
-    assert_eq!(block.values().as_ndarray(), expected);
+    let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, expected);
 
     assert_eq!(
         block.properties(),
@@ -391,8 +400,7 @@ fn nan_fill_value() {
     // The new first block merges blocks with key_1=0 and key_1=1.
     // Samples present in one block but missing in the other should be NaN.
     let block = tensor.block_by_id(0);
-    let block_values = block.values();
-    let values = block_values.as_ndarray();
+    let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
 
     // Sample 0 exists in both blocks -> values from block_1 (1.0) and block_2 (2.0)
     assert_eq!(values[[0, 0, 0]], 1.0);
@@ -408,8 +416,7 @@ fn nan_fill_value() {
 
     // Second block (key_2=1) only has key_1=0, so the key_1=1 columns should be NaN
     let block = tensor.block_by_id(1);
-    let block_values = block.values();
-    let values = block_values.as_ndarray();
+    let values = block.values().to_ndarray_lock::<f64>().read().unwrap();
     assert_eq!(values[[0, 0, 0]], 3.0);
     assert!(values[[0, 0, 4]].is_nan());
 }

--- a/rust/metatensor/tests/keys-to-samples.rs
+++ b/rust/metatensor/tests/keys-to-samples.rs
@@ -3,8 +3,6 @@ use metatensor::{Labels, TensorMap};
 mod utils;
 use utils::{example_tensor, example_block, make_fill_value};
 
-use ndarray::ArrayD;
-
 #[test]
 fn sorted_samples() {
     let keys_to_move = Labels::empty(vec!["key_2"]);
@@ -18,14 +16,16 @@ fn sorted_samples() {
 
     // The first two blocks are not modified
     let block_1 = tensor.block_by_id(0);
-    assert_eq!(block_1.values().as_ndarray(), ArrayD::from_elem(vec![3, 1, 1], 1.0));
+    let values = block_1.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, ndarray::Array::from_elem(vec![3, 1, 1], 1.0));
     assert_eq!(block_1.samples().count(), 3);
     assert_eq!(block_1.samples()[0], [0, 0]);
     assert_eq!(block_1.samples()[1], [2, 0]);
     assert_eq!(block_1.samples()[2], [4, 0]);
 
     let block_2 = tensor.block_by_id(1);
-    assert_eq!(block_2.values().as_ndarray(), ArrayD::from_elem(vec![3, 1, 3], 2.0));
+    let values = block_2.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, ndarray::Array::from_elem(vec![3, 1, 3], 2.0));
     assert_eq!(block_2.samples().count(), 3);
     assert_eq!(block_2.samples()[0], [0, 0]);
     assert_eq!(block_2.samples()[1], [1, 0]);
@@ -55,7 +55,7 @@ fn sorted_samples() {
     assert_eq!(block_3.properties().count(), 1);
     assert_eq!(block_3.properties()[0], [0]);
 
-    let expected = ArrayD::from_shape_vec(vec![8, 3, 1], vec![
+    let expected = ndarray::Array::from_shape_vec(vec![8, 3, 1], vec![
         3.0, 3.0, 3.0,
         4.0, 4.0, 4.0,
         4.0, 4.0, 4.0,
@@ -65,7 +65,8 @@ fn sorted_samples() {
         3.0, 3.0, 3.0,
         3.0, 3.0, 3.0,
     ]).unwrap();
-    assert_eq!(block_3.values().as_ndarray(), expected);
+    let values = block_3.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, expected);
 
     let gradient_3 = block_3.gradient("parameter").unwrap();
     assert_eq!(gradient_3.samples().names(), ["sample", "parameter"]);
@@ -74,12 +75,13 @@ fn sorted_samples() {
     assert_eq!(gradient_3.samples()[1], [4, -2]);
     assert_eq!(gradient_3.samples()[2], [5, 3]);
 
-    let expected = ArrayD::from_shape_vec(vec![3, 3, 1], vec![
+    let expected = ndarray::Array::from_shape_vec(vec![3, 3, 1], vec![
         14.0, 14.0, 14.0,
         13.0, 13.0, 13.0,
         14.0, 14.0, 14.0,
     ]).unwrap();
-    assert_eq!(gradient_3.values().as_ndarray(), expected);
+    let values = gradient_3.values().to_ndarray_lock::<f64>().read().unwrap();
+    assert_eq!(*values, expected);
 }
 
 #[test]

--- a/rust/metatensor/tests/serialization.rs
+++ b/rust/metatensor/tests/serialization.rs
@@ -214,7 +214,7 @@ mod dtype_serialization {
             #[test]
             fn $name() {
                 let (samples, properties) = make_labels();
-                let data = ndarray::ArcArray::<$ty, _>::from_elem(vec![2, 3], $val);
+                let data = ndarray::Array::<$ty, _>::from_elem(vec![2, 3], $val);
                 let block = TensorBlock::new(data, &samples, &[], &properties).unwrap();
 
                 let mut buf = Vec::new();
@@ -243,7 +243,7 @@ mod dtype_serialization {
     #[test]
     fn f64_roundtrip() {
         let (samples, properties) = make_labels();
-        let data = ndarray::ArcArray::<f64, _>::from_elem(vec![2, 3], 3.41);
+        let data = ndarray::Array::<f64, _>::from_elem(vec![2, 3], 3.41);
         let block = TensorBlock::new(data, &samples, &[], &properties).unwrap();
 
         let mut buf = Vec::new();
@@ -264,7 +264,7 @@ mod dtype_serialization {
         properties.add(&[0]);
         properties.add(&[1]);
         let properties = properties.finish();
-        let data = ndarray::ArcArray::<f64, _>::from_elem(vec![0, 2], 0.0);
+        let data = ndarray::Array::<f64, _>::from_elem(vec![0, 2], 0.0);
         let block = TensorBlock::new(data, &samples, &[], &properties).unwrap();
 
         let mut buf = Vec::new();

--- a/rust/metatensor/tests/utils/mod.rs
+++ b/rust/metatensor/tests/utils/mod.rs
@@ -1,15 +1,12 @@
 #![allow(dead_code)]
 #![allow(clippy::needless_return)]
 
-use metatensor::{LabelsBuilder, Labels, TensorBlock, TensorMap, Array};
-use metatensor::c_api::mts_array_t;
+use metatensor::{MtsArray, Labels, LabelsBuilder, TensorBlock, TensorMap};
 
-use ndarray::ArcArray;
 
 /// Create an mts_array_t fill value with the given scalar
-pub fn make_fill_value(scalar: f64) -> mts_array_t {
-    let data: Box<dyn Array> = Box::new(ArcArray::from_elem(vec![], scalar));
-    mts_array_t::from(data)
+pub fn make_fill_value(scalar: f64) -> MtsArray {
+    MtsArray::from(ndarray::Array::from_elem(vec![], scalar))
 }
 
 pub fn example_labels<const N: usize>(names: Vec<&str>, values: Vec<[i32; N]>) -> Labels {
@@ -34,7 +31,7 @@ pub fn example_block(
 
     let shape = vec![samples.count(), components[0].count(), properties.count()];
     let mut block = TensorBlock::new(
-        ArcArray::from_elem(shape, values),
+        ndarray::Array::from_elem(shape, values),
         &samples,
         &components,
         &properties,
@@ -44,7 +41,7 @@ pub fn example_block(
 
     let shape = vec![gradient_samples.count(), components[0].count(), properties.count()];
     let gradient = TensorBlock::new(
-        ArcArray::from_elem(shape, gradient_values),
+        ndarray::Array::from_elem(shape, gradient_values),
         &gradient_samples,
         &components,
         &properties,


### PR DESCRIPTION
This type can be safely shared through dlpack with other languages.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
