### PR TITLE
Automatically generate ctype declaration for DLPack types

### DIFF
--- a/julia/src/generated/_c_api.jl
+++ b/julia/src/generated/_c_api.jl
@@ -19,30 +19,30 @@ mts_data_origin_t = UInt64
 mts_create_array_callback_t = Ptr{Cvoid}  # TODO: actual type
 mts_realloc_buffer_t = Ptr{Cvoid}         # TODO: actual type
 
-# DLPack types
-struct DLPackVersion
-    major :: UInt32
-    minor :: UInt32
-end
-
-struct DLDevice
-    device_type :: Int32
-    device_id :: Int32
-end
-
-struct DLDataType
-    code :: UInt8
-    bits :: UInt8
-    lanes :: UInt16
-end
-
 # ====== End of manual definitions ====== #
 
 
-# ===== Macros definitions
-
-
 # ===== Enum definitions
+
+
+# enum DLDeviceType
+const DLDeviceType = UInt32
+const kDLCPU = DLDeviceType(1)
+const kDLCUDA = DLDeviceType(2)
+const kDLCUDAHost = DLDeviceType(3)
+const kDLOpenCL = DLDeviceType(4)
+const kDLVulkan = DLDeviceType(7)
+const kDLMetal = DLDeviceType(8)
+const kDLVPI = DLDeviceType(9)
+const kDLROCM = DLDeviceType(10)
+const kDLROCMHost = DLDeviceType(11)
+const kDLExtDev = DLDeviceType(12)
+const kDLCUDAManaged = DLDeviceType(13)
+const kDLOneAPI = DLDeviceType(14)
+const kDLWebGPU = DLDeviceType(15)
+const kDLHexagon = DLDeviceType(16)
+const kDLMAIA = DLDeviceType(17)
+const kDLTrn = DLDeviceType(18)
 
 
 # enum DLDataTypeCode
@@ -79,6 +79,46 @@ const MTS_INTERNAL_ERROR = mts_status_t(255)
 
 
 # ===== Struct definitions
+struct DLPackVersion
+    major :: UInt32
+    minor :: UInt32
+end
+
+struct DLDevice
+    device_type :: DLDeviceType
+    device_id :: Int32
+end
+
+struct DLDataType
+    code :: UInt8
+    bits :: UInt8
+    lanes :: UInt16
+end
+
+struct DLTensor
+    data :: Ptr{Cvoid}
+    device :: DLDevice
+    ndim :: Int32
+    dtype :: DLDataType
+    shape :: Ptr{Int64}
+    strides :: Ptr{Int64}
+    byte_offset :: UInt64
+end
+
+struct DLManagedTensor
+    dl_tensor :: DLTensor
+    manager_ctx :: Ptr{Cvoid}
+    deleter :: Ptr{Cvoid} #= (Ptr{DLManagedTensor}) -> Cvoid =#
+end
+
+struct DLManagedTensorVersioned
+    version :: DLPackVersion
+    manager_ctx :: Ptr{Cvoid}
+    deleter :: Ptr{Cvoid} #= (Ptr{DLManagedTensorVersioned}) -> Cvoid =#
+    flags :: UInt64
+    dl_tensor :: DLTensor
+end
+
 struct mts_block_t
 end
 
@@ -110,7 +150,6 @@ struct mts_array_t
     copy :: Ptr{Cvoid} #= (Ptr{Cvoid}, Ptr{mts_array_t}) -> mts_status_t =#
     move_data :: Ptr{Cvoid} #= (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{mts_data_movement_t}, UIntptr) -> mts_status_t =#
 end
-
 
 
 # ===== Function definitions

