### PR TITLE
Overhaul error handling

### DIFF
--- a/docs/src/core/reference/c/misc.rst
+++ b/docs/src/core/reference/c/misc.rst
@@ -33,17 +33,11 @@ Error handling
 
 .. doxygenfunction:: mts_last_error
 
+.. doxygenfunction:: mts_set_last_error
+
 .. doxygenfunction:: mts_disable_panic_printing
 
-.. doxygentypedef:: mts_status_t
-
-.. doxygendefine:: MTS_SUCCESS
-
-.. doxygendefine:: MTS_INVALID_PARAMETER_ERROR
-
-.. doxygendefine:: MTS_BUFFER_SIZE_ERROR
-
-.. doxygendefine:: MTS_INTERNAL_ERROR
+.. doxygenenum:: mts_status_t
 
 
 Serialization

--- a/julia/src/generated/_c_api.jl
+++ b/julia/src/generated/_c_api.jl
@@ -14,7 +14,6 @@ else
 end
 
 Cbool = Cuchar
-mts_status_t = Int32
 mts_data_origin_t = UInt64
 
 mts_create_array_callback_t = Ptr{Cvoid}  # TODO: actual type
@@ -41,12 +40,6 @@ end
 
 
 # ===== Macros definitions
-MTS_SUCCESS = 0
-MTS_INVALID_PARAMETER_ERROR = 1
-MTS_IO_ERROR = 2
-MTS_SERIALIZATION_ERROR = 3
-MTS_BUFFER_SIZE_ERROR = 254
-MTS_INTERNAL_ERROR = 255
 
 
 # ===== Enum definitions
@@ -72,6 +65,17 @@ const kDLFloat8_e8m0fnu = DLDataTypeCode(14)
 const kDLFloat6_e2m3fn = DLDataTypeCode(15)
 const kDLFloat6_e3m2fn = DLDataTypeCode(16)
 const kDLFloat4_e2m1fn = DLDataTypeCode(17)
+
+
+# enum mts_status_t
+const mts_status_t = UInt32
+const MTS_SUCCESS = mts_status_t(0)
+const MTS_INVALID_PARAMETER_ERROR = mts_status_t(1)
+const MTS_IO_ERROR = mts_status_t(2)
+const MTS_SERIALIZATION_ERROR = mts_status_t(3)
+const MTS_BUFFER_SIZE_ERROR = mts_status_t(4)
+const MTS_CALLBACK_ERROR = mts_status_t(254)
+const MTS_INTERNAL_ERROR = mts_status_t(255)
 
 
 # ===== Struct definitions
@@ -127,11 +131,19 @@ function mts_version()
     )
 end
 
