### PR TITLE
Remove unnecessary block lookup in operations

### DIFF
--- a/python/metatensor_core/metatensor/_tensor.py
+++ b/python/metatensor_core/metatensor/_tensor.py
@@ -363,18 +363,13 @@ class TensorMap:
         When ``selection`` is an ``int``, this is equivalent to
         :py:func:`TensorMap.block_by_id`.
 
-        When ``selection`` is an :py:class:`Labels`, it should only contain a single
-        entry, which will be used for the selection.
-
-        When ``selection`` is a ``Dict[str, int]``, it is converted into a single single
-        :py:class:`LabelsEntry` (the dict keys becoming the names and the dict values
-        being joined together to form the :py:class:`LabelsEntry` values), which is then
-        used for the selection.
-
-        When ``selection`` is a :py:class:`LabelsEntry`, this function finds the key in
-        this :py:class:`TensorMap` with the same values as ``selection`` for the
-        dimensions/names contained in the ``selection``; and return the corresponding
-        indexes.
+        When ``selection`` is a :py:class:`Labels`, :py:class:`LabelsEntry` or
+        ``Dict[str, int]``, this function finds the key in this :py:class:`TensorMap`
+        with the same values as ``selection`` for the dimensions/names contained in the
+        ``selection`` (which can be a subset of the dimensions of the keys); and return
+        the corresponding block. This performs a lookup in the keys, so it will be
+        slower than :py:func:`TensorMap.block_by_id`, but it is more convenient when the
+        position of the block is not known.
 
         If ``selection`` is :py:obj:`None`, the selection can be passed as keyword
         arguments, which will be converted to a ``Dict[str, int]``.
@@ -461,18 +456,13 @@ class TensorMap:
         :py:func:`TensorMap.block_by_id`; and for a ``List[int]`` this is equivalent to
         :py:func:`TensorMap.blocks_by_id`.
 
-        When ``selection`` is an :py:class:`Labels`, it should only contain a single
-        entry, which will be used for the selection.
-
-        When ``selection`` is a ``Dict[str, int]``, it is converted into a single single
-        :py:class:`LabelsEntry` (the dict keys becoming the names and the dict values
-        being joined together to form the :py:class:`LabelsEntry` values), which is then
-        used for the selection.
-
-        When ``selection`` is a :py:class:`LabelsEntry`, this function finds all keys in
-        this :py:class:`TensorMap` with the same values as ``selection`` for the
-        dimensions/names contained in the ``selection``; and return the corresponding
-        blocks.
+        When ``selection`` is a :py:class:`Labels`, :py:class:`LabelsEntry` or
+        ``Dict[str, int]``, this function finds the keys in this :py:class:`TensorMap`
+        with the same values as ``selection`` for the dimensions/names contained in the
+        ``selection`` (which can be a subset of the dimensions of the keys); and return
+        the corresponding blocks. This performs a lookup in the keys, so it will be
+        slower than :py:func:`TensorMap.blocks_by_id`, but it is more convenient when
+        the position of the blocks is not known.
 
         If ``selection`` is :py:obj:`None`, the selection can be passed as keyword
         arguments, which will be converted to a ``Dict[str, int]``.

--- a/python/metatensor_operations/metatensor_operations/_abs.py
+++ b/python/metatensor_operations/metatensor_operations/_abs.py
@@ -68,5 +68,5 @@ def abs(A: TensorMap) -> TensorMap:
     blocks: List[TensorBlock] = []
     keys = A.keys
     for i in range(len(keys)):
-        blocks.append(_abs_block(block=A.block(keys.entry(i))))
+        blocks.append(_abs_block(block=A.block_by_id(i)))
     return TensorMap(keys, blocks)

