### PR TITLE
Preserve info dict under multiple operations

### DIFF
--- a/python/metatensor_operations/metatensor_operations/_abs.py
+++ b/python/metatensor_operations/metatensor_operations/_abs.py
@@ -69,4 +69,7 @@ def abs(A: TensorMap) -> TensorMap:
     keys = A.keys
     for i in range(len(keys)):
         blocks.append(_abs_block(block=A.block(keys.entry(i))))
-    return TensorMap(keys, blocks)
+    result = TensorMap(keys, blocks)
+    for name, value in A.info().items():
+        result.set_info(name, value)
+    return result

--- a/python/metatensor_operations/metatensor_operations/_add.py
+++ b/python/metatensor_operations/metatensor_operations/_add.py
@@ -141,4 +141,8 @@ def add(A: TensorMap, B: Union[int, float, TensorMap]) -> TensorMap:
 
         raise TypeError("`B` must be a metatensor TensorMap or a scalar value" + extra)
 
-    return TensorMap(A.keys, blocks)
+    result = TensorMap(A.keys, blocks)
+    if not is_tensor_map:
+        for name, value in A.info().items():
+            result.set_info(name, value)
+    return result

--- a/python/metatensor_operations/metatensor_operations/_detach.py
+++ b/python/metatensor_operations/metatensor_operations/_detach.py
@@ -61,4 +61,7 @@ def detach(tensor: TensorMap) -> TensorMap:
     for block in tensor.blocks():
         blocks.append(detach_block(block))
 
-    return TensorMap(tensor.keys, blocks)
+    result = TensorMap(tensor.keys, blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result

--- a/python/metatensor_operations/metatensor_operations/_divide.py
+++ b/python/metatensor_operations/metatensor_operations/_divide.py
@@ -162,4 +162,8 @@ def divide(A: TensorMap, B: Union[float, int, TensorMap]) -> TensorMap:
 
         raise TypeError("`B` must be a metatensor TensorMap or a scalar value" + extra)
 
-    return TensorMap(A.keys, blocks)
+    result = TensorMap(A.keys, blocks)
+    if not is_tensor_map:
+        for name, value in A.info().items():
+            result.set_info(name, value)
+    return result

--- a/python/metatensor_operations/metatensor_operations/_drop_blocks.py
+++ b/python/metatensor_operations/metatensor_operations/_drop_blocks.py
@@ -98,7 +98,10 @@ def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> TensorMa
             ),
         )
 
-    return TensorMap(keys=new_keys, blocks=new_blocks)
+    result = TensorMap(keys=new_keys, blocks=new_blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result
 
 
 @torch_jit_script
@@ -174,4 +177,7 @@ def drop_empty_blocks(tensor: TensorMap, copy: bool = False) -> TensorMap:
                 tensor.keys.values, (0, len(tensor.keys.names))
             ),
         )
-    return TensorMap(keys=new_keys, blocks=new_blocks)
+    result = TensorMap(keys=new_keys, blocks=new_blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result

--- a/python/metatensor_operations/metatensor_operations/_empty_like.py
+++ b/python/metatensor_operations/metatensor_operations/_empty_like.py
@@ -155,4 +155,7 @@ def empty_like(
                 block=block, gradients=gradients, requires_grad=requires_grad
             )
         )
-    return TensorMap(tensor.keys, blocks)
+    result = TensorMap(tensor.keys, blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result

--- a/python/metatensor_operations/metatensor_operations/_filter_blocks.py
+++ b/python/metatensor_operations/metatensor_operations/_filter_blocks.py
@@ -94,4 +94,7 @@ def filter_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> Tensor
             ),
         )
 