-function mts_last_error()
+function mts_last_error(message::Ptr{Ptr{Cchar}}, origin::Ptr{Ptr{Cchar}}, data::Ptr{Ptr{Cvoid}})
     ccall((:mts_last_error, libmetatensor), 
-        Ptr{Cchar},
-        (),
-        
+        mts_status_t,
+        (Ptr{Ptr{Cchar}}, Ptr{Ptr{Cchar}}, Ptr{Ptr{Cvoid}},),
+        message, origin, data
+    )
+end
+
+function mts_set_last_error(message::Ptr{Cchar}, origin::Ptr{Cchar}, data::Ptr{Cvoid}, data_deleter::Ptr{Cvoid} #= (Ptr{Cvoid}) -> Cvoid =#)
+    ccall((:mts_set_last_error, libmetatensor), 
+        mts_status_t,
+        (Ptr{Cchar}, Ptr{Cchar}, Ptr{Cvoid}, Ptr{Cvoid} #= (Ptr{Cvoid}) -> Cvoid =#,),
+        message, origin, data, data_deleter
     )
 end
 

--- a/metatensor-core/CHANGELOG.md
+++ b/metatensor-core/CHANGELOG.md
@@ -39,6 +39,8 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
   allowing to remove the need to copy all data back to CPU when creating labels.
   As part of this, `mts_labels_create` is now `mts_labels`, and
   `mts_labels_create_assume_unique` is now `mts_labels_assume_unique`.
+- `mts_last_error` can now return custom data and error origin together with the
+  last error message. These can be set by a new function `mts_set_last_error`.
 
 #### Added
 
@@ -46,6 +48,10 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
   `mts_block_dtype`, `mts_tensormap_dtype` to access dtype and device of metatensor data.
 - There are new functions to work with `mts_labels_t`: `mts_labels_dimensions`,
   `mts_labels_values`, and `mts_labels_values_cpu`.
+- `mts_set_last_error` to set the last error that occured in a callback before
+  transferring control back to libmetatensor. The data set by this function can
+  then be retrieved with `mts_last_error` and used to store and rethrow
+  exceptions across the C API boundary.
 
 ### metatensor-core C++
 

--- a/metatensor-core/include/metatensor.h
+++ b/metatensor-core/include/metatensor.h
@@ -17,36 +17,54 @@
 typedef struct DLManagedTensorVersioned DLManagedTensorVersioned;
 
 /**
- * Status code used when a function succeeded
+ * Status type returned by all functions in the C API.
+ *
+ * The value 0 (`MTS_SUCCESS`) is used to indicate successful operations.
  */
-#define MTS_SUCCESS 0
-
-/**
- * Status code used when a function got an invalid parameter
- */
-#define MTS_INVALID_PARAMETER_ERROR 1
-
-/**
- * Status code indicating I/O error when loading/writing `mts_tensormap_t` to a file
- */
-#define MTS_IO_ERROR 2
-
-/**
- * Status code indicating errors in the serialization format when
- * loading/writing `mts_tensormap_t` to a file
- */
-#define MTS_SERIALIZATION_ERROR 3
-
-/**
- * Status code used when a memory buffer is too small to fit the requested data
- */
-#define MTS_BUFFER_SIZE_ERROR 254
-
-/**
- * Status code used when there was an internal error, i.e. there is a bug
- * inside metatensor itself
- */
-#define MTS_INTERNAL_ERROR 255
+enum mts_status_t
+#ifdef __cplusplus
+  : int32_t
+#endif // __cplusplus
+ {
+  /**
+   * Status code used when a function succeeded
+   */
+  MTS_SUCCESS = 0,
+  /**
+   * Status code used when a function got an invalid parameter
+   */
+  MTS_INVALID_PARAMETER_ERROR = 1,
+  /**
+   * Status code indicating I/O error when loading/writing `mts_tensormap_t`
+   * to a file
+   */
+  MTS_IO_ERROR = 2,
+  /**
+   * Status code indicating errors in the serialization format when
+   * loading/writing `mts_tensormap_t` to a file
+   */
+  MTS_SERIALIZATION_ERROR = 3,
+  /**
+   * Status code used when a memory buffer is too small to fit the requested
+   * data
+   */
+  MTS_BUFFER_SIZE_ERROR = 4,
+  /**
+   * Status code indicating errors that comes from callbacks provided by the
+   * user of metatensor. The error message and arbitrary custom data can be
+   * stored using `mts_set_last_error` inside the callback, and retrieved
+   * later with `mts_last_error`.
+   */
+  MTS_CALLBACK_ERROR = 254,
+  /**
+   * Status code used when there was an internal error, i.e. there is a bug
+   * inside metatensor itself
+   */
+  MTS_INTERNAL_ERROR = 255,
+};
+#ifndef __cplusplus
+typedef int32_t mts_status_t;
+#endif // __cplusplus
 
 /**
  * Basic building block for tensor map. A single block contains a n-dimensional
@@ -73,16 +91,6 @@ typedef struct mts_labels_t mts_labels_t;
  * Opaque type representing a `TensorMap`.
  */
 typedef struct mts_tensormap_t mts_tensormap_t;
-
-/**
- * Status type returned by all functions in the C API.
- *
- * The value 0 (`MTS_SUCCESS`) is used to indicate successful operations,
- * positive values are used by this library to indicate errors, while negative
- * values are reserved for users of this library to indicate their own errors
- * in callbacks.
- */
-typedef int32_t mts_status_t;
 
 /**
  * A single 64-bit integer representing a data origin (numpy ndarray, rust
@@ -144,9 +152,13 @@ typedef struct mts_array_t {
   void (*destroy)(void *array);
   /**
    * This function needs to store the "data origin" for this array in
-   * `origin`. Users of `mts_array_t` should register a single data
-   * origin with `mts_register_data_origin`, and use it for all compatible
-   * arrays.
+   * `origin`. Users of `mts_array_t` should register a single data origin
+   * with `mts_register_data_origin`, and use it for all compatible arrays.
+   *
+   * This function should return `MTS_SUCCESS` on success, or
+   * `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+   * should call `mts_set_last_error` with an appropriate error message
+   * before returning.
    */
   mts_status_t (*origin)(const void *array, mts_data_origin_t *origin);
   /**
@@ -154,12 +166,22 @@ typedef struct mts_array_t {
    * via DLPack.
    *
    * The implementation must store the device information in `*device`.
+   *
+   * This function should return `MTS_SUCCESS` on success, or
+   * `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+   * should call `mts_set_last_error` with an appropriate error message
+   * before returning.
    */
   mts_status_t (*device)(const void *array, DLDevice *device);
   /**
    * Query the data type of this array without a full DLPack export.
    *
    * The implementation must store the data type in `*dtype`.
+   *
+   * This function should return `MTS_SUCCESS` on success, or
+   * `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+   * should call `mts_set_last_error` with an appropriate error message
+   * before returning.
    */
   mts_status_t (*dtype)(const void *array, DLDataType *dtype);
   /**
@@ -199,6 +221,11 @@ typedef struct mts_array_t {
    * responsible for calling its `deleter` function when the tensor is no
    * longer needed. The lifetime of the `DLManagedTensorVersioned` must not
    * exceed the lifetime of the `mts_array_t` it was created from.
+   *
+   * This function should return `MTS_SUCCESS` on success, or
+   * `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+   * should call `mts_set_last_error` with an appropriate error message
+   * before returning.
    */
   mts_status_t (*as_dlpack)(void *array,
                             DLManagedTensorVersioned **dl_managed_tensor,
@@ -210,16 +237,31 @@ typedef struct mts_array_t {
    * pointer, and the number of dimension (size of the `*shape` array) in
    * `*shape_count`. If the array is a single scalar, `shape_count` should be
    * set to 0, and the shape pointer to `NULL`.
+   *
+   * This function should return `MTS_SUCCESS` on success, or
+   * `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+   * should call `mts_set_last_error` with an appropriate error message
+   * before returning.
    */
   mts_status_t (*shape)(const void *array, const uintptr_t **shape, uintptr_t *shape_count);
   /**
    * Change the shape of the array managed by this `mts_array_t` to the given
    * `shape`. `shape_count` must contain the number of elements in the
    * `shape` array.
+   *
+   * This function should return `MTS_SUCCESS` on success, or
+   * `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+   * should call `mts_set_last_error` with an appropriate error message
+   * before returning.
    */
   mts_status_t (*reshape)(void *array, const uintptr_t *shape, uintptr_t shape_count);
   /**
    * Swap the axes `axis_1` and `axis_2` in this `array`.
+   *
+   * This function should return `MTS_SUCCESS` on success, or
+   * `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+   * should call `mts_set_last_error` with an appropriate error message
+   * before returning.
    */
   mts_status_t (*swap_axes)(void *array, uintptr_t axis_1, uintptr_t axis_2);
   /**
@@ -233,6 +275,11 @@ typedef struct mts_array_t {
    * with the same dtype as this array. This function should call
    * `fill_value.destroy` if the function pointer is not `NULL` when
    * `fill_value` is no longer needed.
+   *
+   * This function should return `MTS_SUCCESS` on success, or
+   * `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+   * should call `mts_set_last_error` with an appropriate error message
+   * before returning.
    */
   mts_status_t (*create)(const void *array,
                          const uintptr_t *shape,
@@ -244,6 +291,11 @@ typedef struct mts_array_t {
    *
    * The new array is expected to have the same data origin and parameters
    * (data type, data location, etc.)
+   *
+   * This function should return `MTS_SUCCESS` on success, or
+   * `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+   * should call `mts_set_last_error` with an appropriate error message
+   * before returning.
    */
   mts_status_t (*copy)(const void *array, struct mts_array_t *new_array);
   /**
@@ -260,6 +312,11 @@ typedef struct mts_array_t {
    * `array[movements[i].sample_out, ..., movements[i].properties_start_out +
    * x]` for `i` up to `movements_count` and `x` up to
    * `movements[i].properties_length`. All indexes are 0-based.
+   *
+   * This function should return `MTS_SUCCESS` on success, or
+   * `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+   * should call `mts_set_last_error` with an appropriate error message
+   * before returning.
    */
   mts_status_t (*move_data)(void *output,
                             const void *input,
@@ -291,6 +348,11 @@ typedef uint8_t *(*mts_realloc_buffer_t)(void *user_data, uint8_t *ptr, uintptr_
  *
  * The newly created array should live on CPU, since metatensor will use
  * `mts_array_t.data` to get the data pointer and write to it.
+ *
+ * This function should return `MTS_SUCCESS` on success, or
+ * `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+ * should call `mts_set_last_error` with an appropriate error message before
+ * returning.
  */
 typedef mts_status_t (*mts_create_array_callback_t)(const uintptr_t *shape,
                                                     uintptr_t shape_count,
@@ -321,9 +383,28 @@ const char *mts_version(void);
 /**
  * Get the last error message that was created on the current thread.
  *
- * @returns the last error message, as a NULL-terminated string
+ * @param message if not NULL, this will be set to the last error message, as a
+ *        NULL-terminated string
+ * @param origin if not NULL, this will be set to the origin of the last error,
+ *        as a NULL-terminated string
+ * @param data if not NULL, this will be set to the custom data of the last error
+ *
+ * @returns The status code of this operation.
  */
-const char *mts_last_error(void);
+mts_status_t mts_last_error(const char **message, const char **origin, void **data);
+
+/**
+ * Set the last error message for the current thread.
+ *
+ * This is useful when the error is created in a callback provided by the user
+ * of metatensor.
+ *
+ * @param message the error message to set, as a NULL-terminated string
+ */
+mts_status_t mts_set_last_error(const char *message,
+                                const char *origin,
+                                void *data,
+                                void (*data_deleter)(void*));
 
 /**
  * Create a new set of Labels from the given dimension names and values

--- a/metatensor-core/include/metatensor/errors.hpp
+++ b/metatensor-core/include/metatensor/errors.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstring>
+#include <cstdio>
+
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -15,49 +18,26 @@ namespace metatensor {
     };
 
     namespace details {
-        /// Singleton class storing the last exception throw by a C++ callback.
-        ///
-        /// When passing callbacks from C++ to Rust, we need to convert exceptions
-        /// into status code (see the `catch` blocks in this file). This class
-        /// allows to save the message associated with an exception, and rethrow an
-        /// exception with the same message later (the actual exception type is lost
-        /// in the process).
-        class LastCxxError {
-        public:
-            /// Set the last error message to `message`
-            static void set_message(std::string message) {
-                auto& stored_message = LastCxxError::get();
-                stored_message = std::move(message);
-            }
-
-            /// Get the last error message
-            static const std::string& message() {
-                return LastCxxError::get();
-            }
-
-        private:
-            static std::string& get() {
-                #pragma clang diagnostic push
-                #pragma clang diagnostic ignored "-Wexit-time-destructors"
-                /// we are using a per-thread static value to store the last C++
-                /// exception.
-                static thread_local std::string STORED_MESSAGE;
-                #pragma clang diagnostic pop
-
-                return STORED_MESSAGE;
-            }
-        };
-
         /// Check if a return status from the C API indicates an error, and if it is
         /// the case, throw an exception of type `metatensor::Error` with the last
         /// error message from the library.
         inline void check_status(mts_status_t status) {
             if (status == MTS_SUCCESS) {
                 return;
-            } else if (status > 0) {
-                throw Error(mts_last_error());
-            } else { // status < 0
-                throw Error("error in C++ callback: " + LastCxxError::message());
+            } else if (status == MTS_CALLBACK_ERROR) {
+                const char* message = nullptr;
+                const char* origin = nullptr;
+                void* data = nullptr;
+                mts_last_error(&message, &origin, &data);
+                if (origin != nullptr &&std::strcmp(origin, "C++ exception") == 0 && data != nullptr) {
+                    std::rethrow_exception(*static_cast<std::exception_ptr*>(data));
+                } else {
+                    throw Error(message == nullptr ? "unknown error" : message);
+                }
+            } else {
+                const char* message = nullptr;
+                mts_last_error(&message, nullptr, nullptr);
+                throw Error(message == nullptr ? "unknown error" : message);
             }
         }
 
@@ -71,23 +51,57 @@ namespace metatensor {
             try {
                 function(std::move(args)...);
                 return MTS_SUCCESS;
-            } catch (const std::exception& e) {
-                details::LastCxxError::set_message(e.what());
-                return -1;
             } catch (...) {
-                details::LastCxxError::set_message("error was not an std::exception");
-                return -128;
+                auto* exception_ptr = new std::exception_ptr(std::current_exception());
+
+                const char* message = nullptr;
+                try {
+                    std::rethrow_exception(*exception_ptr);
+                } catch (const std::exception& e) {
+                    message = e.what();
+                } catch (...) {
+                    message = "C++ code threw an exception that was not an std::exception";
+                }
+
+                auto status = mts_set_last_error(
+                    message,
+                    "C++ exception",
+                    exception_ptr,
+                    [](void *ptr) { delete static_cast<std::exception_ptr*>(ptr); }
+                );
+
+                if (status != MTS_SUCCESS) {
+                    // If we failed to set the error, we are in a very bad state,
+                    // but we should still try to report the original error
+                    // message if possible.
+                    std::fprintf(stderr, "INTERNAL ERROR: unable to set last error after C++ callback failure (status: %d). ", status);
+                    if (message != nullptr) {
+                        fprintf(stderr, "C++ error was: %s\n", message);
+                    } else {
+                        fprintf(stderr, "Unknown C++ error\n");
+                    }
+                    delete exception_ptr;
+                }
+
+                return MTS_CALLBACK_ERROR;
             }
         }
 
         /// Check if a pointer allocated by the C API is null, and if it is the
-        /// case, throw an exception of type `metatensor::Error` with the last error
-        /// message from the library.
+        /// case, throw an exception of type `metatensor::Error` with the last
+        /// error message from the library.
         inline void check_pointer(const void* pointer) {
             if (pointer == nullptr) {
-                throw Error(mts_last_error());
+                const char* message = nullptr;
+                const char* origin = nullptr;
+                void* data = nullptr;
+                mts_last_error(&message, &origin, &data);
+                if (std::strcmp(origin, "C++ exception") == 0 && data != nullptr) {
+                    std::rethrow_exception(*static_cast<std::exception_ptr*>(data));
+                } else {
+                    throw Error(message);
+                }
             }
         }
-
     } // namespace details
 } // namespace metatensor

--- a/metatensor-core/include/metatensor/labels.hpp
+++ b/metatensor-core/include/metatensor/labels.hpp
@@ -57,9 +57,7 @@ public:
         labels_ = mts_labels(
             c_dimensions.data(), c_dimensions.size(), std::move(values).release()
         );
-        if (labels_ == nullptr) {
-            throw Error(mts_last_error());
-        }
+        details::check_pointer(labels_);
     }
 
     /// Create a new set of Labels from the given `names` and `values`.
@@ -95,9 +93,7 @@ public:
         labels_ = mts_labels_assume_unique(
             c_dimensions.data(), c_dimensions.size(), std::move(array).release()
         );
-        if (labels_ == nullptr) {
-            throw Error(mts_last_error());
-        }
+        details::check_pointer(labels_);
     }
 
     /// Create an empty set of Labels with the given dimension names.
@@ -138,9 +134,7 @@ public:
         }
 
         labels_ = mts_labels_clone(other.labels_);
-        if (labels_ == nullptr) {
-            throw Error(mts_last_error());
-        }
+        details::check_pointer(labels_);
         return *this;
     }
 

--- a/metatensor-core/src/c_api/io/block.rs
+++ b/metatensor-core/src/c_api/io/block.rs
@@ -167,10 +167,8 @@ fn wrap_create_array(create_array: &mts_create_array_callback_t) -> impl Fn(Vec<
         if status.is_success() {
             return Ok(array);
         } else {
-            return Err(Error::External {
-                status: status,
-                context: "failed to create a new array in mts_block_load".into()
-            });
+            crate::c_api::add_error_context("failed to create a new array in mts_block_load");
+            return Err(Error::CallbackError);
         }
     }
 }

--- a/metatensor-core/src/c_api/io/mod.rs
+++ b/metatensor-core/src/c_api/io/mod.rs
@@ -19,6 +19,11 @@ mod tensor;
 ///
 /// The newly created array should live on CPU, since metatensor will use
 /// `mts_array_t.data` to get the data pointer and write to it.
+///
+/// This function should return `MTS_SUCCESS` on success, or
+/// `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+/// should call `mts_set_last_error` with an appropriate error message before
+/// returning.
 #[allow(non_camel_case_types)]
 type mts_create_array_callback_t = unsafe extern "C" fn(
     shape: *const usize,

--- a/metatensor-core/src/c_api/io/tensor.rs
+++ b/metatensor-core/src/c_api/io/tensor.rs
@@ -198,10 +198,8 @@ fn wrap_create_array(create_array: &mts_create_array_callback_t) -> impl Fn(Vec<
         if status.is_success() {
             return Ok(array);
         } else {
-            return Err(Error::External {
-                status: status,
-                context: "failed to create a new array in mts_tensormap_load".into()
-            });
+            crate::c_api::add_error_context("failed to create a new array in mts_tensormap_load");
+            return Err(Error::CallbackError);
         }
     }
 }

--- a/metatensor-core/src/c_api/mod.rs
+++ b/metatensor-core/src/c_api/mod.rs
@@ -7,9 +7,7 @@ use once_cell::sync::Lazy;
 #[macro_use]
 mod status;
 pub use self::status::{catch_unwind, mts_status_t};
-
-#[cfg(test)]
-pub use self::status::MTS_SUCCESS;
+pub(crate) use self::status::add_error_context;
 
 mod labels;
 mod data;

--- a/metatensor-core/src/c_api/status.rs
+++ b/metatensor-core/src/c_api/status.rs
@@ -1,69 +1,137 @@
 use std::panic::UnwindSafe;
 use std::cell::RefCell;
-use std::os::raw::c_char;
-use std::ffi::CString;
+use std::os::raw::{c_char, c_void};
+use std::ffi::{CString, CStr};
 
 use crate::Error;
+
+#[derive(Debug)]
+struct LastError {
+    message: CString,
+    origin: CString,
+    custom_data: *mut c_void,
+    custom_data_deleter: Option<unsafe extern "C" fn(*mut c_void)>,
+}
+
+impl std::ops::Drop for LastError {
+    fn drop(&mut self) {
+        if let Some(deleter) = self.custom_data_deleter {
+            unsafe { deleter(self.custom_data) };
+        }
+    }
+}
 
 // Save the last error message in thread local storage.
 //
 // This is marginally better than a standard global static value because it
 // allow multiple threads to each have separate errors conditions.
 thread_local! {
-    pub static LAST_ERROR_MESSAGE: RefCell<CString> = RefCell::new(CString::new("").expect("invalid C string"));
+    pub static LAST_ERROR: RefCell<LastError> = RefCell::new(LastError {
+        message: CString::new("").expect("invalid C string"),
+        origin: CString::new("").expect("invalid C string"),
+        custom_data: std::ptr::null_mut(),
+        custom_data_deleter: None,
+    });
+}
+
+/// Add some context to the last error message, by prefixing it with the provided
+pub(crate) fn add_error_context(context: &str) {
+    LAST_ERROR.with(|last_error| {
+        let mut last_error = last_error.borrow_mut();
+        let current_message = last_error.message.to_str().unwrap_or("<invalid UTF-8 in error message>");
+        last_error.message = CString::new(
+            format!("{}: {}", context, current_message)
+        ).expect("error message contains a null byte");
+    });
 }
 
 /// Status type returned by all functions in the C API.
 ///
-/// The value 0 (`MTS_SUCCESS`) is used to indicate successful operations,
-/// positive values are used by this library to indicate errors, while negative
-/// values are reserved for users of this library to indicate their own errors
-/// in callbacks.
-#[repr(transparent)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(non_camel_case_types)]
+/// The value 0 (`MTS_SUCCESS`) is used to indicate successful operations.
+#[repr(i32)]
 #[must_use]
-pub struct mts_status_t(pub(crate) i32);
+#[non_exhaustive]
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum mts_status_t {
+    /// Status code used when a function succeeded
+    MTS_SUCCESS = 0,
+    /// Status code used when a function got an invalid parameter
+    MTS_INVALID_PARAMETER_ERROR = 1,
+    /// Status code indicating I/O error when loading/writing `mts_tensormap_t`
+    /// to a file
+    MTS_IO_ERROR = 2,
+    /// Status code indicating errors in the serialization format when
+    /// loading/writing `mts_tensormap_t` to a file
+    MTS_SERIALIZATION_ERROR = 3,
+    /// Status code used when a memory buffer is too small to fit the requested
+    /// data
+    MTS_BUFFER_SIZE_ERROR = 4,
+    /// Status code indicating errors that comes from callbacks provided by the
+    /// user of metatensor. The error message and arbitrary custom data can be
+    /// stored using `mts_set_last_error` inside the callback, and retrieved
+    /// later with `mts_last_error`.
+    MTS_CALLBACK_ERROR = 254,
+    /// Status code used when there was an internal error, i.e. there is a bug
+    /// inside metatensor itself
+    MTS_INTERNAL_ERROR = 255,
+}
 
 impl mts_status_t {
     pub fn is_success(self) -> bool {
-        self.0 == MTS_SUCCESS
-    }
-
-    pub fn as_i32(self) -> i32 {
-        self.0
+        self == mts_status_t::MTS_SUCCESS
     }
 }
 
-/// Status code used when a function succeeded
-pub const MTS_SUCCESS: i32 = 0;
-/// Status code used when a function got an invalid parameter
-pub const MTS_INVALID_PARAMETER_ERROR: i32 = 1;
-/// Status code indicating I/O error when loading/writing `mts_tensormap_t` to a file
-pub const MTS_IO_ERROR: i32 = 2;
-/// Status code indicating errors in the serialization format when
-/// loading/writing `mts_tensormap_t` to a file
-pub const MTS_SERIALIZATION_ERROR: i32 = 3;
-
-/// Status code used when a memory buffer is too small to fit the requested data
-pub const MTS_BUFFER_SIZE_ERROR: i32 = 254;
-/// Status code used when there was an internal error, i.e. there is a bug
-/// inside metatensor itself
-pub const MTS_INTERNAL_ERROR: i32 = 255;
+impl std::fmt::Display for mts_status_t {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // this is an if instead of a match to allow the catch-all case
+        // at the end, since we can't enforce that callbacks don't return
+        // arbitrary status codes.
+        let code = *self as i32;
+        if code == mts_status_t::MTS_SUCCESS as i32 {
+            write!(f, "MTS_SUCCESS")
+        } else if code == mts_status_t::MTS_INVALID_PARAMETER_ERROR as i32 {
+            write!(f, "MTS_INVALID_PARAMETER_ERROR")
+        } else if code == mts_status_t::MTS_IO_ERROR as i32 {
+            write!(f, "MTS_IO_ERROR")
+        } else if code == mts_status_t::MTS_SERIALIZATION_ERROR as i32 {
+            write!(f, "MTS_SERIALIZATION_ERROR")
+        } else if code == mts_status_t::MTS_BUFFER_SIZE_ERROR as i32 {
+            write!(f, "MTS_BUFFER_SIZE_ERROR")
+        } else if code == mts_status_t::MTS_CALLBACK_ERROR as i32 {
+            write!(f, "MTS_CALLBACK_ERROR")
+        } else if code == mts_status_t::MTS_INTERNAL_ERROR as i32 {
+            write!(f, "MTS_INTERNAL_ERROR")
+        } else {
+            write!(f, "unknown status code {}", code)
+        }
+    }
+}
 
 impl From<Error> for mts_status_t {
     #[allow(clippy::match_same_arms)]
     fn from(error: Error) -> mts_status_t {
-        LAST_ERROR_MESSAGE.with(|message| {
-            *message.borrow_mut() = CString::new(format!("{}", error)).expect("error message contains a null byte");
+        if let Error::CallbackError = error {
+            // if the error is already a callback error, keep the original
+            // status code and LAST_ERROR
+            return mts_status_t::MTS_CALLBACK_ERROR;
+        }
+
+        LAST_ERROR.set(LastError {
+            message: CString::new(format!("{}", error)).expect("error message contains a null byte"),
+            origin: CString::new("metatensor-core").expect("invalid C string"),
+            custom_data: std::ptr::null_mut(),
+            custom_data_deleter: None,
         });
+
         match error {
-            Error::InvalidParameter(_) => mts_status_t(MTS_INVALID_PARAMETER_ERROR),
-            Error::Io(_) => mts_status_t(MTS_IO_ERROR),
-            Error::Serialization(_) => mts_status_t(MTS_SERIALIZATION_ERROR),
-            Error::BufferSize(_) => mts_status_t(MTS_BUFFER_SIZE_ERROR),
-            Error::External {status, .. } => status,
-            Error::Internal(_) => mts_status_t(MTS_INTERNAL_ERROR),
+            Error::InvalidParameter(_) => mts_status_t::MTS_INVALID_PARAMETER_ERROR,
+            Error::Io(_) => mts_status_t::MTS_IO_ERROR,
+            Error::Serialization(_) => mts_status_t::MTS_SERIALIZATION_ERROR,
+            Error::BufferSize(_) => mts_status_t::MTS_BUFFER_SIZE_ERROR,
+            Error::CallbackError => unreachable!(),
+            Error::Internal(_) => mts_status_t::MTS_INTERNAL_ERROR,
         }
     }
 }
@@ -72,7 +140,7 @@ impl From<Error> for mts_status_t {
 /// the error into `mts_status_t`.
 pub fn catch_unwind<F>(function: F) -> mts_status_t where F: FnOnce() -> Result<(), Error> + UnwindSafe {
     match std::panic::catch_unwind(function) {
-        Ok(Ok(())) => mts_status_t(MTS_SUCCESS),
+        Ok(Ok(())) => mts_status_t::MTS_SUCCESS,
         Ok(Err(error)) => error.into(),
         Err(error) => Error::from(error).into()
     }
@@ -99,23 +167,84 @@ macro_rules! check_pointers_non_null {
 
 /// Get the last error message that was created on the current thread.
 ///
-/// @returns the last error message, as a NULL-terminated string
+/// @param message if not NULL, this will be set to the last error message, as a
+///        NULL-terminated string
+/// @param origin if not NULL, this will be set to the origin of the last error,
+///        as a NULL-terminated string
+/// @param data if not NULL, this will be set to the custom data of the last error
+///
+/// @returns The status code of this operation.
 #[no_mangle]
-pub unsafe extern "C" fn mts_last_error() -> *const c_char {
-    let mut result = std::ptr::null();
-    let wrapper = std::panic::AssertUnwindSafe(&mut result);
-    let status = catch_unwind(move || {
-        let _ = &wrapper;
-        LAST_ERROR_MESSAGE.with(|message| {
-            *wrapper.0 = message.borrow().as_ptr();
+pub unsafe extern "C" fn mts_last_error(
+    message: *mut *const c_char,
+    origin: *mut *const c_char,
+    data: *mut *mut c_void,
+) -> mts_status_t {
+    let status = std::panic::catch_unwind(|| {
+        LAST_ERROR.with(|last_error| {
+            if !message.is_null() {
+                *message = last_error.borrow().message.as_ptr();
+            }
+            if !origin.is_null() {
+                *origin = last_error.borrow().origin.as_ptr();
+            }
+            if !data.is_null() {
+                *data = last_error.borrow().custom_data;
+            }
         });
-        Ok(())
     });
 
-    if status.0 != MTS_SUCCESS {
-        eprintln!("ERROR: unable to get last error message!");
-        return std::ptr::null();
+    match status {
+        Ok(()) => mts_status_t::MTS_SUCCESS,
+        Err(error) => {
+            // something went very wrong, try to print a message to stderr
+            let last_error_debug = LAST_ERROR.with(|last_error| {
+                format!("{:?}", last_error.borrow())
+            });
+            if error.is::<String>() {
+                eprintln!("panic in mts_last_error: {:?}, last_error: {:?}", error.downcast_ref::<String>(), last_error_debug);
+            } else if error.is::<&str>() {
+                eprintln!("panic in mts_last_error: {:?}, last_error: {:?}", error.downcast_ref::<&str>(), last_error_debug);
+            } else {
+                eprintln!("panic in mts_last_error: unknown panic error type. last_error: {:?}", last_error_debug);
+            }
+            mts_status_t::MTS_INTERNAL_ERROR
+        }
     }
+}
 
-    return result;
+/// Set the last error message for the current thread.
+///
+/// This is useful when the error is created in a callback provided by the user
+/// of metatensor.
+///
+/// @param message the error message to set, as a NULL-terminated string
+#[no_mangle]
+pub unsafe extern "C" fn mts_set_last_error(
+    message: *const c_char,
+    origin: *const c_char,
+    data: *mut c_void,
+    data_deleter: Option<unsafe extern "C" fn(*mut c_void)>,
+) -> mts_status_t {
+    catch_unwind(move || {
+        let message = if message.is_null() {
+            CString::new("<no message provided>").expect("invalid C string")
+        } else {
+            CString::from(CStr::from_ptr(message))
+        };
+
+        let origin = if origin.is_null() {
+            CString::new("<no origin provided>").expect("invalid C string")
+        } else {
+            CString::from(CStr::from_ptr(origin))
+        };
+
+        LAST_ERROR.set(LastError {
+            message: message,
+            origin: origin,
+            custom_data: data,
+            custom_data_deleter: data_deleter,
+        });
+        Ok(())
+    })
 }

--- a/metatensor-core/src/data.rs
+++ b/metatensor-core/src/data.rs
@@ -82,9 +82,13 @@ pub struct mts_array_t {
     pub destroy: Option<unsafe extern "C" fn(array: *mut c_void)>,
 
     /// This function needs to store the "data origin" for this array in
-    /// `origin`. Users of `mts_array_t` should register a single data
-    /// origin with `mts_register_data_origin`, and use it for all compatible
-    /// arrays.
+    /// `origin`. Users of `mts_array_t` should register a single data origin
+    /// with `mts_register_data_origin`, and use it for all compatible arrays.
+    ///
+    /// This function should return `MTS_SUCCESS` on success, or
+    /// `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+    /// should call `mts_set_last_error` with an appropriate error message
+    /// before returning.
     pub origin: Option<unsafe extern "C" fn(
         array: *const c_void,
         origin: *mut mts_data_origin_t
@@ -94,6 +98,11 @@ pub struct mts_array_t {
     /// via DLPack.
     ///
     /// The implementation must store the device information in `*device`.
+    ///
+    /// This function should return `MTS_SUCCESS` on success, or
+    /// `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+    /// should call `mts_set_last_error` with an appropriate error message
+    /// before returning.
     pub device: Option<unsafe extern "C" fn(
         array: *const c_void,
         device: *mut DLDevice,
@@ -102,6 +111,11 @@ pub struct mts_array_t {
     /// Query the data type of this array without a full DLPack export.
     ///
     /// The implementation must store the data type in `*dtype`.
+    ///
+    /// This function should return `MTS_SUCCESS` on success, or
+    /// `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+    /// should call `mts_set_last_error` with an appropriate error message
+    /// before returning.
     pub dtype: Option<unsafe extern "C" fn(
         array: *const c_void,
         dtype: *mut DLDataType,
@@ -143,6 +157,11 @@ pub struct mts_array_t {
     /// responsible for calling its `deleter` function when the tensor is no
     /// longer needed. The lifetime of the `DLManagedTensorVersioned` must not
     /// exceed the lifetime of the `mts_array_t` it was created from.
+    ///
+    /// This function should return `MTS_SUCCESS` on success, or
+    /// `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+    /// should call `mts_set_last_error` with an appropriate error message
+    /// before returning.
     pub as_dlpack: Option<unsafe extern "C" fn(
         array: *mut c_void,
         dl_managed_tensor: *mut *mut DLManagedTensorVersioned,
@@ -155,6 +174,11 @@ pub struct mts_array_t {
     /// pointer, and the number of dimension (size of the `*shape` array) in
     /// `*shape_count`. If the array is a single scalar, `shape_count` should be
     /// set to 0, and the shape pointer to `NULL`.
+    ///
+    /// This function should return `MTS_SUCCESS` on success, or
+    /// `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+    /// should call `mts_set_last_error` with an appropriate error message
+    /// before returning.
     pub shape: Option<unsafe extern "C" fn(
         array: *const c_void,
         shape: *mut *const usize,
@@ -164,6 +188,11 @@ pub struct mts_array_t {
     /// Change the shape of the array managed by this `mts_array_t` to the given
     /// `shape`. `shape_count` must contain the number of elements in the
     /// `shape` array.
+    ///
+    /// This function should return `MTS_SUCCESS` on success, or
+    /// `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+    /// should call `mts_set_last_error` with an appropriate error message
+    /// before returning.
     pub reshape: Option<unsafe extern "C" fn(
         array: *mut c_void,
         shape: *const usize,
@@ -171,6 +200,11 @@ pub struct mts_array_t {
     ) -> mts_status_t>,
 
     /// Swap the axes `axis_1` and `axis_2` in this `array`.
+    ///
+    /// This function should return `MTS_SUCCESS` on success, or
+    /// `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+    /// should call `mts_set_last_error` with an appropriate error message
+    /// before returning.
     pub swap_axes: Option<unsafe extern "C" fn(
         array: *mut c_void,
         axis_1: usize,
@@ -187,6 +221,11 @@ pub struct mts_array_t {
     /// with the same dtype as this array. This function should call
     /// `fill_value.destroy` if the function pointer is not `NULL` when
     /// `fill_value` is no longer needed.
+    ///
+    /// This function should return `MTS_SUCCESS` on success, or
+    /// `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+    /// should call `mts_set_last_error` with an appropriate error message
+    /// before returning.
     pub create: Option<unsafe extern "C" fn(
         array: *const c_void,
         shape: *const usize,
@@ -199,6 +238,11 @@ pub struct mts_array_t {
     ///
     /// The new array is expected to have the same data origin and parameters
     /// (data type, data location, etc.)
+    ///
+    /// This function should return `MTS_SUCCESS` on success, or
+    /// `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+    /// should call `mts_set_last_error` with an appropriate error message
+    /// before returning.
     pub copy: Option<unsafe extern "C" fn(
         array: *const c_void,
         new_array: *mut mts_array_t,
@@ -217,6 +261,11 @@ pub struct mts_array_t {
     /// `array[movements[i].sample_out, ..., movements[i].properties_start_out +
     /// x]` for `i` up to `movements_count` and `x` up to
     /// `movements[i].properties_length`. All indexes are 0-based.
+    ///
+    /// This function should return `MTS_SUCCESS` on success, or
+    /// `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+    /// should call `mts_set_last_error` with an appropriate error message
+    /// before returning.
     pub move_data: Option<unsafe extern "C" fn(
         output: *mut c_void,
         input: *const c_void,
@@ -317,9 +366,8 @@ impl mts_array_t {
         };
 
         if !status.is_success() {
-            return Err(Error::External {
-                status, context: "calling mts_array_t.origin failed".into()
-            });
+            crate::c_api::add_error_context("calling mts_array_t.origin failed");
+            return Err(Error::CallbackError);
         }
 
         return Ok(origin);
@@ -335,9 +383,8 @@ impl mts_array_t {
         };
 
         if !status.is_success() {
-            return Err(Error::External {
-                status, context: "calling mts_array_t.device failed".into()
-            });
+            crate::c_api::add_error_context("calling mts_array_t.device failed");
+            return Err(Error::CallbackError);
         }
 
         return Ok(device);
@@ -350,9 +397,8 @@ impl mts_array_t {
         let mut dtype = DLDataType { code: dlpk::sys::DLDataTypeCode::kDLFloat, bits: 64, lanes: 1 };
         let status = unsafe { function(self.ptr, &mut dtype) };
         if !status.is_success() {
-            return Err(Error::External {
-                status, context: "calling mts_array_t.dtype failed".into()
-            });
+            crate::c_api::add_error_context("calling mts_array_t.dtype failed");
+            return Err(Error::CallbackError);
         }
         return Ok(dtype);
     }
@@ -377,9 +423,8 @@ impl mts_array_t {
             function(self.ptr, &mut dl_managed_tensor, device, stream_c, max_version)
         };
         if !status.is_success() {
-            return Err(Error::External {
-                status, context: "calling mts_array_t.as_dlpack failed".into()
-            });
+            crate::c_api::add_error_context("calling mts_array_t.as_dlpack failed");
+            return Err(Error::CallbackError);
         }
         assert!(!dl_managed_tensor.is_null(), "mts_array_t.as_dlpack returned a null pointer on success");
         let ptr = NonNull::new(dl_managed_tensor).expect("pointer is null, this should not happen");
@@ -407,9 +452,8 @@ impl mts_array_t {
         };
 
         if !status.is_success() {
-            return Err(Error::External {
-                status, context: "calling mts_array_t.shape failed".into()
-            });
+            crate::c_api::add_error_context("calling mts_array_t.shape failed");
+            return Err(Error::CallbackError);
         }
 
         if shape_count == 0 {
@@ -436,9 +480,8 @@ impl mts_array_t {
         };
 
         if !status.is_success() {
-            return Err(Error::External {
-                status, context: "calling mts_array_t.reshape failed".into()
-            });
+            crate::c_api::add_error_context("calling mts_array_t.reshape failed");
+            return Err(Error::CallbackError);
         }
 
         return Ok(());
@@ -457,9 +500,8 @@ impl mts_array_t {
         };
 
         if !status.is_success() {
-            return Err(Error::External {
-                status, context: "calling mts_array_t.swap_axes failed".into()
-            });
+            crate::c_api::add_error_context("calling mts_array_t.swap_axes failed");
+            return Err(Error::CallbackError);
         }
 
         return Ok(());
@@ -512,9 +554,8 @@ impl mts_array_t {
         };
 
         if !status.is_success() {
-            return Err(Error::External {
-                status, context: "calling mts_array_t.create failed".into()
-            });
+            crate::c_api::add_error_context("calling mts_array_t.create failed");
+            return Err(Error::CallbackError);
         }
 
         return Ok(data_storage);
@@ -531,9 +572,8 @@ impl mts_array_t {
         };
 
         if !status.is_success() {
-            return Err(Error::External {
-                status, context: "calling mts_array_t.create failed".into()
-            });
+            crate::c_api::add_error_context("calling mts_array_t.copy failed");
+            return Err(Error::CallbackError);
         }
 
         return Ok(new_array);
@@ -569,9 +609,8 @@ impl mts_array_t {
         };
 
         if !status.is_success() {
-            return Err(Error::External {
-                status, context: "calling mts_array_t.move_data failed".into()
-            });
+            crate::c_api::add_error_context("calling mts_array_t.move_data failed");
+            return Err(Error::CallbackError);
         }
 
         return Ok(());
@@ -583,8 +622,6 @@ pub(crate) use self::tests::TestArray;
 
 #[cfg(test)]
 mod tests {
-    use crate::c_api::MTS_SUCCESS;
-
     use super::*;
 
     pub struct TestArray {
@@ -674,33 +711,33 @@ mod tests {
         unsafe extern "C" fn origin(_: *const c_void, origin: *mut mts_data_origin_t) -> mts_status_t {
             *origin = register_data_origin("rust.TestArray".into());
 
-            return mts_status_t(MTS_SUCCESS);
+            return mts_status_t::MTS_SUCCESS;
         }
 
         unsafe extern "C" fn other_origin(_: *const c_void, origin: *mut mts_data_origin_t) -> mts_status_t {
             *origin = register_data_origin("rust.TestArrayOtherOrigin".into());
 
-            return mts_status_t(MTS_SUCCESS);
+            return mts_status_t::MTS_SUCCESS;
         }
 
         unsafe extern "C" fn device_cpu(_: *const c_void, device: *mut DLDevice) -> mts_status_t {
             *device = DLDevice::cpu();
-            return mts_status_t(MTS_SUCCESS);
+            return mts_status_t::MTS_SUCCESS;
         }
 
         unsafe extern "C" fn device_cuda(_: *const c_void, device: *mut DLDevice) -> mts_status_t {
             *device = DLDevice { device_type: dlpk::sys::DLDeviceType::kDLCUDA, device_id: 0 };
-            return mts_status_t(MTS_SUCCESS);
+            return mts_status_t::MTS_SUCCESS;
         }
 
         unsafe extern "C" fn dtype_f64(_: *const c_void, dtype: *mut DLDataType) -> mts_status_t {
             *dtype = DLDataType { code: dlpk::sys::DLDataTypeCode::kDLFloat, bits: 64, lanes: 1 };
-            return mts_status_t(MTS_SUCCESS);
+            return mts_status_t::MTS_SUCCESS;
         }
 
         unsafe extern "C" fn dtype_f32(_: *const c_void, dtype: *mut DLDataType) -> mts_status_t {
             *dtype = DLDataType { code: dlpk::sys::DLDataTypeCode::kDLFloat, bits: 32, lanes: 1 };
-            return mts_status_t(MTS_SUCCESS);
+            return mts_status_t::MTS_SUCCESS;
         }
 
         unsafe extern "C" fn shape(ptr: *const c_void, shape: *mut *const usize, shape_count: *mut usize) -> mts_status_t {
@@ -709,7 +746,7 @@ mod tests {
             *shape = (*ptr).shape.as_ptr();
             *shape_count = (*ptr).shape.len();
 
-            return mts_status_t(MTS_SUCCESS);
+            return mts_status_t::MTS_SUCCESS;
         }
 
         unsafe extern "C" fn reshape(ptr: *mut c_void, shape_ptr: *const usize, shape_count: usize) -> mts_status_t {
@@ -722,7 +759,7 @@ mod tests {
                 shape.push(shape_ptr.add(i).read());
             }
 
-            return mts_status_t(MTS_SUCCESS);
+            return mts_status_t::MTS_SUCCESS;
         }
 
         unsafe extern "C" fn swap_axes(ptr: *mut c_void, axis_1: usize, axis_2: usize) -> mts_status_t {
@@ -731,7 +768,7 @@ mod tests {
             let shape = &mut (*ptr).shape;
             shape.swap(axis_1, axis_2);
 
-            return mts_status_t(MTS_SUCCESS);
+            return mts_status_t::MTS_SUCCESS;
         }
 
         unsafe extern "C" fn destroy(ptr: *mut c_void) {

--- a/metatensor-core/src/lib.rs
+++ b/metatensor-core/src/lib.rs
@@ -26,7 +26,6 @@ use self::tensor::TensorMap;
 
 #[doc(hidden)]
 mod c_api;
-use c_api::mts_status_t;
 
 mod io;
 
@@ -41,11 +40,8 @@ pub enum Error {
     Io(std::io::Error),
     /// Serialization format error when loading/writing `TensorMap` to a file
     Serialization(String),
-    /// External error, coming from a function used as a callback in `mts_array_t`
-    External {
-        status: mts_status_t,
-        context: String,
-    },
+    /// Error coming from an external function used as a callback
+    CallbackError,
     /// Any other internal error, usually these are internal bugs.
     Internal(String),
 }
@@ -57,7 +53,7 @@ impl std::fmt::Display for Error {
             Error::Io(e) => write!(f, "io error: {}", e),
             Error::Serialization(e) => write!(f, "serialization format error: {}", e),
             Error::BufferSize(e) => write!(f, "buffer is not big enough: {}", e),
-            Error::External { status, context } => write!(f, "external error: {} (status {})", context, status.as_i32()),
+            Error::CallbackError => write!(f, "callback error"),
             Error::Internal(e) => write!(f, "internal metatensor error (this is likely a bug, please report it): {}", e),
         }
     }
@@ -70,7 +66,7 @@ impl std::error::Error for Error {
             Error::Serialization(_) |
             Error::Internal(_) |
             Error::BufferSize(_) |
-            Error::External {..} => None,
+            Error::CallbackError => None,
             Error::Io(e) => Some(e),
         }
     }

--- a/metatensor-core/tests/cpp/blocks.cpp
+++ b/metatensor-core/tests/cpp/blocks.cpp
@@ -131,7 +131,11 @@ TEST_CASE("Blocks") {
             Labels({"properties"}, {{5}, {3}})
         );
 
-        CHECK_THROWS_WITH(block.clone(), "external error: calling mts_array_t.create failed (status -1)");
+        CHECK_THROWS_WITH(block.clone(), "can not copy this!");
+
+        // reset the last error, this should free the exception and avoid memory leak
+        auto status = mts_set_last_error(nullptr, nullptr, nullptr, nullptr);
+        CHECK(status == MTS_SUCCESS);
     }
 
 

--- a/metatensor-core/tests/cpp/tensor.cpp
+++ b/metatensor-core/tests/cpp/tensor.cpp
@@ -310,7 +310,11 @@ TEST_CASE("TensorMap") {
         ));
         tensor = TensorMap(Labels({"keys"}, {{0}}), std::move(blocks));
 
-        CHECK_THROWS_WITH(tensor.clone(), "external error: calling mts_array_t.create failed (status -1)");
+        CHECK_THROWS_WITH(tensor.clone(), "can not copy this!");
+
+        // reset the last error, this should free the exception and avoid memory leak
+        auto status = mts_set_last_error(nullptr, nullptr, nullptr, nullptr);
+        CHECK(status == MTS_SUCCESS);
     }
 
     SECTION("clone metadata") {
@@ -320,7 +324,11 @@ TEST_CASE("TensorMap") {
         CHECK(clone.keys() == tensor.keys());
 
         auto block = clone.block_by_id(0);
-        CHECK_THROWS_WITH(block.values(), "error in C++ callback: can not call `as_dlpack` for an EmtpyDataArray");
+        CHECK_THROWS_WITH(block.values(), "can not call `as_dlpack` for an EmtpyDataArray");
+
+        // reset the last error, this should free the exception and avoid memory leak
+        auto status = mts_set_last_error(nullptr, nullptr, nullptr, nullptr);
+        CHECK(status == MTS_SUCCESS);
     }
 }
 

--- a/metatensor-torch/src/block.cpp
+++ b/metatensor-torch/src/block.cpp
@@ -135,10 +135,7 @@ TensorBlock TensorBlockHolder::to_positional(
 }
 
 torch::Tensor TensorBlockHolder::values() const {
-    // const_cast is fine here, because the returned torch::Tensor does not
-    // allow modifications to the underlying mts_array (only to the values
-    // inside the tensor).
-    auto array = const_cast<metatensor::TensorBlock&>(block_).mts_array();
+    auto array = block_.const_mts_array();
 
     if (array.origin() != TORCH_DATA_ORIGIN) {
         C10_THROW_ERROR(ValueError,

--- a/python/metatensor_core/metatensor/_c_api.py
+++ b/python/metatensor_core/metatensor/_c_api.py
@@ -20,12 +20,6 @@ if arch == "32bit":
 elif arch == "64bit":
     c_uintptr_t = ctypes.c_uint64
 
-MTS_SUCCESS = 0
-MTS_INVALID_PARAMETER_ERROR = 1
-MTS_IO_ERROR = 2
-MTS_SERIALIZATION_ERROR = 3
-MTS_BUFFER_SIZE_ERROR = 254
-MTS_INTERNAL_ERROR = 255
 
 
 mts_status_t = ctypes.c_int32
@@ -52,6 +46,16 @@ class DLDataTypeCode(enum.Enum):
     kDLFloat6_e2m3fn = 15
     kDLFloat6_e3m2fn = 16
     kDLFloat4_e2m1fn = 17
+
+
+mts_status_t = ctypes.c_int
+MTS_SUCCESS = 0
+MTS_INVALID_PARAMETER_ERROR = 1
+MTS_IO_ERROR = 2
+MTS_SERIALIZATION_ERROR = 3
+MTS_BUFFER_SIZE_ERROR = 4
+MTS_CALLBACK_ERROR = 254
+MTS_INTERNAL_ERROR = 255
 
 
 # ============================================================================ #
@@ -159,8 +163,19 @@ def setup_functions(lib):
     lib.mts_version.restype = ctypes.c_char_p
 
     lib.mts_last_error.argtypes = [
+        POINTER(ctypes.c_char_p),
+        POINTER(ctypes.c_char_p),
+        POINTER(POINTER(None)),
     ]
-    lib.mts_last_error.restype = ctypes.c_char_p
+    lib.mts_last_error.restype = mts_status_t
+
+    lib.mts_set_last_error.argtypes = [
+        ctypes.c_char_p,
+        ctypes.c_char_p,
+        ctypes.c_void_p,
+        CFUNCTYPE(None, ctypes.c_void_p),
+    ]
+    lib.mts_set_last_error.restype = _check_status
 
     lib.mts_labels.argtypes = [
         POINTER(ctypes.c_char_p),

--- a/python/metatensor_core/metatensor/data/extract.py
+++ b/python/metatensor_core/metatensor/data/extract.py
@@ -112,7 +112,10 @@ def _is_python_origin(origin):
 def data_origin(mts_array):
     """Get the data origin of an mts_array"""
     origin = mts_data_origin_t()
-    mts_array.origin(mts_array.ptr, origin)
+
+    status = mts_array.origin(mts_array.ptr, origin)
+    _check_status(status)
+
     return origin.value
 
 

--- a/python/metatensor_core/metatensor/status.py
+++ b/python/metatensor_core/metatensor/status.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import atexit
+import ctypes
+import sys
 from typing import Optional
 
 from ._c_api import MTS_SUCCESS
@@ -17,41 +20,106 @@ class MetatensorError(Exception):
         """status code for this exception"""
 
 
-LAST_EXCEPTION = None
-
-
-def _save_exception(e):
-    global LAST_EXCEPTION
-    LAST_EXCEPTION = e
-
-
 def _check_status(status):
     if status == MTS_SUCCESS:
         return
-    elif status > MTS_SUCCESS:
-        raise MetatensorError(last_error(), status)
-    elif status < MTS_SUCCESS:
-        global LAST_EXCEPTION
-        e = LAST_EXCEPTION
-        LAST_EXCEPTION = None
-        raise MetatensorError(last_error(), status) from e
+    else:
+        raise _get_exception(status)
 
 
 def _check_pointer(pointer):
     if not pointer:
-        global LAST_EXCEPTION
-        if LAST_EXCEPTION is not None:
-            e = LAST_EXCEPTION
-            LAST_EXCEPTION = None
-            raise MetatensorError(last_error()) from e
-        else:
-            raise MetatensorError(last_error())
+        raise _get_exception()
 
 
-def last_error():
-    """Get the last error message on this thread"""
+def _delete_exception(exception):
+    # decrement the reference count of the exception
+    exception_ptr = ctypes.cast(exception, ctypes.py_object).value
+    ctypes.pythonapi.Py_DecRef(exception_ptr)
+
+
+_DELETE_EXCEPTION = ctypes.CFUNCTYPE(None, ctypes.c_void_p)(_delete_exception)
+
+
+def _save_exception(e):
+    """
+    Save the given exception in metatensor's thread-local storage, so that it can be
+    retrieved later with `_get_exception()`.
+    """
     from ._c_lib import _get_library
 
     lib = _get_library()
-    message = lib.mts_last_error()
-    return message.decode("utf8")
+
+    # increment the reference count of the exception
+    exception_ptr = ctypes.py_object(e)
+    ctypes.pythonapi.Py_IncRef(exception_ptr)
+
+    try:
+        lib.mts_set_last_error(
+            ctypes.c_char_p(str(e).encode("utf8")),
+            ctypes.c_char_p(b"Python exception"),
+            ctypes.c_void_p.from_buffer(exception_ptr),
+            _DELETE_EXCEPTION,
+        )
+    except Exception as err:
+        # if we failed to save the exception, we are in a very bad state, but we should
+        # still try to report the original error message if possible.
+        print(
+            "INTERNAL ERROR: unable to save last error after Python callback failure",
+            file=sys.stderr,
+        )
+        print(
+            f"original error was: {e}, error while saving was {err}",
+            file=sys.stderr,
+        )
+        ctypes.pythonapi.Py_DecRef(exception_ptr)
+
+
+def _get_exception(status=None):
+    """
+    Get the last error from libmetatensor that happened on the current thread.
+
+    If the last error was caused by a Python exception, this returns the exception as
+    is, otherwise it returns a new MetatensorError with the last error message.
+    """
+    from ._c_lib import _get_library
+
+    lib = _get_library()
+    message = ctypes.c_char_p()
+    origin = ctypes.c_char_p()
+    user_data = ctypes.c_void_p()
+    status = lib.mts_last_error(
+        ctypes.byref(message), ctypes.byref(origin), ctypes.byref(user_data)
+    )
+
+    if status != MTS_SUCCESS:
+        return MetatensorError(
+            "INTERNAL ERROR: failed to get the last error", status=status
+        )
+
+    if origin.value == b"Python exception" and user_data.value is not None:
+        # This error was caused by a Python exception, so we re-raise it here
+        # (the exception is stored in the user_data pointer)
+        return ctypes.cast(user_data, ctypes.py_object).value
+
+    return MetatensorError(message.value.decode("utf8"), status=status)
+
+
+def _clear_last_error():
+    """
+    Clear the last error that happened if it was caused by a Python exception, to
+    avoid trying to free the exception object after Python itself is unloaded.
+    """
+    from ._c_lib import _get_library
+
+    try:
+        lib = _get_library()
+        origin = ctypes.c_char_p()
+        status = lib.mts_last_error(None, ctypes.byref(origin), None)
+        if status == MTS_SUCCESS and origin.value == b"Python exception":
+            lib.mts_set_last_error(None, None, None, None)
+    except Exception:
+        pass
+
+
+atexit.register(_clear_last_error)

--- a/python/metatensor_core/metatensor/utils.py
+++ b/python/metatensor_core/metatensor/utils.py
@@ -19,7 +19,7 @@ except ImportError:
         pass
 
 
-from ._c_api import MTS_BUFFER_SIZE_ERROR
+from ._c_api import MTS_BUFFER_SIZE_ERROR, MTS_CALLBACK_ERROR, MTS_SUCCESS
 from .status import MetatensorError, _save_exception
 
 
@@ -47,8 +47,8 @@ def catch_exceptions(function):
             function(*args, **kwargs)
         except Exception as e:
             _save_exception(e)
-            return -1
-        return 0
+            return MTS_CALLBACK_ERROR
+        return MTS_SUCCESS
 
     return inner
 

--- a/python/metatensor_core/tests/data.py
+++ b/python/metatensor_core/tests/data.py
@@ -481,3 +481,25 @@ def test_parent_keepalive():
     assert tensor_ref() is None
 
     assert np.isclose(transformed, 1.1596965632269784)
+
+
+class CustomError(RuntimeError):
+    pass
+
+
+@metatensor.utils.catch_exceptions
+def error_origin(this, origin):
+    raise CustomError("This is a test error from Python callback")
+
+
+ERROR_ORIGIN = metatensor.data.array._cast_to_ctype_functype(error_origin, "origin")
+
+
+def test_error_capture():
+    mts_array = metatensor.data.create_mts_array(np.array([1, 2, 3]))
+    mts_array.origin = ERROR_ORIGIN
+
+    with pytest.raises(CustomError, match="This is a test error from Python callback"):
+        _ = metatensor.data.data_origin(mts_array)
+
+    free_mts_array(mts_array)

--- a/rust/metatensor-sys/src/c_api.rs
+++ b/rust/metatensor-sys/src/c_api.rs
@@ -20,12 +20,14 @@ use dlpk::sys::*;
 )]
 extern "C" {}
 
-pub const MTS_SUCCESS: i32 = 0;
-pub const MTS_INVALID_PARAMETER_ERROR: i32 = 1;
-pub const MTS_IO_ERROR: i32 = 2;
-pub const MTS_SERIALIZATION_ERROR: i32 = 3;
-pub const MTS_BUFFER_SIZE_ERROR: i32 = 254;
-pub const MTS_INTERNAL_ERROR: i32 = 255;
+pub const MTS_SUCCESS: mts_status_t = 0;
+pub const MTS_INVALID_PARAMETER_ERROR: mts_status_t = 1;
+pub const MTS_IO_ERROR: mts_status_t = 2;
+pub const MTS_SERIALIZATION_ERROR: mts_status_t = 3;
+pub const MTS_BUFFER_SIZE_ERROR: mts_status_t = 4;
+pub const MTS_CALLBACK_ERROR: mts_status_t = 254;
+pub const MTS_INTERNAL_ERROR: mts_status_t = 255;
+pub type mts_status_t = i32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct mts_block_t {
@@ -41,7 +43,6 @@ pub struct mts_labels_t {
 pub struct mts_tensormap_t {
     _unused: [u8; 0],
 }
-pub type mts_status_t = i32;
 pub type mts_data_origin_t = u64;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -262,7 +263,21 @@ pub type mts_create_array_callback_t = ::std::option::Option<
 extern "C" {
     pub fn mts_disable_panic_printing();
     pub fn mts_version() -> *const ::std::os::raw::c_char;
-    pub fn mts_last_error() -> *const ::std::os::raw::c_char;
+    #[must_use]
+    pub fn mts_last_error(
+        message: *mut *const ::std::os::raw::c_char,
+        origin: *mut *const ::std::os::raw::c_char,
+        data: *mut *mut ::std::os::raw::c_void,
+    ) -> mts_status_t;
+    #[must_use]
+    pub fn mts_set_last_error(
+        message: *const ::std::os::raw::c_char,
+        origin: *const ::std::os::raw::c_char,
+        data: *mut ::std::os::raw::c_void,
+        data_deleter: ::std::option::Option<
+            unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void),
+        >,
+    ) -> mts_status_t;
     pub fn mts_labels(
         dimensions: *const *const ::std::os::raw::c_char,
         dimensions_count: usize,

--- a/rust/metatensor/src/data/array_ref.rs
+++ b/rust/metatensor/src/data/array_ref.rs
@@ -7,14 +7,15 @@ use dlpk::sys::DLDevice;
 
 use crate::c_api::{mts_array_t, mts_data_origin_t, mts_data_movement_t};
 use crate::Error;
+use crate::errors::check_status;
 
-use super::external::{check_status_external, MtsArray};
+use super::external::MtsArray;
 use super::origin::get_data_origin;
 
 /// Reference to a data array in metatensor-core
 ///
 /// The data array can come from any origin, this struct provides facilities to
-/// access data that was created through the [`Array`] trait, and in particular
+/// access data that was created through the [`crate::Array`] trait, and in particular
 /// as `ndarray::ArrayD` instances.
 #[derive(Debug, Clone, Copy)]
 pub struct ArrayRef<'a> {
@@ -45,7 +46,7 @@ impl<'a> ArrayRef<'a> {
     /// Get the underlying array as an `&dyn Any` instance.
     ///
     /// This function panics if the array was not created though this crate and
-    /// the [`Array`] trait.
+    /// the [`crate::Array`] trait.
     #[inline]
     pub fn as_any(&self) -> &dyn std::any::Any {
         let origin = self.origin().unwrap_or(0);
@@ -65,7 +66,7 @@ impl<'a> ArrayRef<'a> {
     /// re-using the same lifetime as the `ArrayRef`.
     ///
     /// This function panics if the array was not created though this crate and
-    /// the [`Array`] trait.
+    /// the [`crate::Array`] trait.
     #[inline]
     pub fn to_any(self) -> &'a dyn std::any::Any {
         let origin = self.origin().unwrap_or(0);
@@ -114,10 +115,7 @@ impl<'a> ArrayRef<'a> {
 
         let mut origin = 0;
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut origin),
-                "mts_array_t.origin",
-            )?;
+            check_status(function(self.array.ptr, &mut origin))?;
         }
 
         return Ok(origin);
@@ -131,10 +129,7 @@ impl<'a> ArrayRef<'a> {
 
         let mut device = DLDevice::cpu();
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut device),
-                "mts_array_t.device",
-            )?;
+            check_status(function(self.array.ptr, &mut device))?;
         }
 
         return Ok(device);
@@ -148,10 +143,7 @@ impl<'a> ArrayRef<'a> {
 
         let mut dtype = dlpk::sys::DLDataType { code: dlpk::sys::DLDataTypeCode::kDLFloat, bits: 0, lanes: 0 };
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut dtype),
-                "mts_array_t.dtype",
-            )?;
+            check_status(function(self.array.ptr, &mut dtype))?;
         }
 
         return Ok(dtype);
@@ -172,10 +164,7 @@ impl<'a> ArrayRef<'a> {
         let stream_c = stream.as_ref().map_or(std::ptr::null(), |s| s as *const i64);
 
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut tensor, device, stream_c, max_version),
-                "mts_array_t.as_dlpack",
-            )?;
+            check_status(function(self.array.ptr, &mut tensor, device, stream_c, max_version))?;
         }
 
         let tensor = NonNull::new(tensor).expect("got a NULL DLManagedTensorVersioned from `as_dlpack`");
@@ -196,10 +185,7 @@ impl<'a> ArrayRef<'a> {
         let mut shape_count: usize = 0;
 
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut shape, &mut shape_count),
-                "mts_array_t.shape"
-            )?;
+            check_status(function(self.array.ptr, &mut shape, &mut shape_count))?;
         }
 
         if shape_count == 0 {
@@ -222,16 +208,13 @@ impl<'a> ArrayRef<'a> {
 
         let mut new_array = mts_array_t::null();
         unsafe {
-            check_status_external(
-                function(
-                    self.array.ptr,
-                    shape.as_ptr(),
-                    shape.len(),
-                    *fill_value.as_raw(),
-                    &mut new_array
-                ),
-                "mts_array_t.create",
-            )?;
+            check_status(function(
+                self.array.ptr,
+                shape.as_ptr(),
+                shape.len(),
+                *fill_value.as_raw(),
+                &mut new_array
+            ))?;
         }
 
         return Ok(MtsArray::from_raw(new_array));
@@ -244,10 +227,7 @@ impl<'a> ArrayRef<'a> {
         let function = self.array.copy.expect("mts_array_t.copy function is NULL");
         let mut new_array = mts_array_t::null();
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut new_array),
-                "mts_array_t.copy",
-            )?;
+            check_status(function(self.array.ptr, &mut new_array))?;
         }
 
         return Ok(MtsArray::from_raw(new_array));
@@ -257,8 +237,8 @@ impl<'a> ArrayRef<'a> {
 /// Mutable reference to a data array in metatensor-core
 ///
 /// The data array can come from any origin, this struct provides facilities to
-/// access data that was created through the [`Array`] trait, and in particular
-/// as `ndarray::ArrayD` instances.
+/// access data that was created through the [`crate::Array`] trait, and in
+/// particular as `ndarray::ArrayD` instances.
 #[derive(Debug)]
 pub struct ArrayRefMut<'a> {
     array: mts_array_t,
@@ -291,7 +271,7 @@ impl<'a> ArrayRefMut<'a> {
     /// Get the underlying array as an `&dyn Any` instance.
     ///
     /// This function panics if the array was not created though this crate and
-    /// the [`Array`] trait.
+    /// the [`crate::Array`] trait.
     #[inline]
     pub fn as_any(&self) -> &dyn std::any::Any {
         let origin = self.origin().unwrap_or(0);
@@ -311,7 +291,7 @@ impl<'a> ArrayRefMut<'a> {
     /// re-using the same lifetime as the `ArrayRefMut`.
     ///
     /// This function panics if the array was not created though this crate and
-    /// the [`Array`] trait.
+    /// the [`crate::Array`] trait.
     #[inline]
     pub fn to_any(self) -> &'a dyn std::any::Any {
         let origin = self.origin().unwrap_or(0);
@@ -330,7 +310,7 @@ impl<'a> ArrayRefMut<'a> {
     /// Get the underlying array as an `&mut dyn Any` instance.
     ///
     /// This function panics if the array was not created though this crate and
-    /// the [`Array`] trait.
+    /// the [`crate::Array`] trait.
     #[inline]
     pub fn to_any_mut(self) -> &'a mut dyn std::any::Any {
         let origin = self.origin().unwrap_or(0);
@@ -401,10 +381,7 @@ impl<'a> ArrayRefMut<'a> {
 
         let mut origin = 0;
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut origin),
-                "mts_array_t.origin",
-            )?;
+            check_status(function(self.array.ptr, &mut origin))?;
         }
 
         return Ok(origin);
@@ -418,10 +395,7 @@ impl<'a> ArrayRefMut<'a> {
 
         let mut device = DLDevice::cpu();
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut device),
-                "mts_array_t.device",
-            )?;
+            check_status(function(self.array.ptr, &mut device))?;
         }
 
         return Ok(device);
@@ -435,10 +409,7 @@ impl<'a> ArrayRefMut<'a> {
 
         let mut dtype = dlpk::sys::DLDataType { code: dlpk::sys::DLDataTypeCode::kDLFloat, bits: 0, lanes: 0 };
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut dtype),
-                "mts_array_t.dtype",
-            )?;
+            check_status(function(self.array.ptr, &mut dtype))?;
         }
 
         return Ok(dtype);
@@ -459,10 +430,13 @@ impl<'a> ArrayRefMut<'a> {
         let stream_c = stream.as_ref().map_or(std::ptr::null(), |s| s as *const i64);
 
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut tensor, device, stream_c, max_version),
-                "mts_array_t.as_dlpack",
-            )?;
+            check_status(function(
+                self.array.ptr,
+                &mut tensor,
+                device,
+                stream_c,
+                max_version
+            ))?;
         }
 
         let tensor = NonNull::new(tensor).expect("got a NULL DLManagedTensorVersioned from `as_dlpack`");
@@ -483,10 +457,7 @@ impl<'a> ArrayRefMut<'a> {
         let mut shape_count: usize = 0;
 
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut shape, &mut shape_count),
-                "mts_array_t.shape"
-            )?;
+            check_status(function(self.array.ptr, &mut shape, &mut shape_count))?;
         }
 
         if shape_count == 0 {
@@ -507,10 +478,7 @@ impl<'a> ArrayRefMut<'a> {
         let function = self.array.reshape.expect("mts_array_t.reshape function is NULL");
 
         unsafe {
-            check_status_external(
-                function(self.array.ptr, shape.as_ptr(), shape.len()),
-                "mts_array_t.reshape",
-            )?;
+            check_status(function(self.array.ptr, shape.as_ptr(), shape.len()))?;
         }
 
         return Ok(());
@@ -523,10 +491,7 @@ impl<'a> ArrayRefMut<'a> {
         let function = self.array.swap_axes.expect("mts_array_t.swap_axes function is NULL");
 
         unsafe {
-            check_status_external(
-                function(self.array.ptr, axis_1, axis_2),
-                "mts_array_t.swap_axes",
-            )?;
+            check_status(function(self.array.ptr, axis_1, axis_2))?;
         }
 
         return Ok(());
@@ -541,16 +506,13 @@ impl<'a> ArrayRefMut<'a> {
 
         let mut new_array = mts_array_t::null();
         unsafe {
-            check_status_external(
-                function(
-                    self.array.ptr,
-                    shape.as_ptr(),
-                    shape.len(),
-                    *fill_value.as_raw(),
-                    &mut new_array
-                ),
-                "mts_array_t.create",
-            )?;
+            check_status(function(
+                self.array.ptr,
+                shape.as_ptr(),
+                shape.len(),
+                *fill_value.as_raw(),
+                &mut new_array
+            ))?;
         }
 
         return Ok(MtsArray::from_raw(new_array));
@@ -563,10 +525,7 @@ impl<'a> ArrayRefMut<'a> {
         let function = self.array.copy.expect("mts_array_t.copy function is NULL");
         let mut new_array = mts_array_t::null();
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut new_array),
-                "mts_array_t.copy",
-            )?;
+            check_status(function(self.array.ptr, &mut new_array))?;
         }
 
         return Ok(MtsArray::from_raw(new_array));
@@ -584,10 +543,12 @@ impl<'a> ArrayRefMut<'a> {
 
         let input = input.into();
         unsafe {
-            check_status_external(
-                function(self.array.ptr, input.as_raw().ptr, moves.as_ptr(), moves.len()),
-                "mts_array_t.move_data",
-            )?;
+            check_status(function(
+                self.array.ptr,
+                input.as_raw().ptr,
+                moves.as_ptr(),
+                moves.len(),
+            ))?;
         }
 
         return Ok(());

--- a/rust/metatensor/src/data/external.rs
+++ b/rust/metatensor/src/data/external.rs
@@ -4,11 +4,10 @@ use std::sync::{Arc, RwLock, RwLockReadGuard};
 use ndarray::ArrayD;
 use dlpk::sys::DLDevice;
 
-use crate::c_api::{mts_array_t, mts_data_origin_t, mts_data_movement_t, mts_status_t};
-use crate::c_api::{MTS_SUCCESS, mts_last_error};
+use crate::c_api::{mts_array_t, mts_data_origin_t, mts_data_movement_t};
 
 use crate::Error;
-use crate::errors::{LAST_RUST_ERROR, RUST_FUNCTION_FAILED_ERROR_CODE};
+use crate::errors::check_status;
 
 use super::{ArrayRef, ArrayRefMut};
 use super::origin::get_data_origin;
@@ -48,7 +47,7 @@ impl MtsArray {
     /// Get the underlying array as an `&dyn Any` instance.
     ///
     /// This function panics if the array was not created though this crate and
-    /// the [`Array`] trait.
+    /// the [`crate::Array`] trait.
     #[inline]
     pub fn as_any(&self) -> &dyn std::any::Any {
         let origin = self.origin().unwrap_or(0);
@@ -104,10 +103,7 @@ impl MtsArray {
 
         let mut origin = 0;
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut origin),
-                "mts_array_t.origin",
-            )?;
+            check_status(function(self.array.ptr, &mut origin))?;
         }
 
         return Ok(origin);
@@ -121,10 +117,7 @@ impl MtsArray {
 
         let mut device = DLDevice::cpu();
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut device),
-                "mts_array_t.device",
-            )?;
+            check_status(function(self.array.ptr, &mut device))?;
         }
 
         return Ok(device);
@@ -138,10 +131,7 @@ impl MtsArray {
 
         let mut dtype = dlpk::sys::DLDataType { code: dlpk::sys::DLDataTypeCode::kDLFloat, bits: 0, lanes: 0 };
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut dtype),
-                "mts_array_t.dtype",
-            )?;
+            check_status(function(self.array.ptr, &mut dtype))?;
         }
 
         return Ok(dtype);
@@ -162,10 +152,7 @@ impl MtsArray {
         let stream_c = stream.as_ref().map_or(std::ptr::null(), |s| s as *const i64);
 
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut tensor, device, stream_c, max_version),
-                "mts_array_t.as_dlpack",
-            )?;
+            check_status(function(self.array.ptr, &mut tensor, device, stream_c, max_version))?;
         }
 
         let tensor = NonNull::new(tensor).expect("got a NULL DLManagedTensorVersioned from `as_dlpack`");
@@ -186,10 +173,7 @@ impl MtsArray {
         let mut shape_count: usize = 0;
 
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut shape, &mut shape_count),
-                "mts_array_t.shape"
-            )?;
+            check_status(function(self.array.ptr, &mut shape, &mut shape_count))?;
         }
 
         if shape_count == 0 {
@@ -210,10 +194,7 @@ impl MtsArray {
         let function = self.array.reshape.expect("mts_array_t.reshape function is NULL");
 
         unsafe {
-            check_status_external(
-                function(self.array.ptr, shape.as_ptr(), shape.len()),
-                "mts_array_t.reshape",
-            )?;
+            check_status(function(self.array.ptr, shape.as_ptr(), shape.len()))?;
         }
 
         return Ok(());
@@ -226,10 +207,7 @@ impl MtsArray {
         let function = self.array.swap_axes.expect("mts_array_t.swap_axes function is NULL");
 
         unsafe {
-            check_status_external(
-                function(self.array.ptr, axis_1, axis_2),
-                "mts_array_t.swap_axes",
-            )?;
+            check_status(function(self.array.ptr, axis_1, axis_2))?;
         }
 
         return Ok(());
@@ -244,16 +222,13 @@ impl MtsArray {
 
         let mut new_array = mts_array_t::null();
         unsafe {
-            check_status_external(
-                function(
-                    self.array.ptr,
-                    shape.as_ptr(),
-                    shape.len(),
-                    *fill_value.as_raw(),
-                    &mut new_array
-                ),
-                "mts_array_t.create",
-            )?;
+            check_status(function(
+                self.array.ptr,
+                shape.as_ptr(),
+                shape.len(),
+                *fill_value.as_raw(),
+                &mut new_array
+            ))?;
         }
 
         return Ok(MtsArray::from_raw(new_array));
@@ -266,10 +241,7 @@ impl MtsArray {
         let function = self.array.copy.expect("mts_array_t.copy function is NULL");
         let mut new_array = mts_array_t::null();
         unsafe {
-            check_status_external(
-                function(self.array.ptr, &mut new_array),
-                "mts_array_t.copy",
-            )?;
+            check_status(function(self.array.ptr, &mut new_array))?;
         }
 
         return Ok(MtsArray::from_raw(new_array));
@@ -287,10 +259,12 @@ impl MtsArray {
 
         let input = input.into();
         unsafe {
-            check_status_external(
-                function(self.array.ptr, input.as_raw().ptr, moves.as_ptr(), moves.len()),
-                "mts_array_t.move_data",
-            )?;
+            check_status(function(
+                self.array.ptr,
+                input.as_raw().ptr,
+                moves.as_ptr(),
+                moves.len(),
+            ))?;
         }
 
         return Ok(());
@@ -306,24 +280,5 @@ impl<'a> From<&'a MtsArray> for ArrayRef<'a> {
 impl<'a> From<&'a mut MtsArray> for ArrayRefMut<'a> {
     fn from(array: &'a mut MtsArray) -> ArrayRefMut<'a> {
         array.as_mut()
-    }
-}
-
-/// Check the status code returned by arbitrary functions inside an
-/// `mts_array_t`
-pub(super) fn check_status_external(status: mts_status_t, function: &str) -> Result<(), Error> {
-    if status == MTS_SUCCESS {
-        return Ok(());
-    } else if status > 0 {
-        let message = unsafe {
-            std::ffi::CStr::from_ptr(mts_last_error())
-        };
-        let message = message.to_str().expect("invalid UTF8");
-
-        return Err(Error { code: Some(status), message: message.to_owned() });
-    } else if status == RUST_FUNCTION_FAILED_ERROR_CODE {
-        return Err(LAST_RUST_ERROR.with(|e| e.borrow().clone()));
-    } else {
-        return Err(Error { code: Some(status), message: format!("calling {} failed", function) });
     }
 }

--- a/rust/metatensor/src/errors.rs
+++ b/rust/metatensor/src/errors.rs
@@ -1,45 +1,85 @@
 use std::ffi::CStr;
-use std::cell::RefCell;
 
-use crate::c_api::{mts_status_t, MTS_SUCCESS, mts_last_error};
-
-/// Error code used to indicate failure of a Rust function
-pub const RUST_FUNCTION_FAILED_ERROR_CODE: i32 = -4242;
-
-thread_local! {
-    /// Storage for the last error coming from a Rust function
-    pub static LAST_RUST_ERROR: RefCell<Error> = RefCell::new(Error {code: None, message: String::new()});
-}
+use crate::c_api::{mts_status_t, MTS_SUCCESS, MTS_CALLBACK_ERROR};
 
 pub use metatensor_sys::Error;
+
+fn get_last_error(status: Option<mts_status_t>) -> Error {
+    let mut message = std::ptr::null();
+    let mut origin = std::ptr::null();
+    let mut user_data = std::ptr::null_mut();
+    let last_error_status = unsafe {
+        crate::c_api::mts_last_error(
+             &mut message, &mut origin, &mut user_data
+        )
+    };
+
+    if last_error_status != MTS_SUCCESS {
+        return Error {
+            code: status,
+            message: "INTERNAL ERROR: failed to get the last error".into(),
+        };
+    }
+
+    let message = if message.is_null() {
+        "<no message provided>"
+    } else {
+        unsafe { CStr::from_ptr(message).to_str().unwrap_or("<invalid UTF-8 in error message>") }
+    };
+
+    let origin = if origin.is_null() {
+        "<no origin provided>"
+    } else {
+        unsafe { CStr::from_ptr(origin).to_str().unwrap_or("<invalid UTF-8 in error origin>") }
+    };
+
+    if !user_data.is_null() && origin == "Rust Error" {
+        let rust_error = unsafe {
+            user_data.cast::<Error>().as_ref().expect("should not be null")
+        };
+        return rust_error.clone();
+    }
+
+    return Error {
+        code: status,
+        message: message.to_owned(),
+    };
+}
+
+unsafe extern "C" fn error_deleter(data: *mut std::ffi::c_void) {
+    let _ = unsafe { Box::from_raw(data.cast::<Error>()) };
+}
+
+fn store_last_error(error: Error) -> mts_status_t {
+    let c_message = std::ffi::CString::new(error.message.clone()).expect("found NULL byte in error message");
+    let c_origin = std::ffi::CString::new("Rust Error").expect("found NULL byte in error origin");
+    let status = unsafe {
+        crate::c_api::mts_set_last_error(
+            c_message.as_ptr(),
+            c_origin.as_ptr(),
+            Box::into_raw(Box::new(error)).cast(),
+            Some(error_deleter),
+        )
+    };
+
+    check_status(status).expect("failed to set last error");
+
+    return MTS_CALLBACK_ERROR;
+}
 
 /// Check an `mts_status_t`, returning an error if is it not `MTS_SUCCESS`
 pub fn check_status(status: mts_status_t) -> Result<(), Error> {
     if status == MTS_SUCCESS {
         return Ok(())
-    } else if status > 0 {
-        let message = unsafe {
-            CStr::from_ptr(mts_last_error())
-        };
-        let message = message.to_str().expect("invalid UTF8");
-
-        return Err(Error { code: Some(status), message: message.to_owned() });
-    } else if status == RUST_FUNCTION_FAILED_ERROR_CODE {
-        return Err(LAST_RUST_ERROR.with(|e| e.borrow().clone()));
     } else {
-        return Err(Error { code: Some(status), message: "external function call failed".into() });
+        return Err(get_last_error(Some(status)));
     }
 }
 
 /// Check a pointer allocated by metatensor-core, returning an error if is null
 pub fn check_ptr<T>(ptr: *const T) -> Result<(), Error> {
     if ptr.is_null() {
-        let message = unsafe {
-            CStr::from_ptr(mts_last_error())
-        };
-        let message = message.to_str().expect("invalid UTF8");
-
-        return Err(Error { code: None, message: message.to_owned() });
+        return Err(get_last_error(None));
     }
 
     return Ok(())
@@ -52,24 +92,10 @@ pub(crate) fn catch_unwind<F>(function: F) -> mts_status_t where F: FnOnce() -> 
     match std::panic::catch_unwind(function) {
         Ok(Ok(())) => MTS_SUCCESS,
         Ok(Err(e)) => {
-            // Store the error in LAST_RUST_ERROR, we will extract it later
-            // in `check_status`
-            LAST_RUST_ERROR.with(|last_error| {
-                let mut last_error = last_error.borrow_mut();
-                *last_error = e;
-            });
-
-            RUST_FUNCTION_FAILED_ERROR_CODE
+            return store_last_error(e);
         },
         Err(e) => {
-            // Store the error in LAST_RUST_ERROR, we will extract it later
-            // in `check_status`
-            LAST_RUST_ERROR.with(|last_error| {
-                let mut last_error = last_error.borrow_mut();
-                *last_error = e.into();
-            });
-
-            RUST_FUNCTION_FAILED_ERROR_CODE
+            return store_last_error(e.into());
         }
     }
 }

--- a/rust/metatensor/src/labels.rs
+++ b/rust/metatensor/src/labels.rs
@@ -5,6 +5,7 @@ use std::iter::FusedIterator;
 
 use crate::MtsArray;
 use crate::c_api::mts_labels_t;
+use crate::errors::check_ptr;
 use crate::errors::{Error, check_status};
 
 /// A single value inside a label.
@@ -864,16 +865,7 @@ impl LabelsBuilder {
                 array.into_raw(),
             )
         };
-
-        if ptr.is_null() {
-            let error = unsafe { crate::c_api::mts_last_error() };
-            let message = if error.is_null() {
-                "failed to create labels".to_string()
-            } else {
-                unsafe { std::ffi::CStr::from_ptr(error) }.to_string_lossy().into_owned()
-            };
-            panic!("{}", message);
-        }
+        check_ptr(ptr).expect("invalid labels");
 
         unsafe { Labels::from_raw(ptr) }
     }

--- a/rust/metatensor/src/tensor.rs
+++ b/rust/metatensor/src/tensor.rs
@@ -204,7 +204,8 @@ impl TensorMap {
     unsafe fn raw_block_mut_by_id<'a>(ptr: *mut mts_tensormap_t, index: usize) -> TensorBlockRefMut<'a> {
         let mut block = std::ptr::null_mut();
 
-        check_status(crate::c_api::mts_tensormap_block_by_id(
+        check_status(
+            crate::c_api::mts_tensormap_block_by_id(
             ptr,
             &mut block,
             index,

--- a/scripts/check-c-api-docs.py
+++ b/scripts/check-c-api-docs.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 A small script checking that all the C API functions are documented
 """
@@ -48,6 +49,7 @@ def functions_in_outline():
     functions = [
         "mts_version",
         "mts_last_error",
+        "mts_set_last_error",
         "mts_disable_panic_printing",
         "mts_get_data_origin",
         "mts_register_data_origin",
@@ -73,6 +75,9 @@ def all_functions():
 
     class AstVisitor(c_ast.NodeVisitor):
         def visit_Decl(self, node):
+            if not isinstance(node.type, c_ast.FuncDecl):
+                return
+
             if not node.name.startswith("mts_"):
                 return
 

--- a/scripts/update-declarations.py
+++ b/scripts/update-declarations.py
@@ -81,13 +81,27 @@ class AstVisitor(c_ast.NodeVisitor):
         self.defines = {}
 
     def visit_Decl(self, node):
-        if not node.name.startswith("mts_"):
+        node_name = node.name
+        if node_name is None:
+            node_name = node.type.name
+
+        if not node_name.startswith("mts_"):
             return
 
-        function = Function(node.name, node.type.type)
-        for parameter in node.type.args.params:
-            function.add_arg(parameter.name, parameter.type)
-        self.functions.append(function)
+        if isinstance(node.type, c_ast.Enum):
+            enum = Enum(node_name)
+            for enumerator in node.type.values.enumerators:
+                # Strip C unsigned/long suffixes (e.g. 0U, 1UL)
+                value = enumerator.value.value.rstrip("UuLl")
+                enum.add_value(enumerator.name, value)
+            self.enums.append(enum)
+        elif isinstance(node.type, c_ast.FuncDecl):
+            function = Function(node.name, node.type.type)
+            for parameter in node.type.args.params:
+                function.add_arg(parameter.name, parameter.type)
+            self.functions.append(function)
+        else:
+            raise RuntimeError(f"Unknown declaration type for {node_name}")
 
     def visit_Typedef(self, node):
         # Extract mts_* types and DLDataTypeCode enum
@@ -265,11 +279,18 @@ elif arch == "64bit":
                 continue
             f.write(f"{name} = {_py_type(c_type)}\n")
 
-        # Auto-generated enums (DLDataTypeCode)
+        # Enums
         for enum in data.enums:
-            f.write(f"\n\nclass {enum.name}(enum.Enum):\n")
-            for name, value in enum.values.items():
-                f.write(f"    {name} = {value}\n")
+            if enum.name == "mts_status_t":
+                # mts_status_t is a special case, we want it to be an int for better
+                # interop with C
+                f.write(f"\n\n{enum.name} = ctypes.c_int\n")
+                for name, value in enum.values.items():
+                    f.write(f"{name} = {value}\n")
+            else:
+                f.write(f"\n\nclass {enum.name}(enum.Enum):\n")
+                for name, value in enum.values.items():
+                    f.write(f"    {name} = {value}\n")
 
         # Manual DLPack struct definitions
         f.write("""
@@ -349,7 +370,7 @@ DLManagedTensorVersioned._fields_ = [
                 f.write(f"\n        {arg},")
             f.write("\n    ]\n")
             restype = _py_type(function.restype)
-            if restype == "mts_status_t":
+            if restype == "mts_status_t" and function.name != "mts_last_error":
                 restype = "_check_status"
             f.write(f"    lib.{function.name}.restype = {restype}\n")
 
@@ -437,7 +458,6 @@ else
 end
 
 Cbool = Cuchar
-mts_status_t = Int32
 mts_data_origin_t = UInt64
 
 mts_create_array_callback_t = Ptr{Cvoid}  # TODO: actual type
@@ -534,16 +554,16 @@ def generate_rust():
                 os.path.join(tmpdir, "c_api.rs"),
                 "--disable-header-comment",
                 "--no-doc-comments",
-                "--default-macro-constant-type=signed",
                 "--merge-extern-blocks",
+                "--must-use-type",
+                "mts_status_t",
                 "--allowlist-function",
                 "^mts_.*",
                 "--allowlist-type",
                 "^mts_.*",
                 "--allowlist-var",
                 "^MTS_.*",
-                "--must-use-type",
-                "mts_status_t",
+                "--no-prepend-enum-name",
                 "--blocklist-type",
                 "DL.*",
                 "--rust-target",

--- a/tox.ini
+++ b/tox.ini
@@ -188,6 +188,8 @@ deps =
     torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.11.*}
     ase
 
+    pycparser
+
 setenv =
     # ignore the fact that metatensor.torch.operations was loaded from a file
     # not in `metatensor/torch/operations`
@@ -196,6 +198,8 @@ setenv =
     UV_INDEX_STRATEGY = unsafe-best-match
 
 commands =
+    python ./scripts/check-c-api-docs.py
+
     # metatensor-core is installed by tox
     # install metatensor and other dependencies
     uv pip install . python/metatensor_operations python/metatensor_learn python/metatensor_torch {[testenv]build_single_wheel} --force-reinstall


### PR DESCRIPTION
We now have `mts_set_last_error` that can re-use the same thread local storage for error as libmetatensor. Both this function and `mts_last_error` allow saving arbitrary data together with the error, which is used to stored C++ or Python exceptions and retreive them later.

This was prompted by painful debugging of some errors where the error thrown by torch was lost to limbo and no longer accessible.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?