--- a/metatensor-core/build.rs
+++ b/metatensor-core/build.rs
@@ -24,7 +24,6 @@ fn main() {
     config.autogen_warning = Some(generated_comment.into());
     config.includes.push("metatensor/version.h".into());
     config.includes.push("metatensor/dlpack/dlpack.h".into());
-    config.after_includes = Some("typedef struct DLManagedTensorVersioned DLManagedTensorVersioned;".into());
 
     let result = cbindgen::Builder::new()
         .with_crate(crate_dir)

--- a/metatensor-core/include/metatensor.h
+++ b/metatensor-core/include/metatensor.h
@@ -14,7 +14,6 @@
 #include <stdlib.h>
 #include "metatensor/version.h"
 #include "metatensor/dlpack/dlpack.h"
-typedef struct DLManagedTensorVersioned DLManagedTensorVersioned;
 
 /**
  * Status type returned by all functions in the C API.

--- a/python/metatensor_core/metatensor/_c_api.py
+++ b/python/metatensor_core/metatensor/_c_api.py
@@ -9,9 +9,45 @@ do not edit it manually!
 """
 
 import ctypes
-import enum
 import platform
 from ctypes import CFUNCTYPE, POINTER
+
+
+class EnumType(type(ctypes.c_int32)):
+    def __new__(metacls, name, bases, dict):
+        if "_members_" not in dict:
+            _members_ = {}
+            for key, value in dict.items():
+                if not key.startswith("_"):
+                    _members_[key] = value
+
+            dict["_members_"] = _members_
+        else:
+            _members_ = dict["_members_"]
+
+        dict["_reverse_map_"] = {v: k for k, v in _members_.items()}
+        cls = type(ctypes.c_int32).__new__(metacls, name, bases, dict)
+        for key, value in cls._members_.items():
+            globals()[key] = value
+        return cls
+
+    def __repr__(self):
+        return "<Enumeration %s>" % self.__name__
+
+
+class Enum(ctypes.c_int32):
+    __metaclass__ = EnumType
+    _members_ = {}
+
+    def __repr__(self):
+        value_str = self._reverse_map_.get(self.value, str(self.value))
+        return f"{self.__class__.__name__}.{value_str}"
+
+    def __eq__(self, other):
+        if isinstance(other, int):
+            return self.value == other
+
+        return type(self) is type(other) and self.value == other.value
 
 
 arch = platform.architecture()[0]
@@ -22,12 +58,26 @@ elif arch == "64bit":
 
 
 
-mts_status_t = ctypes.c_int32
-mts_data_origin_t = ctypes.c_uint64
-mts_realloc_buffer_t = CFUNCTYPE(ctypes.c_char_p, ctypes.c_void_p, ctypes.c_char_p, c_uintptr_t)
+class DLDeviceType(Enum):
+    kDLCPU = 1
+    kDLCUDA = 2
+    kDLCUDAHost = 3
+    kDLOpenCL = 4
+    kDLVulkan = 7
+    kDLMetal = 8
+    kDLVPI = 9
+    kDLROCM = 10
+    kDLROCMHost = 11
+    kDLExtDev = 12
+    kDLCUDAManaged = 13
+    kDLOneAPI = 14
+    kDLWebGPU = 15
+    kDLHexagon = 16
+    kDLMAIA = 17
+    kDLTrn = 18
 
 
-class DLDataTypeCode(enum.Enum):
+class DLDataTypeCode(Enum):
     kDLInt = 0
     kDLUInt = 1
     kDLFloat = 2
@@ -48,61 +98,38 @@ class DLDataTypeCode(enum.Enum):
     kDLFloat4_e2m1fn = 17
 
 
-mts_status_t = ctypes.c_int
-MTS_SUCCESS = 0
-MTS_INVALID_PARAMETER_ERROR = 1
-MTS_IO_ERROR = 2
-MTS_SERIALIZATION_ERROR = 3
-MTS_BUFFER_SIZE_ERROR = 4
-MTS_CALLBACK_ERROR = 254
-MTS_INTERNAL_ERROR = 255
+class mts_status_t(Enum):
+    MTS_SUCCESS = 0
+    MTS_INVALID_PARAMETER_ERROR = 1
+    MTS_IO_ERROR = 2
+    MTS_SERIALIZATION_ERROR = 3
+    MTS_BUFFER_SIZE_ERROR = 4
+    MTS_CALLBACK_ERROR = 254
+    MTS_INTERNAL_ERROR = 255
 
 
-# ============================================================================ #
-# DLPack types
-# ============================================================================ #
 class DLPackVersion(ctypes.Structure):
-    _fields_ = [
-        ("major", ctypes.c_uint32),
-        ("minor", ctypes.c_uint32),
-    ]
+    pass
+
 
 class DLDevice(ctypes.Structure):
-    _fields_ = [
-        ("device_type", ctypes.c_int32),
-        ("device_id", ctypes.c_int32),
-    ]
+    pass
+
 
 class DLDataType(ctypes.Structure):
-    _fields_ = [
-        ("code", ctypes.c_uint8),
-        ("bits", ctypes.c_uint8),
-        ("lanes", ctypes.c_uint16),
-    ]
+    pass
+
 
 class DLTensor(ctypes.Structure):
-    _fields_ = [
-        ("data", ctypes.c_void_p),
-        ("device", DLDevice),
-        ("ndim", ctypes.c_int32),
-        ("dtype", DLDataType),
-        ("shape", POINTER(ctypes.c_int64)),
-        ("strides", POINTER(ctypes.c_int64)),
-        ("byte_offset", ctypes.c_uint64),
-    ]
+    pass
+
+
+class DLManagedTensor(ctypes.Structure):
+    pass
+
 
 class DLManagedTensorVersioned(ctypes.Structure):
     pass
-
-_DLManagedTensorVersionedDeleter = CFUNCTYPE(None, POINTER(DLManagedTensorVersioned))
-
-DLManagedTensorVersioned._fields_ = [
-    ("version", DLPackVersion),
-    ("manager_ctx", ctypes.c_void_p),
-    ("deleter", _DLManagedTensorVersionedDeleter),
-    ("flags", ctypes.c_uint64),
-    ("dl_tensor", DLTensor),
-]
 
 
 class mts_block_t(ctypes.Structure):
@@ -120,6 +147,61 @@ class mts_tensormap_t(ctypes.Structure):
 class mts_data_movement_t(ctypes.Structure):
     pass
 
+
+class mts_array_t(ctypes.Structure):
+    pass
+
+
+DLPackManagedTensorAllocator = CFUNCTYPE(ctypes.c_int, POINTER(DLTensor), POINTER(POINTER(DLManagedTensorVersioned)), ctypes.c_void_p, CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p))
+DLPackManagedTensorFromPyObjectNoSync = CFUNCTYPE(ctypes.c_int, ctypes.c_void_p, POINTER(POINTER(DLManagedTensorVersioned)))
+DLPackDLTensorFromPyObjectNoSync = CFUNCTYPE(ctypes.c_int, ctypes.c_void_p, POINTER(DLTensor))
+DLPackCurrentWorkStream = CFUNCTYPE(ctypes.c_int, DLDeviceType, ctypes.c_int32, POINTER(POINTER(None)))
+DLPackManagedTensorToPyObjectNoSync = CFUNCTYPE(ctypes.c_int, POINTER(DLManagedTensorVersioned), POINTER(POINTER(None)))
+mts_data_origin_t = ctypes.c_uint64
+mts_realloc_buffer_t = CFUNCTYPE(ctypes.c_char_p, ctypes.c_void_p, ctypes.c_char_p, c_uintptr_t)
+mts_create_array_callback_t = CFUNCTYPE(mts_status_t, POINTER(c_uintptr_t), c_uintptr_t, DLDataType, POINTER(mts_array_t))
+
+
+DLPackVersion._fields_ = [
+    ("major", ctypes.c_uint32),
+    ("minor", ctypes.c_uint32),
+]
+
+DLDevice._fields_ = [
+    ("device_type", DLDeviceType),
+    ("device_id", ctypes.c_int32),
+]
+
+DLDataType._fields_ = [
+    ("code", ctypes.c_uint8),
+    ("bits", ctypes.c_uint8),
+    ("lanes", ctypes.c_uint16),
+]
+
+DLTensor._fields_ = [
+    ("data", ctypes.c_void_p),
+    ("device", DLDevice),
+    ("ndim", ctypes.c_int32),
+    ("dtype", DLDataType),
+    ("shape", POINTER(ctypes.c_int64)),
+    ("strides", POINTER(ctypes.c_int64)),
+    ("byte_offset", ctypes.c_uint64),
+]
+
+DLManagedTensor._fields_ = [
+    ("dl_tensor", DLTensor),
+    ("manager_ctx", ctypes.c_void_p),
+    ("deleter", CFUNCTYPE(None, POINTER(DLManagedTensor))),
+]
+
+DLManagedTensorVersioned._fields_ = [
+    ("version", DLPackVersion),
+    ("manager_ctx", ctypes.c_void_p),
+    ("deleter", CFUNCTYPE(None, POINTER(DLManagedTensorVersioned))),
+    ("flags", ctypes.c_uint64),
+    ("dl_tensor", DLTensor),
+]
+
 mts_data_movement_t._fields_ = [
     ("sample_in", c_uintptr_t),
     ("sample_out", c_uintptr_t),
@@ -127,10 +209,6 @@ mts_data_movement_t._fields_ = [
     ("properties_start_out", c_uintptr_t),
     ("properties_length", c_uintptr_t),
 ]
-
-
-class mts_array_t(ctypes.Structure):
-    pass
 
 mts_array_t._fields_ = [
     ("ptr", ctypes.c_void_p),
@@ -146,9 +224,6 @@ mts_array_t._fields_ = [
     ("copy", CFUNCTYPE(mts_status_t, ctypes.c_void_p, POINTER(mts_array_t))),
     ("move_data", CFUNCTYPE(mts_status_t, ctypes.c_void_p, ctypes.c_void_p, POINTER(mts_data_movement_t), c_uintptr_t)),
 ]
-
-
-mts_create_array_callback_t = CFUNCTYPE(mts_status_t, POINTER(c_uintptr_t), c_uintptr_t, DLDataType, POINTER(mts_array_t))
 
 
 def setup_functions(lib):

--- a/python/metatensor_core/metatensor/data/array.py
+++ b/python/metatensor_core/metatensor/data/array.py
@@ -6,6 +6,7 @@ import numpy as np
 from .._c_api import (
     DLDataType,
     DLDevice,
+    DLDeviceType,
     DLManagedTensorVersioned,
     DLPackVersion,
     c_uintptr_t,
@@ -284,7 +285,7 @@ def _extract_scalar_from_mts_array(mts_array):
 
     # Use as_dlpack to get the data
     dl_managed_ptr = ctypes.POINTER(DLManagedTensorVersioned)()
-    device = DLDevice(device_type=1, device_id=0)  # kDLCPU
+    device = DLDevice(device_type=DLDeviceType.kDLCPU, device_id=0)
     version = DLPackVersion(major=1, minor=0)
     status = mts_array.as_dlpack(
         mts_array.ptr,
@@ -430,7 +431,7 @@ def _mts_array_as_dlpack(this, dl_managed_tensor_ptr_ptr, device, stream, max_ve
     wrapper = _KNOWN_ARRAY_WRAPPERS[this]
     array = wrapper.array
 
-    dl_device = (device.device_type, device.device_id)
+    dl_device = (device.device_type.value, device.device_id)
     stream = stream.contents if stream else None
     max_version = (max_version.major, max_version.minor)
 
@@ -443,7 +444,6 @@ def _mts_array_as_dlpack(this, dl_managed_tensor_ptr_ptr, device, stream, max_ve
         )
     except Exception as _:
         # Fallback to legacy signatures. Each fallback drops one parameter.
-        # Warn so users know their array library doesn't support full DLPack.
         try:
             capsule = array.__dlpack__(stream=stream, dl_device=dl_device)
         except Exception:
@@ -556,11 +556,6 @@ _MTS_ARRAY_ORIGIN_NUMPY = _cast_to_ctype_functype(mts_array_origin_numpy, "origi
 _MTS_ARRAY_ORIGIN_PYTORCH = _cast_to_ctype_functype(mts_array_origin_pytorch, "origin")
 
 
-# DLPack device type codes (from dlpack.h DLDeviceType enum)
-_KDLCPU = 1
-_KDLCUDA = 2
-
-
 @catch_exceptions
 def _mts_array_device_numpy(this, device_ptr):
     wrapper = _KNOWN_ARRAY_WRAPPERS[this]
@@ -570,7 +565,7 @@ def _mts_array_device_numpy(this, device_ptr):
         device_ptr[0] = DLDevice(device_type=device_type, device_id=device_id)
     except Exception:
         # Fallback for older numpy versions that don't have __dlpack_device__
-        device_ptr[0] = DLDevice(device_type=_KDLCPU, device_id=0)
+        device_ptr[0] = DLDevice(device_type=DLDeviceType.kDLCPU, device_id=0)
 
 
 @catch_exceptions
@@ -584,15 +579,15 @@ def _mts_array_device_pytorch(this, device_ptr):
         # Fallback for older torch version that don't have __dlpack_device__
         torch_dev = tensor.device
         if torch_dev.type == "cpu":
-            device_ptr[0] = DLDevice(device_type=_KDLCPU, device_id=0)
+            device_ptr[0] = DLDevice(device_type=DLDeviceType.kDLCPU, device_id=0)
         elif torch_dev.type == "cuda":
             device_ptr[0] = DLDevice(
-                device_type=_KDLCUDA, device_id=torch_dev.index or 0
+                device_type=DLDeviceType.kDLCUDA, device_id=torch_dev.index or 0
             )
         elif torch_dev.type == "meta":
-            device_ptr[0] = DLDevice(device_type=12, device_id=0)  # kDLExtDev
+            device_ptr[0] = DLDevice(device_type=DLDeviceType.kDLExtDev, device_id=0)
         else:
-            device_ptr[0] = DLDevice(device_type=_KDLCPU, device_id=0)
+            raise ValueError(f"unsupported torch device type: {torch_dev.type}")
 
 
 _MTS_ARRAY_DEVICE_NUMPY = _cast_to_ctype_functype(_mts_array_device_numpy, "device")

--- a/python/metatensor_core/metatensor/data/extract.py
+++ b/python/metatensor_core/metatensor/data/extract.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from .._c_api import (
     DLDevice,
+    DLDeviceType,
     DLManagedTensorVersioned,
     DLPackVersion,
     c_uintptr_t,
@@ -161,7 +162,7 @@ class ExternalCpuArray(np.ndarray):
 
         # Use as_dlpack to get data pointer and dtype
         dl_managed_ptr = ctypes.POINTER(DLManagedTensorVersioned)()
-        device = DLDevice(device_type=1, device_id=0)  # kDLCPU
+        device = DLDevice(device_type=DLDeviceType.kDLCPU, device_id=0)
         version = DLPackVersion(major=1, minor=0)
         status = mts_array.as_dlpack(
             mts_array.ptr,

--- a/python/metatensor_core/metatensor/io/_block.py
+++ b/python/metatensor_core/metatensor/io/_block.py
@@ -24,20 +24,20 @@ from ._utils import _save_buffer_raw
 
 
 _DLPACK_TO_NUMPY = {
-    (DLDataTypeCode.kDLFloat.value, 16): np.float16,
-    (DLDataTypeCode.kDLFloat.value, 32): np.float32,
-    (DLDataTypeCode.kDLFloat.value, 64): np.float64,
-    (DLDataTypeCode.kDLInt.value, 8): np.int8,
-    (DLDataTypeCode.kDLInt.value, 16): np.int16,
-    (DLDataTypeCode.kDLInt.value, 32): np.int32,
-    (DLDataTypeCode.kDLInt.value, 64): np.int64,
-    (DLDataTypeCode.kDLUInt.value, 8): np.uint8,
-    (DLDataTypeCode.kDLUInt.value, 16): np.uint16,
-    (DLDataTypeCode.kDLUInt.value, 32): np.uint32,
-    (DLDataTypeCode.kDLUInt.value, 64): np.uint64,
-    (DLDataTypeCode.kDLBool.value, 8): np.bool_,
-    (DLDataTypeCode.kDLComplex.value, 64): np.complex64,
-    (DLDataTypeCode.kDLComplex.value, 128): np.complex128,
+    (DLDataTypeCode.kDLFloat, 16): np.float16,
+    (DLDataTypeCode.kDLFloat, 32): np.float32,
+    (DLDataTypeCode.kDLFloat, 64): np.float64,
+    (DLDataTypeCode.kDLInt, 8): np.int8,
+    (DLDataTypeCode.kDLInt, 16): np.int16,
+    (DLDataTypeCode.kDLInt, 32): np.int32,
+    (DLDataTypeCode.kDLInt, 64): np.int64,
+    (DLDataTypeCode.kDLUInt, 8): np.uint8,
+    (DLDataTypeCode.kDLUInt, 16): np.uint16,
+    (DLDataTypeCode.kDLUInt, 32): np.uint32,
+    (DLDataTypeCode.kDLUInt, 64): np.uint64,
+    (DLDataTypeCode.kDLBool, 8): np.bool_,
+    (DLDataTypeCode.kDLComplex, 64): np.complex64,
+    (DLDataTypeCode.kDLComplex, 128): np.complex128,
 }
 
 
@@ -62,17 +62,17 @@ def _dlpack_dtype_to_torch(dtype):
     import torch
 
     _MAP = {
-        (DLDataTypeCode.kDLFloat.value, 16): torch.float16,
-        (DLDataTypeCode.kDLFloat.value, 32): torch.float32,
-        (DLDataTypeCode.kDLFloat.value, 64): torch.float64,
-        (DLDataTypeCode.kDLInt.value, 8): torch.int8,
-        (DLDataTypeCode.kDLInt.value, 16): torch.int16,
-        (DLDataTypeCode.kDLInt.value, 32): torch.int32,
-        (DLDataTypeCode.kDLInt.value, 64): torch.int64,
-        (DLDataTypeCode.kDLUInt.value, 8): torch.uint8,
-        (DLDataTypeCode.kDLBool.value, 8): torch.bool,
-        (DLDataTypeCode.kDLComplex.value, 64): torch.complex64,
-        (DLDataTypeCode.kDLComplex.value, 128): torch.complex128,
+        (DLDataTypeCode.kDLFloat, 16): torch.float16,
+        (DLDataTypeCode.kDLFloat, 32): torch.float32,
+        (DLDataTypeCode.kDLFloat, 64): torch.float64,
+        (DLDataTypeCode.kDLInt, 8): torch.int8,
+        (DLDataTypeCode.kDLInt, 16): torch.int16,
+        (DLDataTypeCode.kDLInt, 32): torch.int32,
+        (DLDataTypeCode.kDLInt, 64): torch.int64,
+        (DLDataTypeCode.kDLUInt, 8): torch.uint8,
+        (DLDataTypeCode.kDLBool, 8): torch.bool,
+        (DLDataTypeCode.kDLComplex, 64): torch.complex64,
+        (DLDataTypeCode.kDLComplex, 128): torch.complex128,
     }
     result = _MAP.get((dtype.code, dtype.bits))
     if result is None:

--- a/python/metatensor_core/metatensor/status.py
+++ b/python/metatensor_core/metatensor/status.py
@@ -4,7 +4,7 @@ import ctypes
 import sys
 from typing import Optional
 
-from ._c_api import MTS_SUCCESS
+from ._c_api import mts_status_t
 
 
 class MetatensorError(Exception):
@@ -21,7 +21,7 @@ class MetatensorError(Exception):
 
 
 def _check_status(status):
-    if status == MTS_SUCCESS:
+    if status == mts_status_t.MTS_SUCCESS:
         return
     else:
         raise _get_exception(status)
@@ -92,7 +92,7 @@ def _get_exception(status=None):
         ctypes.byref(message), ctypes.byref(origin), ctypes.byref(user_data)
     )
 
-    if status != MTS_SUCCESS:
+    if status != mts_status_t.MTS_SUCCESS:
         return MetatensorError(
             "INTERNAL ERROR: failed to get the last error", status=status
         )
@@ -116,7 +116,7 @@ def _clear_last_error():
         lib = _get_library()
         origin = ctypes.c_char_p()
         status = lib.mts_last_error(None, ctypes.byref(origin), None)
-        if status == MTS_SUCCESS and origin.value == b"Python exception":
+        if status == mts_status_t.MTS_SUCCESS and origin.value == b"Python exception":
             lib.mts_set_last_error(None, None, None, None)
     except Exception:
         pass

--- a/python/metatensor_core/metatensor/utils.py
+++ b/python/metatensor_core/metatensor/utils.py
@@ -19,7 +19,7 @@ except ImportError:
         pass
 
 
-from ._c_api import MTS_BUFFER_SIZE_ERROR, MTS_CALLBACK_ERROR, MTS_SUCCESS
+from ._c_api import mts_status_t
 from .status import MetatensorError, _save_exception
 
 
@@ -32,7 +32,7 @@ def _call_with_growing_buffer(callback, initial=1024):
             callback(buffer, bufflen)
             break
         except MetatensorError as e:
-            if e.status == MTS_BUFFER_SIZE_ERROR:
+            if e.status == mts_status_t.MTS_BUFFER_SIZE_ERROR:
                 # grow the buffer and retry
                 bufflen *= 2
             else:
@@ -47,8 +47,8 @@ def catch_exceptions(function):
             function(*args, **kwargs)
         except Exception as e:
             _save_exception(e)
-            return MTS_CALLBACK_ERROR
-        return MTS_SUCCESS
+            return mts_status_t.MTS_CALLBACK_ERROR
+        return mts_status_t.MTS_SUCCESS
 
     return inner
 

--- a/python/metatensor_core/tests/data.py
+++ b/python/metatensor_core/tests/data.py
@@ -17,14 +17,15 @@ except ImportError:
 
 import metatensor
 from metatensor._c_api import (
-    MTS_SUCCESS,
     DLDevice,
+    DLDeviceType,
     DLManagedTensorVersioned,
     DLPackVersion,
     c_uintptr_t,
     mts_array_t,
     mts_data_movement_t,
 )
+from metatensor.status import _check_status
 
 
 # Kanged from the metatensor-torch _test_utils
@@ -59,9 +60,8 @@ class MtsArrayMixin:
         mts_array = metatensor.data.create_mts_array(array)
 
         device = DLDevice()
-        status = mts_array.device(mts_array.ptr, device)
-        assert status == MTS_SUCCESS
-        assert device.device_type == 1  # kDLCPU
+        _check_status(mts_array.device(mts_array.ptr, device))
+        assert device.device_type == DLDeviceType.kDLCPU
         assert device.device_id == 0
 
         free_mts_array(mts_array)
@@ -73,8 +73,7 @@ class MtsArrayMixin:
         assert _get_shape(mts_array, self) == [2, 3, 4]
 
         new_shape = ctypes.ARRAY(c_uintptr_t, 4)(2, 3, 2, 2)
-        status = mts_array.reshape(mts_array.ptr, new_shape, len(new_shape))
-        assert status == MTS_SUCCESS
+        _check_status(mts_array.reshape(mts_array.ptr, new_shape, len(new_shape)))
 
         assert _get_shape(mts_array, self) == [2, 3, 2, 2]
 
@@ -102,15 +101,15 @@ class MtsArrayMixin:
             fill_value_array = self.create_array((), dtype=dtype)
             fill_value_mts = metatensor.data.create_mts_array(fill_value_array)
 
-            status = mts_array.create(
-                mts_array.ptr,
-                new_shape,
-                len(new_shape),
-                fill_value_mts,
-                new_mts_array,
+            _check_status(
+                mts_array.create(
+                    mts_array.ptr,
+                    new_shape,
+                    len(new_shape),
+                    fill_value_mts,
+                    new_mts_array,
+                )
             )
-
-            assert status == MTS_SUCCESS
 
             new_array = metatensor.data.mts_array_to_python_array(new_mts_array)
             assert id(new_array) != id(array)
@@ -141,8 +140,7 @@ class MtsArrayMixin:
         mts_array = metatensor.data.create_mts_array(array)
 
         copy = mts_array_t()
-        status = mts_array.copy(mts_array.ptr, copy)
-        assert status == MTS_SUCCESS
+        _check_status(mts_array.copy(mts_array.ptr, copy))
 
         array_copy = metatensor.data.mts_array_to_python_array(copy)
         assert id(array_copy) != id(array)
@@ -224,16 +222,17 @@ class MtsArrayMixin:
         dl_managed_ptr = ctypes.POINTER(DLManagedTensorVersioned)()
         version = DLPackVersion(1, 0)
 
-        status = mts_array.as_dlpack(
-            mts_array.ptr,
-            ctypes.byref(dl_managed_ptr),
-            dldevice,
-            None,  # stream
-            version,
+        _check_status(
+            mts_array.as_dlpack(
+                mts_array.ptr,
+                ctypes.byref(dl_managed_ptr),
+                dldevice,
+                None,  # stream
+                version,
+            )
         )
 
         # Check we got a valid pointer back
-        assert status == MTS_SUCCESS
         assert bool(dl_managed_ptr)
 
         # Dereference to check contents
@@ -355,9 +354,7 @@ if HAS_TORCH:
 def _get_shape(mts_array, test):
     shape_ptr = ctypes.POINTER(c_uintptr_t)()
     shape_count = c_uintptr_t()
-    status = mts_array.shape(mts_array.ptr, shape_ptr, shape_count)
-
-    assert status == MTS_SUCCESS
+    _check_status(mts_array.shape(mts_array.ptr, shape_ptr, shape_count))
 
     shape = []
     for i in range(shape_count.value):
@@ -402,8 +399,10 @@ def test_external_cuda_array_cpu_path():
     arr = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
     mts_array = metatensor.data.create_mts_array(arr)
 
-    # Use device_type=1 (kDLCPU) to test the full code path without a GPU
-    result = ExternalCudaArray(mts_array, parent=None, device_type=1, device_id=0)
+    # Use kDLCP) to test the full code path without a GPU
+    result = ExternalCudaArray(
+        mts_array, parent=None, device_type=DLDeviceType.kDLCPU, device_id=0
+    )
 
     assert isinstance(result, torch.Tensor)
     assert result.shape == (2, 2)

--- a/scripts/update-declarations.py
+++ b/scripts/update-declarations.py
@@ -27,17 +27,6 @@ METATENSOR_HEADER = os.path.relpath(
     os.path.join(ROOT, "metatensor-core", "include", "metatensor.h")
 )
 
-# DL types that appear in the mts_array_t vtable and public API
-DLPACK_TYPES = frozenset(
-    {
-        "DLDevice",
-        "DLPackVersion",
-        "DLDataType",
-        "DLDataTypeCode",
-        "DLManagedTensorVersioned",
-    }
-)
-
 
 # ============================================================================ #
 # Shared AST parsing
@@ -104,8 +93,8 @@ class AstVisitor(c_ast.NodeVisitor):
             raise RuntimeError(f"Unknown declaration type for {node_name}")
 
     def visit_Typedef(self, node):
-        # Extract mts_* types and DLDataTypeCode enum
-        if not (node.name.startswith("mts_") or node.name == "DLDataTypeCode"):
+        # Extract metatensor and dlpack stuff only
+        if not (node.name.startswith("mts_") or node.name.startswith("DL")):
             return
 
         if isinstance(node.type.type, c_ast.Enum):
@@ -117,6 +106,9 @@ class AstVisitor(c_ast.NodeVisitor):
             self.enums.append(enum)
 
         elif isinstance(node.type.type, c_ast.Struct):
+            if node.name.startswith("DLPackExchangeAPI"):
+                return
+
             struct = Struct(node.name)
             for _, member in node.type.type.children():
                 struct.add_member(member.name, member.type)
@@ -164,7 +156,7 @@ def parse_header(file):
 
 
 def _py_type_name(name):
-    if name.startswith("mts_") or name in DLPACK_TYPES:
+    if name.startswith("mts_") or name.startswith("DL"):
         return name
     elif name == "uintptr_t":
         return "c_uintptr_t"
@@ -254,9 +246,45 @@ do not edit it manually!
 \"\"\"
 
 import ctypes
-import enum
 import platform
 from ctypes import CFUNCTYPE, POINTER
+
+
+class EnumType(type(ctypes.c_int32)):
+    def __new__(metacls, name, bases, dict):
+        if "_members_" not in dict:
+            _members_ = {}
+            for key, value in dict.items():
+                if not key.startswith("_"):
+                    _members_[key] = value
+
+            dict["_members_"] = _members_
+        else:
+            _members_ = dict["_members_"]
+
+        dict["_reverse_map_"] = {v: k for k, v in _members_.items()}
+        cls = type(ctypes.c_int32).__new__(metacls, name, bases, dict)
+        for key, value in cls._members_.items():
+            globals()[key] = value
+        return cls
+
+    def __repr__(self):
+        return "<Enumeration %s>" % self.__name__
+
+
+class Enum(ctypes.c_int32):
+    __metaclass__ = EnumType
+    _members_ = {}
+
+    def __repr__(self):
+        value_str = self._reverse_map_.get(self.value, str(self.value))
+        return f"{self.__class__.__name__}.{value_str}"
+
+    def __eq__(self, other):
+        if isinstance(other, int):
+            return self.value == other
+
+        return type(self) is type(other) and self.value == other.value
 
 
 arch = platform.architecture()[0]
@@ -268,95 +296,34 @@ elif arch == "64bit":
 """
         )
 
-        # #define constants
-        for name, value in data.defines.items():
-            f.write(f"{name} = {value}\n")
-        f.write("\n\n")
-
-        # Simple typedefs (mts_status_t, etc.) -- skip callback, generated later
-        for name, c_type in data.types.items():
-            if name == "mts_create_array_callback_t":
-                continue
-            f.write(f"{name} = {_py_type(c_type)}\n")
-
         # Enums
         for enum in data.enums:
-            if enum.name == "mts_status_t":
-                # mts_status_t is a special case, we want it to be an int for better
-                # interop with C
-                f.write(f"\n\n{enum.name} = ctypes.c_int\n")
-                for name, value in enum.values.items():
-                    f.write(f"{name} = {value}\n")
-            else:
-                f.write(f"\n\nclass {enum.name}(enum.Enum):\n")
-                for name, value in enum.values.items():
-                    f.write(f"    {name} = {value}\n")
+            f.write(f"\n\nclass {enum.name}(Enum):\n")
+            for name, value in enum.values.items():
+                f.write(f"    {name} = {value}\n")
 
-        # Manual DLPack struct definitions
-        f.write("""
-
-# ============================================================================ #
-# DLPack types
-# ============================================================================ #
-class DLPackVersion(ctypes.Structure):
-    _fields_ = [
-        ("major", ctypes.c_uint32),
-        ("minor", ctypes.c_uint32),
-    ]
-
-class DLDevice(ctypes.Structure):
-    _fields_ = [
-        ("device_type", ctypes.c_int32),
-        ("device_id", ctypes.c_int32),
-    ]
-
-class DLDataType(ctypes.Structure):
-    _fields_ = [
-        ("code", ctypes.c_uint8),
-        ("bits", ctypes.c_uint8),
-        ("lanes", ctypes.c_uint16),
-    ]
-
-class DLTensor(ctypes.Structure):
-    _fields_ = [
-        ("data", ctypes.c_void_p),
-        ("device", DLDevice),
-        ("ndim", ctypes.c_int32),
-        ("dtype", DLDataType),
-        ("shape", POINTER(ctypes.c_int64)),
-        ("strides", POINTER(ctypes.c_int64)),
-        ("byte_offset", ctypes.c_uint64),
-    ]
-
-class DLManagedTensorVersioned(ctypes.Structure):
-    pass
-
-_DLManagedTensorVersionedDeleter = CFUNCTYPE(None, POINTER(DLManagedTensorVersioned))
-
-DLManagedTensorVersioned._fields_ = [
-    ("version", DLPackVersion),
-    ("manager_ctx", ctypes.c_void_p),
-    ("deleter", _DLManagedTensorVersionedDeleter),
-    ("flags", ctypes.c_uint64),
-    ("dl_tensor", DLTensor),
-]
-""")
-
-        # mts_* structs
+        # structs declartions, without fields
         for struct in data.structs:
             f.write(f"\n\nclass {struct.name}(ctypes.Structure):\n")
             f.write("    pass\n")
+
+        # typedefs
+        f.write("\n\n")
+        for name, c_type in data.types.items():
+            if name == "mts_status_t":
+                # this is already defined as an enum
+                continue
+            f.write(f"{name} = {_py_type(c_type)}\n")
+
+        # structs fields definitions
+        f.write("\n")
+        for struct in data.structs:
             if len(struct.members) == 0:
                 continue
             f.write(f"\n{struct.name}._fields_ = [\n")
             for name, type in struct.members.items():
                 f.write(f'    ("{name}", {_py_type(type)}),\n')
             f.write("]\n")
-
-        # Callback typedef (depends on structs above)
-        f.write("\n\n")
-        callback_type = _py_type(data.types["mts_create_array_callback_t"])
-        f.write(f"mts_create_array_callback_t = {callback_type}\n")
 
         # Functions
         f.write("\n\ndef setup_functions(lib):\n")
@@ -393,7 +360,7 @@ CTYPES_TO_JULIA = {
 
 
 def _jl_type_name(name):
-    if name.startswith("mts_") or name in DLPACK_TYPES:
+    if name.startswith("mts_") or name.startswith("DL"):
         return name
     if name in CTYPES_TO_JULIA:
         return CTYPES_TO_JULIA[name]
@@ -463,33 +430,11 @@ mts_data_origin_t = UInt64
 mts_create_array_callback_t = Ptr{Cvoid}  # TODO: actual type
 mts_realloc_buffer_t = Ptr{Cvoid}         # TODO: actual type
 
-# DLPack types
-struct DLPackVersion
-    major :: UInt32
-    minor :: UInt32
-end
-
-struct DLDevice
-    device_type :: Int32
-    device_id :: Int32
-end
-
-struct DLDataType
-    code :: UInt8
-    bits :: UInt8
-    lanes :: UInt16
-end
-
 # ====== End of manual definitions ====== #
 """
         )
 
-        # #define constants
-        f.write("\n\n# ===== Macros definitions\n")
-        for name, value in data.defines.items():
-            f.write(f"{name} = {value}\n")
-
-        # Enums (DLDataTypeCode if extracted)
+        # Enums
         f.write("\n\n# ===== Enum definitions\n")
         for enum in data.enums:
             f.write(f"\n\n# enum {enum.name}\nconst {enum.name} = UInt32\n")
@@ -505,7 +450,7 @@ end
             f.write("end\n\n")
 
         # Functions
-        f.write("\n\n# ===== Function definitions\n")
+        f.write("\n# ===== Function definitions\n")
         for function in data.functions:
             args = [(arg[0], _jl_type(arg[1])) for arg in function.args]
             if args == [(None, "Cvoid")]:


### PR DESCRIPTION
This removes the manual definition for dlpack types in Python and julia bindings, making sure the code stays up to date, and giving full access to the enum values.

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