-    return TensorMap(keys=new_keys, blocks=new_blocks)
+    result = TensorMap(keys=new_keys, blocks=new_blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result

--- a/python/metatensor_operations/metatensor_operations/_make_contiguous.py
+++ b/python/metatensor_operations/metatensor_operations/_make_contiguous.py
@@ -46,4 +46,7 @@ def make_contiguous(tensor: TensorMap) -> TensorMap:
     for block in tensor.blocks():
         new_blocks.append(make_contiguous_block(block))
 
-    return TensorMap(tensor.keys, new_blocks)
+    result = TensorMap(tensor.keys, new_blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result

--- a/python/metatensor_operations/metatensor_operations/_manipulate_dimension.py
+++ b/python/metatensor_operations/metatensor_operations/_manipulate_dimension.py
@@ -125,7 +125,10 @@ def insert_dimension(
 
         blocks.append(new_block)
 
-    return TensorMap(keys=keys, blocks=blocks)
+    result = TensorMap(keys=keys, blocks=blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result
 
 
 @torch_jit_script
@@ -269,7 +272,10 @@ def permute_dimensions(
 
         blocks.append(new_block)
 
-    return TensorMap(keys=keys, blocks=blocks)
+    result = TensorMap(keys=keys, blocks=blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result
 
 
 @torch_jit_script
@@ -364,7 +370,10 @@ def remove_dimension(tensor: TensorMap, axis: str, name: str) -> TensorMap:
 
         blocks.append(new_block)
 
-    return TensorMap(keys=keys, blocks=blocks)
+    result = TensorMap(keys=keys, blocks=blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result
 
 
 @torch_jit_script
@@ -456,4 +465,7 @@ def rename_dimension(tensor: TensorMap, axis: str, old: str, new: str) -> Tensor
 
         blocks.append(new_block)
 
-    return TensorMap(keys=keys, blocks=blocks)
+    result = TensorMap(keys=keys, blocks=blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result

--- a/python/metatensor_operations/metatensor_operations/_multiply.py
+++ b/python/metatensor_operations/metatensor_operations/_multiply.py
@@ -149,4 +149,8 @@ def multiply(A: TensorMap, B: Union[float, int, TensorMap]) -> TensorMap:
 
         raise TypeError("`B` must be a metatensor TensorMap or a scalar value" + extra)
 
-    return TensorMap(A.keys, blocks)
+    result = TensorMap(A.keys, blocks)
+    if not is_tensor_map:
+        for name, value in A.info().items():
+            result.set_info(name, value)
+    return result

--- a/python/metatensor_operations/metatensor_operations/_ones_like.py
+++ b/python/metatensor_operations/metatensor_operations/_ones_like.py
@@ -168,4 +168,7 @@ def ones_like(
                 block=block, gradients=gradients, requires_grad=requires_grad
             )
         )
-    return TensorMap(tensor.keys, blocks)
+    result = TensorMap(tensor.keys, blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result

--- a/python/metatensor_operations/metatensor_operations/_pow.py
+++ b/python/metatensor_operations/metatensor_operations/_pow.py
@@ -88,4 +88,7 @@ def pow(A: TensorMap, B: Union[float, int]) -> TensorMap:
     for block_A in A.blocks():
         blocks.append(_pow_block_constant(block=block_A, constant=B))
 
-    return TensorMap(A.keys, blocks)
+    result = TensorMap(A.keys, blocks)
+    for name, value in A.info().items():
+        result.set_info(name, value)
+    return result

--- a/python/metatensor_operations/metatensor_operations/_random_like.py
+++ b/python/metatensor_operations/metatensor_operations/_random_like.py
@@ -177,4 +177,7 @@ def random_uniform_like(
                 requires_grad=requires_grad,
             )
         )
-    return TensorMap(tensor.keys, blocks)
+    result = TensorMap(tensor.keys, blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result

--- a/python/metatensor_operations/metatensor_operations/_reduce_over_properties.py
+++ b/python/metatensor_operations/metatensor_operations/_reduce_over_properties.py
@@ -336,7 +336,10 @@ def _reduce_over_properties(
                 remaining_properties=remaining_properties,
             )
         )
-    return TensorMap(tensor.keys, blocks)
+    result = TensorMap(tensor.keys, blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result
 
 
 @torch_jit_script

--- a/python/metatensor_operations/metatensor_operations/_reduce_over_samples.py
+++ b/python/metatensor_operations/metatensor_operations/_reduce_over_samples.py
@@ -328,7 +328,10 @@ def _reduce_over_samples(
                 remaining_samples=remaining_samples,
             )
         )
-    return TensorMap(tensor.keys, blocks)
+    result = TensorMap(tensor.keys, blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result
 
 
 @torch_jit_script

--- a/python/metatensor_operations/metatensor_operations/_remove_gradients.py
+++ b/python/metatensor_operations/metatensor_operations/_remove_gradients.py
@@ -83,4 +83,7 @@ def remove_gradients(
     for block in tensor.blocks():
         blocks.append(remove_gradients_block(block, remove))
 
-    return TensorMap(tensor.keys, blocks)
+    result = TensorMap(tensor.keys, blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result

--- a/python/metatensor_operations/metatensor_operations/_requires_grad.py
+++ b/python/metatensor_operations/metatensor_operations/_requires_grad.py
@@ -58,4 +58,7 @@ def requires_grad(tensor: TensorMap, requires_grad: bool = True) -> TensorMap:
     for block in tensor.blocks():
         blocks.append(requires_grad_block(block, requires_grad=requires_grad))
 
-    return TensorMap(tensor.keys, blocks)
+    result = TensorMap(tensor.keys, blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result

--- a/python/metatensor_operations/metatensor_operations/_slice.py
+++ b/python/metatensor_operations/metatensor_operations/_slice.py
@@ -244,13 +244,16 @@ def slice(tensor: TensorMap, axis: str, selection: Labels) -> TensorMap:
 
     _check_slice_args(tensor.block(0), axis=axis, selection=selection)
 
-    return TensorMap(
+    result = TensorMap(
         keys=tensor.keys,
         blocks=[
             _slice_block(tensor[tensor.keys.entry(i)], axis, selection)
             for i in range(len(tensor.keys))
         ],
     )
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result
 
 
 @torch_jit_script

--- a/python/metatensor_operations/metatensor_operations/_sort.py
+++ b/python/metatensor_operations/metatensor_operations/_sort.py
@@ -399,4 +399,7 @@ def sort(
             )
         )
 
-    return TensorMap(new_keys, new_blocks)
+    result = TensorMap(new_keys, new_blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result

--- a/python/metatensor_operations/metatensor_operations/_split.py
+++ b/python/metatensor_operations/metatensor_operations/_split.py
@@ -163,10 +163,13 @@ def split(
         for group_i, new_block in enumerate(new_blocks):
             all_new_blocks[group_i].append(new_block)
 
-    return [
-        TensorMap(keys=tensor.keys, blocks=all_new_blocks[group_i])
-        for group_i in range(len(selections))
-    ]
+    result_tensors: List[TensorMap] = []
+    for group_i in range(len(selections)):
+        new_tensor = TensorMap(keys=tensor.keys, blocks=all_new_blocks[group_i])
+        for name, value in tensor.info().items():
+            new_tensor.set_info(name, value)
+        result_tensors.append(new_tensor)
+    return result_tensors
 
 
 @torch_jit_script

--- a/python/metatensor_operations/metatensor_operations/_zeros_like.py
+++ b/python/metatensor_operations/metatensor_operations/_zeros_like.py
@@ -168,4 +168,7 @@ def zeros_like(
                 block=block, gradients=gradients, requires_grad=requires_grad
             )
         )
-    return TensorMap(tensor.keys, blocks)
+    result = TensorMap(tensor.keys, blocks)
+    for name, value in tensor.info().items():
+        result.set_info(name, value)
+    return result

--- a/python/metatensor_operations/tests/_tests_utils.py
+++ b/python/metatensor_operations/tests/_tests_utils.py
@@ -127,3 +127,55 @@ def large_tensor():
         ),
     )
     return TensorMap(keys, blocks)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers for info propagation tests
+# ---------------------------------------------------------------------------
+
+_INFO = {"description": "test_value", "key2": "value2"}
+
+
+def tensor_with_info() -> TensorMap:
+    """Return the standard test tensor with two info entries set."""
+    t = tensor()
+    t.set_info("description", "test_value")
+    t.set_info("key2", "value2")
+    return t
+
+
+def simple_tensor() -> TensorMap:
+    """Return a minimal one-block TensorMap with info set."""
+    block = TensorBlock(
+        values=np.array([[1.0, 2.0], [3.0, 4.0]]),
+        samples=Labels(["s"], np.array([[0], [1]])),
+        components=[],
+        properties=Labels(["p"], np.array([[0], [1]])),
+    )
+    t = TensorMap(Labels(["key"], np.array([[0]])), [block])
+    t.set_info("description", "test_value")
+    return t
+
+
+def multi_sample_tensor() -> TensorMap:
+    """Tensor with 'system'+'atom' sample axes for reduction tests."""
+    block = TensorBlock(
+        values=np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]),
+        samples=Labels(
+            ["system", "atom"],
+            np.array([[0, 0], [0, 1], [1, 0]]),
+        ),
+        components=[],
+        properties=Labels(["p"], np.array([[0], [1]])),
+    )
+    t = TensorMap(Labels(["key"], np.array([[0]])), [block])
+    t.set_info("description", "test_value")
+    return t
+
+
+def check_info(result: TensorMap, expected: dict):
+    """Assert that result.info() contains exactly the expected key/value pairs."""
+    info = result.info()
+    for key, val in expected.items():
+        assert key in info, f"info key '{key}' missing from result"
+        assert info[key] == val, f"info['{key}'] = {info[key]!r}, expected {val!r}"

--- a/python/metatensor_operations/tests/abs.py
+++ b/python/metatensor_operations/tests/abs.py
@@ -82,3 +82,9 @@ def test_abs(gradients):
 
     # Check the tensors haven't be modified in place
     assert not mts.equal(tensor_abs, tensor)
+
+
+def test_abs_info():
+    t = _tests_utils.tensor_with_info()
+    result = mts.abs(t)
+    _tests_utils.check_info(result, _tests_utils._INFO)

--- a/python/metatensor_operations/tests/add.py
+++ b/python/metatensor_operations/tests/add.py
@@ -4,7 +4,7 @@ import pytest
 import metatensor as mts
 from metatensor import Labels, TensorBlock, TensorMap
 
-from . import _gradcheck
+from . import _gradcheck, _tests_utils
 
 
 try:
@@ -285,3 +285,18 @@ def test_finite_difference():
         rng.manual_seed(123456)
         array = torch.rand(50, 3, dtype=torch.float64, generator=rng)
         _gradcheck.check_finite_differences(function, array, parameter="g")
+
+
+def test_add_scalar_info():
+    t = _tests_utils.tensor_with_info()
+    result = mts.add(t, 1.0)
+    _tests_utils.check_info(result, _tests_utils._INFO)
+
+
+def test_add_tensormap_no_info():
+    """When B is a TensorMap, info must NOT be propagated (ambiguous source)."""
+    t = _tests_utils.tensor_with_info()
+    B = _tests_utils.tensor()
+    B.set_info("description", "other_value")
+    result = mts.add(t, B)
+    assert result.info() == {}, f"Expected empty info, got {result.info()}"

--- a/python/metatensor_operations/tests/detach.py
+++ b/python/metatensor_operations/tests/detach.py
@@ -2,6 +2,8 @@ import os
 
 import metatensor as mts
 
+from . import _tests_utils
+
 
 try:
     import torch  # noqa
@@ -34,3 +36,9 @@ def test_detach():
         detached = mts.detach(output)
         for block in detached:
             assert not block.values.requires_grad
+
+
+def test_detach_info():
+    t = _tests_utils.tensor_with_info()
+    result = mts.detach(t)
+    _tests_utils.check_info(result, _tests_utils._INFO)

--- a/python/metatensor_operations/tests/divide.py
+++ b/python/metatensor_operations/tests/divide.py
@@ -4,6 +4,8 @@ import pytest
 import metatensor as mts
 from metatensor import Labels, TensorBlock, TensorMap
 
+from . import _tests_utils
+
 
 def test_self_divide_tensors_no_gradient():
     block_1 = TensorBlock(
@@ -355,3 +357,17 @@ def test_self_divide_error():
     )
     with pytest.raises(TypeError, match=message):
         mts.divide(tensor, np.ones((3, 4)))
+
+
+def test_divide_scalar_info():
+    t = _tests_utils.tensor_with_info()
+    result = mts.divide(t, 2.0)
+    _tests_utils.check_info(result, _tests_utils._INFO)
+
+
+def test_divide_tensormap_no_info():
+    t = _tests_utils.tensor_with_info()
+    B = _tests_utils.tensor()
+    B.set_info("description", "other_value")
+    result = mts.divide(t, B)
+    assert result.info() == {}, f"Expected empty info, got {result.info()}"

--- a/python/metatensor_operations/tests/drop_blocks.py
+++ b/python/metatensor_operations/tests/drop_blocks.py
@@ -6,6 +6,8 @@ import pytest
 import metatensor as mts
 from metatensor import Labels, TensorBlock, TensorMap
 
+from . import _tests_utils
+
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
@@ -193,3 +195,16 @@ def test_copy_flag(tensor):
         assert np.all(
             new_tensor_not_copied[key].values == new_tensor_copied[key].values[:] + 3.14
         )
+
+
+def test_drop_blocks_info():
+    t = _tests_utils.tensor_with_info()
+    keys_to_drop = Labels(names=["key_1", "key_2"], values=np.array([[2, 3]]))
+    result = mts.drop_blocks(t, keys_to_drop)
+    _tests_utils.check_info(result, _tests_utils._INFO)
+
+
+def test_drop_empty_blocks_info():
+    t = _tests_utils.tensor_with_info()
+    result = mts.drop_empty_blocks(t)
+    _tests_utils.check_info(result, _tests_utils._INFO)

--- a/python/metatensor_operations/tests/empty_like.py
+++ b/python/metatensor_operations/tests/empty_like.py
@@ -4,6 +4,8 @@ import pytest
 
 import metatensor as mts
 
+from . import _tests_utils
+
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
@@ -25,3 +27,9 @@ def test_empty_like_error():
     message = "requested gradient 'err' in 'empty_like' is not defined in this tensor"
     with pytest.raises(ValueError, match=message):
         tensor = mts.empty_like(tensor, gradients=["positions", "err"])
+
+
+def test_empty_like_info():
+    t = _tests_utils.tensor_with_info()
+    result = mts.empty_like(t)
+    _tests_utils.check_info(result, _tests_utils._INFO)

--- a/python/metatensor_operations/tests/filter_blocks.py
+++ b/python/metatensor_operations/tests/filter_blocks.py
@@ -6,6 +6,8 @@ import pytest
 import metatensor as mts
 from metatensor import Labels, TensorMap
 
+from . import _tests_utils
+
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
@@ -70,6 +72,16 @@ def test_larger_filter(tensor):
 
     assert test_filter.keys == tensor.keys
     assert mts.equal(test_filter, tensor)
+
+
+def test_filter_blocks_info():
+    t = _tests_utils.tensor_with_info()
+    keys_to_keep = Labels(
+        names=["key_1", "key_2"],
+        values=np.array([[0, 0], [1, 0]]),
+    )
+    result = mts.filter_blocks(t, keys_to_keep)
+    _tests_utils.check_info(result, _tests_utils._INFO)
 
 
 def test_copy_flag(tensor):

--- a/python/metatensor_operations/tests/make_contiguous.py
+++ b/python/metatensor_operations/tests/make_contiguous.py
@@ -5,6 +5,8 @@ import pytest
 import metatensor as mts
 from metatensor import TensorBlock, TensorMap
 
+from . import _tests_utils
+
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
@@ -66,3 +68,9 @@ def test_make_contiguous_block(tensor):
 def test_make_contiguous(non_contiguous_tensor):
     assert not mts.is_contiguous(non_contiguous_tensor)
     assert mts.is_contiguous(mts.make_contiguous(non_contiguous_tensor))
+
+
+def test_make_contiguous_info():
+    t = _tests_utils.simple_tensor()
+    result = mts.make_contiguous(t)
+    _tests_utils.check_info(result, {"description": "test_value"})

--- a/python/metatensor_operations/tests/manipulate_dimension.py
+++ b/python/metatensor_operations/tests/manipulate_dimension.py
@@ -7,6 +7,8 @@ from numpy.testing import assert_equal
 import metatensor as mts
 from metatensor import Labels, MetatensorError, TensorBlock, TensorMap
 
+from . import _tests_utils
+
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
@@ -331,3 +333,41 @@ def test_insert_dimension_wrong_size(tensor):
         values=0,
         index=0,
     )
+
+
+def test_insert_dimension_info():
+    t = _tests_utils.simple_tensor()
+    result = mts.insert_dimension(t, axis="keys", index=0, name="new_key", values=0)
+    _tests_utils.check_info(result, {"description": "test_value"})
+
+
+def test_append_dimension_info():
+    t = _tests_utils.simple_tensor()
+    result = mts.append_dimension(t, axis="keys", name="new_key", values=0)
+    _tests_utils.check_info(result, {"description": "test_value"})
+
+
+def test_permute_dimensions_info():
+    t = _tests_utils.tensor_with_info()
+    # tensor_with_info has keys ["key_1", "key_2"] — permute to [1, 0]
+    result = mts.permute_dimensions(t, axis="keys", dimensions_indexes=[1, 0])
+    _tests_utils.check_info(result, _tests_utils._INFO)
+
+
+def test_remove_dimension_info():
+    block = TensorBlock(
+        values=np.array([[1.0, 2.0]]),
+        samples=Labels(["s"], np.array([[0]])),
+        components=[],
+        properties=Labels(["p"], np.array([[0], [1]])),
+    )
+    t = TensorMap(Labels(["key", "extra"], np.array([[0, 0]])), [block])
+    t.set_info("description", "test_value")
+    result = mts.remove_dimension(t, axis="keys", name="extra")
+    _tests_utils.check_info(result, {"description": "test_value"})
+
+
+def test_rename_dimension_info():
+    t = _tests_utils.simple_tensor()
+    result = mts.rename_dimension(t, axis="keys", old="key", new="new_key")
+    _tests_utils.check_info(result, {"description": "test_value"})

--- a/python/metatensor_operations/tests/multiply.py
+++ b/python/metatensor_operations/tests/multiply.py
@@ -6,6 +6,8 @@ import pytest
 import metatensor as mts
 from metatensor import Labels, TensorBlock, TensorMap
 
+from . import _tests_utils
+
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
@@ -342,3 +344,22 @@ def test_self_multiply_error():
     )
     with pytest.raises(TypeError, match=message):
         keys = mts.multiply(tensor, np.ones((3, 4)))
+
+
+def test_multiply_scalar_info():
+    t = _tests_utils.simple_tensor()
+    result = mts.multiply(t, 2.0)
+    _tests_utils.check_info(result, {"description": "test_value"})
+
+
+def test_multiply_tensormap_no_info():
+    t = _tests_utils.simple_tensor()
+    block = TensorBlock(
+        values=np.array([[2.0, 3.0], [4.0, 5.0]]),
+        samples=Labels(["s"], np.array([[0], [1]])),
+        components=[],
+        properties=Labels(["p"], np.array([[0], [1]])),
+    )
+    B = TensorMap(Labels(["key"], np.array([[0]])), [block])
+    result = mts.multiply(t, B)
+    assert "description" not in result.info()

--- a/python/metatensor_operations/tests/ones_like.py
+++ b/python/metatensor_operations/tests/ones_like.py
@@ -5,6 +5,8 @@ import pytest
 
 import metatensor as mts
 
+from . import _tests_utils
+
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
@@ -36,3 +38,9 @@ def test_ones_like_error():
     message = "requested gradient 'err' in 'ones_like' is not defined in this tensor"
     with pytest.raises(ValueError, match=message):
         tensor = mts.ones_like(tensor, gradients=["positions", "err"])
+
+
+def test_ones_like_info():
+    t = _tests_utils.simple_tensor()
+    result = mts.ones_like(t)
+    _tests_utils.check_info(result, {"description": "test_value"})

--- a/python/metatensor_operations/tests/pow.py
+++ b/python/metatensor_operations/tests/pow.py
@@ -6,6 +6,8 @@ import pytest
 import metatensor as mts
 from metatensor import Labels, TensorBlock, TensorMap
 
+from . import _tests_utils
+
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
@@ -358,3 +360,9 @@ def test_self_pow_error():
     message = "`B` must be a scalar value, not <class 'numpy.ndarray'>"
     with pytest.raises(TypeError, match=message):
         keys = mts.pow(tensor, np.ones((3, 4)))
+
+
+def test_pow_info():
+    t = _tests_utils.simple_tensor()
+    result = mts.pow(t, 2)
+    _tests_utils.check_info(result, {"description": "test_value"})

--- a/python/metatensor_operations/tests/random_like.py
+++ b/python/metatensor_operations/tests/random_like.py
@@ -5,6 +5,8 @@ import pytest
 
 import metatensor as mts
 
+from . import _tests_utils
+
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
@@ -38,3 +40,9 @@ def test_random_uniform_like_error():
     )
     with pytest.raises(ValueError, match=message):
         tensor = mts.random_uniform_like(tensor, gradients=["positions", "err"])
+
+
+def test_random_uniform_like_info():
+    t = _tests_utils.simple_tensor()
+    result = mts.random_uniform_like(t)
+    _tests_utils.check_info(result, {"description": "test_value"})

--- a/python/metatensor_operations/tests/reduce_mean.py
+++ b/python/metatensor_operations/tests/reduce_mean.py
@@ -5,6 +5,8 @@ import numpy as np
 import metatensor as mts
 from metatensor import Labels, TensorBlock, TensorMap
 
+from . import _tests_utils
+
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
@@ -359,3 +361,22 @@ def test_reduction_block_multi_properties():
     assert reduce_X_12.block(0).properties == properties_12
     assert reduce_X_23.block(0).properties == properties_23
     assert reduce_X_2.block(0).properties == properties_2
+
+
+def test_mean_over_samples_info():
+    t = _tests_utils.multi_sample_tensor()
+    result = mts.mean_over_samples(t, sample_names="atom")
+    _tests_utils.check_info(result, {"description": "test_value"})
+
+
+def test_mean_over_properties_info():
+    block = TensorBlock(
+        values=np.array([[1.0, 2.0, 3.0]]),
+        samples=Labels(["s"], np.array([[0]])),
+        components=[],
+        properties=Labels(["p", "q"], np.array([[0, 0], [0, 1], [1, 0]])),
+    )
+    t = TensorMap(Labels(["key"], np.array([[0]])), [block])
+    t.set_info("description", "test_value")
+    result = mts.mean_over_properties(t, property_names="q")
+    _tests_utils.check_info(result, {"description": "test_value"})

--- a/python/metatensor_operations/tests/reduce_std.py
+++ b/python/metatensor_operations/tests/reduce_std.py
@@ -5,6 +5,8 @@ import numpy as np
 import metatensor as mts
 from metatensor import Labels, TensorBlock, TensorMap
 
+from . import _tests_utils
+
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
@@ -539,3 +541,41 @@ def get_XdX(block, gradient, der_index):
         idx = gradient.samples[ig][0]
         XdX.append(block.values[idx] * gradient.values[ig])
     return np.stack(XdX)
+
+
+def test_std_over_samples_info():
+    t = _tests_utils.multi_sample_tensor()
+    result = mts.std_over_samples(t, sample_names="atom")
+    _tests_utils.check_info(result, {"description": "test_value"})
+
+
+def test_std_over_properties_info():
+    block = TensorBlock(
+        values=np.array([[1.0, 2.0, 3.0]]),
+        samples=Labels(["s"], np.array([[0]])),
+        components=[],
+        properties=Labels(["p", "q"], np.array([[0, 0], [0, 1], [1, 0]])),
+    )
+    t = TensorMap(Labels(["key"], np.array([[0]])), [block])
+    t.set_info("description", "test_value")
+    result = mts.std_over_properties(t, property_names="q")
+    _tests_utils.check_info(result, {"description": "test_value"})
+
+
+def test_var_over_samples_info():
+    t = _tests_utils.multi_sample_tensor()
+    result = mts.var_over_samples(t, sample_names="atom")
+    _tests_utils.check_info(result, {"description": "test_value"})
+
+
+def test_var_over_properties_info():
+    block = TensorBlock(
+        values=np.array([[1.0, 2.0, 3.0]]),
+        samples=Labels(["s"], np.array([[0]])),
+        components=[],
+        properties=Labels(["p", "q"], np.array([[0, 0], [0, 1], [1, 0]])),
+    )
+    t = TensorMap(Labels(["key"], np.array([[0]])), [block])
+    t.set_info("description", "test_value")
+    result = mts.var_over_properties(t, property_names="q")
+    _tests_utils.check_info(result, {"description": "test_value"})

--- a/python/metatensor_operations/tests/reduce_sum.py
+++ b/python/metatensor_operations/tests/reduce_sum.py
@@ -5,6 +5,8 @@ import numpy as np
 import metatensor as mts
 from metatensor import Labels, TensorBlock, TensorMap
 
+from . import _tests_utils
+
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
@@ -326,3 +328,22 @@ def test_reduction_block_multi_properties():
     assert reduce_X_12.block(0).properties == properties_12
     assert reduce_X_23.block(0).properties == properties_23
     assert reduce_X_2.block(0).properties == properties_2
+
+
+def test_sum_over_samples_info():
+    t = _tests_utils.multi_sample_tensor()
+    result = mts.sum_over_samples(t, sample_names="atom")
+    _tests_utils.check_info(result, {"description": "test_value"})
+
+
+def test_sum_over_properties_info():
+    block = TensorBlock(
+        values=np.array([[1.0, 2.0, 3.0]]),
+        samples=Labels(["s"], np.array([[0]])),
+        components=[],
+        properties=Labels(["p", "q"], np.array([[0, 0], [0, 1], [1, 0]])),
+    )
+    t = TensorMap(Labels(["key"], np.array([[0]])), [block])
+    t.set_info("description", "test_value")
+    result = mts.sum_over_properties(t, property_names="q")
+    _tests_utils.check_info(result, {"description": "test_value"})

--- a/python/metatensor_operations/tests/remove_gradients.py
+++ b/python/metatensor_operations/tests/remove_gradients.py
@@ -2,6 +2,8 @@ import os
 
 import metatensor as mts
 
+from . import _tests_utils
+
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
@@ -22,3 +24,9 @@ def test_remove_subset():
 
     tensor = mts.remove_gradients(tensor, ["positions"])
     assert tensor.block(0).gradients_list() == ["strain"]
+
+
+def test_remove_gradients_info():
+    t = _tests_utils.simple_tensor()
+    result = mts.remove_gradients(t)
+    _tests_utils.check_info(result, {"description": "test_value"})

--- a/python/metatensor_operations/tests/requires_grad.py
+++ b/python/metatensor_operations/tests/requires_grad.py
@@ -4,6 +4,8 @@ import pytest
 
 import metatensor as mts
 
+from . import _tests_utils
+
 
 torch = pytest.importorskip("torch")
 
@@ -30,3 +32,10 @@ def test_requires_grad():
     tensor = mts.requires_grad(tensor, requires_grad=False)
     for block in tensor:
         assert not block.values.requires_grad
+
+
+def test_requires_grad_info():
+    t = _tests_utils.simple_tensor()
+    t = t.to(arrays="torch")
+    result = mts.requires_grad(t)
+    _tests_utils.check_info(result, {"description": "test_value"})

--- a/python/metatensor_operations/tests/slice.py
+++ b/python/metatensor_operations/tests/slice.py
@@ -6,6 +6,8 @@ import pytest
 import metatensor as mts
 from metatensor import Labels, TensorBlock, TensorMap
 
+from . import _tests_utils
+
 
 try:
     import torch  # noqa
@@ -666,3 +668,10 @@ def test_slice_block_errors(tensor):
             axis="samples",
             selection=np.array([[1], [2]]),
         )
+
+
+def test_slice_info():
+    t = _tests_utils.simple_tensor()
+    selection = Labels(["s"], np.array([[0]]))
+    result = mts.slice(t, axis="samples", selection=selection)
+    _tests_utils.check_info(result, {"description": "test_value"})

--- a/python/metatensor_operations/tests/sort.py
+++ b/python/metatensor_operations/tests/sort.py
@@ -4,6 +4,8 @@ import pytest
 import metatensor as mts
 from metatensor import Labels, TensorBlock, TensorMap
 
+from . import _tests_utils
+
 
 @pytest.fixture
 def tensor():
@@ -407,3 +409,9 @@ def test_raise_error(tensor, tensor_sorted_ascending):
     )
     with pytest.raises(ValueError, match=error_message):
         mts.operations.sort(tensor, axes=[5])
+
+
+def test_sort_info():
+    t = _tests_utils.simple_tensor()
+    result = mts.sort(t)
+    _tests_utils.check_info(result, {"description": "test_value"})

--- a/python/metatensor_operations/tests/split.py
+++ b/python/metatensor_operations/tests/split.py
@@ -6,6 +6,8 @@ import pytest
 import metatensor as mts
 from metatensor import Labels
 
+from . import _tests_utils
+
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
@@ -260,3 +262,15 @@ def test_split_errors():
     )
     with pytest.raises(TypeError, match=message):
         mts.split_block(tensor, axis="samples", selections=[])
+
+
+def test_split_info():
+    t = _tests_utils.simple_tensor()
+    # simple_tensor has 1 block with samples s=0 and s=1
+    selections = [
+        Labels(["s"], np.array([[0]])),
+        Labels(["s"], np.array([[1]])),
+    ]
+    results = mts.split(t, axis="samples", selections=selections)
+    for result in results:
+        _tests_utils.check_info(result, {"description": "test_value"})

--- a/python/metatensor_operations/tests/subtract.py
+++ b/python/metatensor_operations/tests/subtract.py
@@ -6,6 +6,8 @@ import pytest
 import metatensor as mts
 from metatensor import Labels, TensorBlock, TensorMap
 
+from . import _tests_utils
+
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
@@ -290,3 +292,22 @@ def test_self_subtract_error():
     )
     with pytest.raises(TypeError, match=message):
         keys = mts.subtract(tensor, np.ones((3, 4)))
+
+
+def test_subtract_scalar_info():
+    t = _tests_utils.simple_tensor()
+    result = mts.subtract(t, 1.0)
+    _tests_utils.check_info(result, {"description": "test_value"})
+
+
+def test_subtract_tensormap_no_info():
+    t = _tests_utils.simple_tensor()
+    block = TensorBlock(
+        values=np.array([[0.5, 1.0], [1.5, 2.0]]),
+        samples=Labels(["s"], np.array([[0], [1]])),
+        components=[],
+        properties=Labels(["p"], np.array([[0], [1]])),
+    )
+    B = TensorMap(Labels(["key"], np.array([[0]])), [block])
+    result = mts.subtract(t, B)
+    assert "description" not in result.info()

--- a/python/metatensor_operations/tests/zeros_like.py
+++ b/python/metatensor_operations/tests/zeros_like.py
@@ -5,6 +5,8 @@ import pytest
 
 import metatensor as mts
 
+from . import _tests_utils
+
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
@@ -36,3 +38,9 @@ def test_zeros_like_error():
     message = "requested gradient 'err' in 'zeros_like' is not defined in this tensor"
     with pytest.raises(ValueError, match=message):
         tensor = mts.zeros_like(tensor, gradients=["positions", "err"])
+
+
+def test_zeros_like_info():
+    t = _tests_utils.simple_tensor()
+    result = mts.zeros_like(t)
+    _tests_utils.check_info(result, {"description": "test_value"})


### PR DESCRIPTION
Update some operations to preserve the `info` dictionary.


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/6559616371.zip)

<!-- download-section Documentation docs end -->