--- a/python/metatensor_operations/metatensor_operations/_equal_metadata.py
+++ b/python/metatensor_operations/metatensor_operations/_equal_metadata.py
@@ -31,9 +31,13 @@ def _equal_metadata_impl(
     if message != "":
         return message
 
-    for key in [tensor_1.keys[i] for i in range(len(tensor_1.keys))]:
+    keys_1 = tensor_1.keys
+    for i in range(len(keys_1)):
         message = _equal_metadata_block_impl(
-            tensor_1[key], tensor_2[key], check=check, check_gradients=check_gradients
+            tensor_1.block_by_id(i),
+            tensor_2.block(keys_1.entry(i)),
+            check=check,
+            check_gradients=check_gradients,
         )
         if message != "":
             return message

--- a/python/metatensor_operations/metatensor_operations/_slice.py
+++ b/python/metatensor_operations/metatensor_operations/_slice.py
@@ -247,7 +247,7 @@ def slice(tensor: TensorMap, axis: str, selection: Labels) -> TensorMap:
     return TensorMap(
         keys=tensor.keys,
         blocks=[
-            _slice_block(tensor[tensor.keys.entry(i)], axis, selection)
+            _slice_block(tensor.block_by_id(i), axis, selection)
             for i in range(len(tensor.keys))
         ],
     )

--- a/python/metatensor_operations/metatensor_operations/_split.py
+++ b/python/metatensor_operations/metatensor_operations/_split.py
@@ -157,8 +157,7 @@ def split(
         all_new_blocks[group_i] = empty_list
 
     for key_index in range(len(tensor.keys)):
-        key = tensor.keys.entry(key_index)
-        new_blocks = _split_block(tensor[key], axis, selections)
+        new_blocks = _split_block(tensor.block_by_id(key_index), axis, selections)
 
         for group_i, new_block in enumerate(new_blocks):
             all_new_blocks[group_i].append(new_block)

--- a/python/metatensor_torch/metatensor_torch/_documentation.py
+++ b/python/metatensor_torch/metatensor_torch/_documentation.py
@@ -1307,18 +1307,13 @@ class TensorMap:
         When ``selection`` is an ``int``, this is equivalent to
         :py:func:`TensorMap.block_by_id`.
 
-        When ``selection`` is an :py:class:`Labels`, it should only contain a single
-        entry, which will be used for the selection.
-
-        When ``selection`` is a ``Dict[str, int]``, it is converted into a single single
-        :py:class:`LabelsEntry` (the dict keys becoming the names and the dict values
-        being joined together to form the :py:class:`LabelsEntry` values), which is then
-        used for the selection.
-
-        When ``selection`` is a :py:class:`LabelsEntry`, this function finds the key in
-        this :py:class:`TensorMap` with the same values as ``selection`` for the
-        dimensions/names contained in the ``selection``; and return the corresponding
-        indexes.
+        When ``selection`` is a :py:class:`Labels`, :py:class:`LabelsEntry` or
+        ``Dict[str, int]``, this function finds the key in this :py:class:`TensorMap`
+        with the same values as ``selection`` for the dimensions/names contained in the
+        ``selection`` (which can be a subset of the dimensions of the keys); and return
+        the corresponding block. This performs a lookup in the keys, so it will be
+        slower than :py:func:`TensorMap.block_by_id`, but it is more convenient when the
+        position of the block is not known.
 
         :param selection: description of the block to extract
         """
@@ -1339,18 +1334,13 @@ class TensorMap:
         :py:func:`TensorMap.block_by_id`; and for a ``List[int]`` this is equivalent to
         :py:func:`TensorMap.blocks_by_id`.
 
-        When ``selection`` is an :py:class:`Labels`, it should only contain a single
-        entry, which will be used for the selection.
-
-        When ``selection`` is a ``Dict[str, int]``, it is converted into a single single
-        :py:class:`LabelsEntry` (the dict keys becoming the names and the dict values
-        being joined together to form the :py:class:`LabelsEntry` values), which is then
-        used for the selection.
-
-        When ``selection`` is a :py:class:`LabelsEntry`, this function finds all keys in
-        this :py:class:`TensorMap` with the same values as ``selection`` for the
-        dimensions/names contained in the ``selection``; and return the corresponding
-        blocks.
+        When ``selection`` is a :py:class:`Labels`, :py:class:`LabelsEntry` or
+        ``Dict[str, int]``, this function finds the keys in this :py:class:`TensorMap`
+        with the same values as ``selection`` for the dimensions/names contained in the
+        ``selection`` (which can be a subset of the dimensions of the keys); and return
+        the corresponding blocks. This performs a lookup in the keys, so it will be
+        slower than :py:func:`TensorMap.blocks_by_id`, but it is more convenient when
+        the position of the blocks is not known.
 
         :param selection: description of the blocks to extract
         """


### PR DESCRIPTION
`tensor.block(tensor.key[i])` has an extra lookup compared to `tensor.block(i)`, it is not needed. We found this when looking at what we can do for #1101 

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
