### PR TITLE
Release metatensor-operations and -learn v0.5.0rc1

### DIFF
--- a/python/metatensor_learn/setup.py
+++ b/python/metatensor_learn/setup.py
@@ -13,7 +13,7 @@ ROOT = pathlib.Path(__file__).parent.resolve()
 METATENSOR_CORE = (ROOT / ".." / "metatensor_core").resolve()
 METATENSOR_OPERATIONS = (ROOT / ".." / "metatensor_operations").resolve()
 
-METATENSOR_LEARN_VERSION = "0.4.0"
+METATENSOR_LEARN_VERSION = "0.5.0.rc1"
 
 
 class bdist_egg_disabled(bdist_egg):
@@ -142,7 +142,7 @@ if __name__ == "__main__":
         install_requires.append(f"metatensor-core @ {METATENSOR_CORE.as_uri()}")
     else:
         # we are building from a sdist/installing from a wheel
-        install_requires.append("metatensor-operations >=0.4.0,<0.5.0")
+        install_requires.append("metatensor-operations >=0.5.0.rc1,<0.6.0")
         install_requires.append("metatensor-core >=0.2.0rc1,<0.3.0")
 
     setup(

--- a/python/metatensor_operations/CHANGELOG.md
+++ b/python/metatensor_operations/CHANGELOG.md
@@ -23,6 +23,14 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   instead of `site-packages/metatensor/operations`. The operations should still
   be imported using `import metatensor as mts; mts.join(...)`
 
+### Added
+
+- Operations for reductions over properties: `mean_over_properties`,
+  `mean_over_properties_block`, `std_over_properties`,
+  `std_over_properties_block`, `sum_over_properties`,
+  `sum_over_properties_block`, `var_over_properties`, and
+  `var_over_properties_block`.
+
 ## [Version 0.4.0](https://github.com/metatensor/metatensor/releases/tag/metatensor-operations-v0.4.0) - 2025-10-29
 
 ### Added

--- a/python/metatensor_operations/setup.py
+++ b/python/metatensor_operations/setup.py
@@ -12,7 +12,7 @@ from setuptools.command.sdist import sdist
 ROOT = pathlib.Path(__file__).parent.resolve()
 METATENSOR_CORE = (ROOT / ".." / "metatensor_core").resolve()
 
-METATENSOR_OPERATIONS_VERSION = "0.4.0"
+METATENSOR_OPERATIONS_VERSION = "0.5.0.rc1"
 
 
 class bdist_egg_disabled(bdist_egg):


### PR DESCRIPTION
The main change here is #1048, plus a dependency on the new metatensor-core