### PR TITLE
Allow moving `mts_array_t` to a different origin and a different device

### DIFF
--- a/julia/src/generated/_c_api.jl
+++ b/julia/src/generated/_c_api.jl
@@ -143,6 +143,7 @@ struct mts_array_t
     device :: Ptr{Cvoid} #= (Ptr{Cvoid}, Ptr{DLDevice}) -> mts_status_t =#
     dtype :: Ptr{Cvoid} #= (Ptr{Cvoid}, Ptr{DLDataType}) -> mts_status_t =#
     as_dlpack :: Ptr{Cvoid} #= (Ptr{Cvoid}, Ptr{Ptr{DLManagedTensorVersioned}}, DLDevice, Ptr{Int64}, DLPackVersion) -> mts_status_t =#
+    from_dlpack :: Ptr{Cvoid} #= (Ptr{Cvoid}, Ptr{DLManagedTensorVersioned}, Ptr{mts_array_t}) -> mts_status_t =#
     shape :: Ptr{Cvoid} #= (Ptr{Cvoid}, Ptr{Ptr{UIntptr}}, Ptr{UIntptr}) -> mts_status_t =#
     reshape :: Ptr{Cvoid} #= (Ptr{Cvoid}, Ptr{UIntptr}, UIntptr) -> mts_status_t =#
     swap_axes :: Ptr{Cvoid} #= (Ptr{Cvoid}, UIntptr, UIntptr) -> mts_status_t =#

--- a/julia/src/generated/_c_api.jl
+++ b/julia/src/generated/_c_api.jl
@@ -147,7 +147,7 @@ struct mts_array_t
     reshape :: Ptr{Cvoid} #= (Ptr{Cvoid}, Ptr{UIntptr}, UIntptr) -> mts_status_t =#
     swap_axes :: Ptr{Cvoid} #= (Ptr{Cvoid}, UIntptr, UIntptr) -> mts_status_t =#
     create :: Ptr{Cvoid} #= (Ptr{Cvoid}, Ptr{UIntptr}, UIntptr, mts_array_t, Ptr{mts_array_t}) -> mts_status_t =#
-    copy :: Ptr{Cvoid} #= (Ptr{Cvoid}, Ptr{mts_array_t}) -> mts_status_t =#
+    copy :: Ptr{Cvoid} #= (Ptr{Cvoid}, DLDevice, Ptr{mts_array_t}) -> mts_status_t =#
     move_data :: Ptr{Cvoid} #= (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{mts_data_movement_t}, UIntptr) -> mts_status_t =#
 end
 

--- a/metatensor-core/CHANGELOG.md
+++ b/metatensor-core/CHANGELOG.md
@@ -24,8 +24,6 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 - `mts_array_t.move_samples_from` is now `mts_array_t.move_data`, and allows for
   more granular data movement. `mts_sample_mapping_t` has been renamed to
   `mts_data_movement_t`.
-- `mts_array_t.data` has been replaced by `mts_array_t.as_dlpack`, returning the
-  data using the [dlpack](https://github.com/dmlc/dlpack) standard. TensorBlock can now contain data on different devices and with varied dtypes.
 - `mts_array_t.copy` now takes a `device` parameter, indicating on which device
   the copy should live.
 - Serialization of `mts_tensor_t`, `mts_block_t` and `mts_labels_t` can now be
@@ -48,6 +46,10 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 #### Added
 
+- `mts_array_t.as_dlpack` function, returning the data using the
+  [dlpack](https://github.com/dmlc/dlpack) standard. TensorBlock and Labels can
+  now contain data on different devices and with varied dtypes.
+- `mts_array_t.from_dlpack` function to create mts_array_t from a dlpack tensor.
 - There are new functions `mts_block_device`, `mts_tensormap_device`,
   `mts_block_dtype`, `mts_tensormap_dtype` to access dtype and device of metatensor data.
 - There are new functions to work with `mts_labels_t`: `mts_labels_dimensions`,
@@ -61,6 +63,7 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 - Removed `mts_tensormap_blocks_matching`, the same behavior can be achieved
   with `mts_labels_selection`.
+- Removed `mts_array_t.data`, users should use `mts_array_t.as_dlpack` instead.
 
 ### metatensor-core C++
 

--- a/metatensor-core/CHANGELOG.md
+++ b/metatensor-core/CHANGELOG.md
@@ -26,6 +26,8 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
   `mts_data_movement_t`.
 - `mts_array_t.data` has been replaced by `mts_array_t.as_dlpack`, returning the
   data using the [dlpack](https://github.com/dmlc/dlpack) standard. TensorBlock can now contain data on different devices and with varied dtypes.
+- `mts_array_t.copy` now takes a `device` parameter, indicating on which device
+  the copy should live.
 - Serialization of `mts_tensor_t`, `mts_block_t` and `mts_labels_t` can now be
   done even if the data lives on a different device or uses a dtype other than
   float64. `mts_create_array_callback_t` now takes an extra parameter for the

--- a/metatensor-core/Cargo.toml
+++ b/metatensor-core/Cargo.toml
@@ -31,7 +31,7 @@ byteorder = {version = "1"}
 num-traits = {version = "0.2", default-features = false}
 zip = {version = "0.6", default-features = false, features = ["deflate"]}
 jzon = "0.12"
-dlpk = { version = "0.1.5", features = ["ndarray", "half"]}
+dlpk = { version = "0.2.0", features = ["ndarray", "half"]}
 ndarray = {version = "0.17"}
 half = { version = "<2.5"}
 

--- a/metatensor-core/include/metatensor.h
+++ b/metatensor-core/include/metatensor.h
@@ -264,10 +264,10 @@ typedef struct mts_array_t {
    */
   mts_status_t (*swap_axes)(void *array, uintptr_t axis_1, uintptr_t axis_2);
   /**
-   * Create a new array with the same options as the current one (data type,
-   * data location, etc.) and the requested `shape`; and store it in
-   * `new_array`. The number of elements in the `shape` array should be given
-   * in `shape_count`.
+   * Create a new array with the same options as the current one (array
+   * origin, data type, device, etc.) and the requested `shape`; and store it
+   * in `new_array`. The number of elements in the `shape` array should be
+   * given in `shape_count`.
    *
    * The new array should be filled with the scalar value from `fill_value`,
    * which must be an `mts_array_t` containing a single scalar (empty shape)
@@ -288,15 +288,15 @@ typedef struct mts_array_t {
   /**
    * Make a copy of this `array` and return the new array in `new_array`.
    *
-   * The new array is expected to have the same data origin and parameters
-   * (data type, data location, etc.)
+   * The new array is expected to have the same array origin and data type as
+   * the original one, but live on the given `device`.
    *
    * This function should return `MTS_SUCCESS` on success, or
    * `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
    * should call `mts_set_last_error` with an appropriate error message
    * before returning.
    */
-  mts_status_t (*copy)(const void *array, struct mts_array_t *new_array);
+  mts_status_t (*copy)(const void *array, DLDevice device, struct mts_array_t *new_array);
   /**
    * Set entries in the `output` array (the current array) taking data from
    * the `input` array. The `output` array is guaranteed to be created by

--- a/metatensor-core/include/metatensor.h
+++ b/metatensor-core/include/metatensor.h
@@ -232,6 +232,28 @@ typedef struct mts_array_t {
                             const int64_t *stream,
                             DLPackVersion max_version);
   /**
+   * Create a new array from a DLPack tensor, taking ownership of the
+   * tensor's data.
+   *
+   * The `new_array` output parameter should be filled with an `mts_array_t`
+   * representing the new array, with the same array origin as the current
+   * one. The implementation should take ownership of the data in
+   * `dl_managed_tensor`, and is responsible for calling the tensor's
+   * `deleter` function when the data is no longer needed.
+   *
+   * Importantly, the `dl_managed_tensor` and thus the new array might have a
+   * different device and/or data type than the current one, and the
+   * implementation should handle this correctly or return an error.
+   *
+   * This function should return `MTS_SUCCESS` on success, or
+   * `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+   * should call `mts_set_last_error` with an appropriate error message
+   * before returning.
+   */
+  mts_status_t (*from_dlpack)(const void *array,
+                              DLManagedTensorVersioned *dl_managed_tensor,
+                              struct mts_array_t *new_array);
+  /**
    * Get the shape of the array managed by this `mts_array_t` in the `*shape`
    * pointer, and the number of dimension (size of the `*shape` array) in
    * `*shape_count`. If the array is a single scalar, `shape_count` should be

--- a/metatensor-core/include/metatensor/arrays.hpp
+++ b/metatensor-core/include/metatensor/arrays.hpp
@@ -674,7 +674,7 @@ public:
             throw Error("invalid mts_array_t: null copy function pointer");
         }
         mts_array_t new_array;
-        details::check_status(other.array_.copy(other.array_.ptr, &new_array));
+        details::check_status(other.array_.copy(other.array_.ptr, other.device(), &new_array));
 
         *this = MtsArray(new_array);
     }
@@ -685,7 +685,7 @@ public:
             throw Error("invalid mts_array_t: null copy function pointer");
         }
         mts_array_t new_array;
-        details::check_status(other.array_.copy(other.array_.ptr, &new_array));
+        details::check_status(other.array_.copy(other.array_.ptr, other.device(), &new_array));
 
         *this = MtsArray(new_array);
         return *this;
@@ -931,13 +931,13 @@ public:
             }, array, dtype);
         };
 
-        array.copy = [](const void* array, mts_array_t* new_array) {
-            return details::catch_exceptions([](const void* array, mts_array_t* new_array){
+        array.copy = [](const void* array, DLDevice device, mts_array_t* new_array) {
+            return details::catch_exceptions([](const void* array, DLDevice device, mts_array_t* new_array){
                 const auto* cxx_array = static_cast<const DataArrayBase*>(array);
-                auto copy = cxx_array->copy();
+                auto copy = cxx_array->copy(device);
                 auto new_array_cxx = DataArrayBase::to_mts_array(std::move(copy));
                 *new_array = std::move(new_array_cxx).release();
-            }, array, new_array);
+            }, array, device, new_array);
         };
 
         array.create = [](const void* array, const uintptr_t* shape, uintptr_t shape_count, mts_array_t fill_value, mts_array_t* new_array) {
@@ -1054,9 +1054,9 @@ public:
     ) = 0;
 
     /// Make a copy of this DataArrayBase and return the new array. The new
-    /// array is expected to have the same data origin and parameters (data
-    /// type, data location, etc.)
-    virtual std::unique_ptr<DataArrayBase> copy() const = 0;
+    /// array is expected to have the same data origin and dtype, but live on
+    /// the given `device`.
+    virtual std::unique_ptr<DataArrayBase> copy(DLDevice device) const = 0;
 
     /// Create a new array with the same options as the current one (data type,
     /// data location, etc.) and the requested `shape`.
@@ -1176,7 +1176,10 @@ public:
         data_ = std::make_shared<std::vector<T>>(std::move(new_data));
     }
 
-    std::unique_ptr<DataArrayBase> copy() const override {
+    std::unique_ptr<DataArrayBase> copy(DLDevice device) const override {
+        if (device.device_type != kDLCPU) {
+            throw Error("SimpleDataArray only supports copying to CPU");
+        }
         return std::unique_ptr<DataArrayBase>(new SimpleDataArray(*this));
     }
 
@@ -1507,7 +1510,10 @@ public:
         std::swap(shape_[axis_1], shape_[axis_2]);
     }
 
-    std::unique_ptr<DataArrayBase> copy() const override {
+    std::unique_ptr<DataArrayBase> copy(DLDevice device) const override {
+        if (device.device_type != kDLCPU) {
+            throw Error("EmptyDataArray only supports copying to CPU");
+        }
         return std::unique_ptr<DataArrayBase>(new EmptyDataArray(*this));
     }
 

--- a/metatensor-core/include/metatensor/arrays.hpp
+++ b/metatensor-core/include/metatensor/arrays.hpp
@@ -174,6 +174,98 @@ namespace details {
             return true;
         }
     }
+
+    template <typename T>
+    std::vector<T> vector_from_dlpack(const DLTensor& dl_tensor) {
+        auto expected_dtype = dtype_of<T>();
+        if (dl_tensor.dtype.code != expected_dtype.code ||
+            dl_tensor.dtype.bits != expected_dtype.bits ||
+            dl_tensor.dtype.lanes != expected_dtype.lanes
+        ) {
+            throw Error(
+                "DLPack dtype does not match the requested C++ type: "
+                "DLPack tensor has dtype (code=" + std::to_string(dl_tensor.dtype.code)
+                + ", bits=" + std::to_string(dl_tensor.dtype.bits)
+                + ", lanes=" + std::to_string(dl_tensor.dtype.lanes)
+                + ") which does not match the expected dtype (code=" + std::to_string(dtype_of<T>().code)
+                + ", bits=" + std::to_string(dtype_of<T>().bits)
+                + ", lanes=" + std::to_string(dtype_of<T>().lanes) + ")"
+            );
+        }
+
+        const auto* byte_ptr = static_cast<const char*>(dl_tensor.data);
+        const auto* data_ptr = reinterpret_cast<const T*>(byte_ptr + dl_tensor.byte_offset);
+
+        if (dl_tensor.ndim == 0) {
+            return std::vector<T>{*static_cast<const T*>(dl_tensor.data)};
+        }
+
+        auto* shape = dl_tensor.shape;
+        assert(shape != nullptr);
+
+        auto* strides = dl_tensor.strides;
+        bool allocated_strides = false;
+        bool is_contiguous = true;
+        if (strides == nullptr) {
+            allocated_strides = true;
+            // If strides is null, the tensor is assumed to be contiguous in row-major order
+            strides = new int64_t[static_cast<size_t>(dl_tensor.ndim)];
+            strides[dl_tensor.ndim - 1] = 1;
+            for (int i = dl_tensor.ndim - 2; i >= 0; --i) {
+                strides[i] = strides[i + 1] * shape[i + 1];
+            }
+        } else {
+            // Check if the tensor is contiguous in row-major order
+            int64_t expected_stride = 1;
+            for (int i = dl_tensor.ndim - 1; i >= 0; --i) {
+                if (strides[i] != expected_stride) {
+                    is_contiguous = false;
+                    break;
+                }
+                expected_stride *= shape[i];
+            }
+        }
+
+        size_t num_elements = 1;
+        for (int i = 0; i < dl_tensor.ndim; i++) {
+            num_elements *= static_cast<size_t>(shape[i]);
+        }
+        auto ndim = static_cast<size_t>(dl_tensor.ndim);
+
+        std::vector<T> data;
+        if (is_contiguous) {
+            // If the tensor is contiguous, we can directly use the data pointer
+            data = std::vector<T> (data_ptr, data_ptr + num_elements);
+        } else {
+            // copy elements one by one using the shape and stride information
+            data.reserve(num_elements);
+
+            std::vector<int64_t> indices(ndim, 0);
+            for (size_t i = 0; i < num_elements; i++) {
+                // Calculate the offset for the current index
+                int64_t offset = 0;
+                for (size_t dim = 0; dim < ndim; dim++) {
+                    offset += indices[dim] * strides[dim];
+                }
+                data.push_back(data_ptr[offset]);
+
+                // Increment indices
+                for (size_t dim =0; dim < ndim; dim++) {
+                    indices[dim]++;
+                    if (indices[dim] < shape[dim]) {
+                        break;
+                    }
+                    indices[dim] = 0;
+                }
+            }
+        }
+
+        if (allocated_strides) {
+            delete[] strides;
+        }
+
+        return data;
+    }
 } // namespace details
 
 
@@ -727,7 +819,7 @@ public:
     /// Get the data origin for this array.
     mts_data_origin_t origin() const {
         if (array_.origin == nullptr) {
-            throw Error("invalid mts_array_t: null origin function pointer");
+            throw Error("invalid mts_array_t: `origin` function pointer is null");
         }
         mts_data_origin_t origin;
         details::check_status(array_.origin(array_.ptr, &origin));
@@ -737,7 +829,7 @@ public:
     /// Get the device where this array's data resides.
     DLDevice device() const {
         if (array_.device == nullptr) {
-            throw Error("invalid mts_array_t: null device function pointer");
+            throw Error("invalid mts_array_t: `device` function pointer is null");
         }
         DLDevice device;
         details::check_status(array_.device(array_.ptr, &device));
@@ -747,7 +839,7 @@ public:
     /// Get the data type of this array.
     DLDataType dtype() const {
         if (array_.dtype == nullptr) {
-            throw Error("invalid mts_array_t: null dtype function pointer");
+            throw Error("invalid mts_array_t: `dtype` function pointer is null");
         }
         DLDataType dtype;
         details::check_status(array_.dtype(array_.ptr, &dtype));
@@ -768,13 +860,29 @@ public:
         DLPackVersion max_version
     ) {
         if (array_.as_dlpack == nullptr) {
-            throw Error("invalid mts_array_t: null as_dlpack function pointer");
+            throw Error("invalid mts_array_t: `as_dlpack` function pointer is null");
         }
         DLManagedTensorVersioned* dlpack;
         details::check_status(
             array_.as_dlpack(array_.ptr, &dlpack, device, stream, max_version)
         );
         return dlpack;
+    }
+
+    /// Create a new `MtsArray` from a DLPack tensor. The returned `MtsArray`
+    /// takes ownership of the DLPack tensor and will call its deleter when it
+    /// goes out of scope.
+    MtsArray from_dlpack(
+        DLManagedTensorVersioned* dl_tensor
+    ) {
+        if (array_.from_dlpack == nullptr) {
+            throw Error("invalid mts_array_t: `from_dlpack` function pointer is null");
+        }
+        mts_array_t new_array;
+        details::check_status(
+            array_.from_dlpack(array_.ptr, dl_tensor, &new_array)
+        );
+        return MtsArray(new_array);
     }
 
     /// Get a DLPackArray corresponding to this array
@@ -802,7 +910,7 @@ public:
         MtsArray fill_value
     ) const {
         if (array_.create == nullptr) {
-            throw Error("invalid mts_array_t: null create function pointer");
+            throw Error("invalid mts_array_t: `create` function pointer is null");
         }
         mts_array_t new_array;
         details::check_status(
@@ -814,7 +922,7 @@ public:
     /// Get the shape of this array
     std::vector<uintptr_t> shape() const {
         if (array_.shape == nullptr) {
-            throw Error("invalid mts_array_t: null shape function pointer");
+            throw Error("invalid mts_array_t: `shape` function pointer is null");
         }
         const uintptr_t* shape;
         uintptr_t shape_count;
@@ -827,7 +935,7 @@ public:
     /// Set the shape of this array to the given `shape`
     void reshape(const std::vector<uintptr_t>& shape) {
         if (array_.reshape == nullptr) {
-            throw Error("invalid mts_array_t: null reshape function pointer");
+            throw Error("invalid mts_array_t: `reshape` function pointer is null");
         }
         details::check_status(
             array_.reshape(array_.ptr, shape.data(), shape.size())
@@ -837,7 +945,7 @@ public:
     /// Swap the axes `axis_1` and `axis_2` in this `array`.
     void swap_axes(uintptr_t axis_1, uintptr_t axis_2) {
         if (array_.swap_axes == nullptr) {
-            throw Error("invalid mts_array_t: null swap_axes function pointer");
+            throw Error("invalid mts_array_t: `swap_axes` function pointer is null");
         }
         details::check_status(
             array_.swap_axes(array_.ptr, axis_1, axis_2)
@@ -861,7 +969,7 @@ public:
         std::vector<mts_data_movement_t> moves
     ) {
         if (array_.move_data == nullptr) {
-            throw Error("invalid mts_array_t: null move_data function pointer");
+            throw Error("invalid mts_array_t: `move_data` function pointer is null");
         }
         details::check_status(
             array_.move_data(array_.ptr, input.array_.ptr, moves.data(), moves.size())
@@ -961,7 +1069,7 @@ public:
 
         array.as_dlpack = [](
             void *array,
-            DLManagedTensorVersioned **dl_managed_tensor,
+            DLManagedTensorVersioned **dl_tensor,
             DLDevice device,
             const int64_t *stream,
             DLPackVersion max_version
@@ -969,15 +1077,35 @@ public:
             return details::catch_exceptions(
                 [](
                     void *array,
-                    DLManagedTensorVersioned **dl_managed_tensor,
+                    DLManagedTensorVersioned **dl_tensor,
                     DLDevice device,
                     const int64_t *stream,
                     DLPackVersion max_version
                 ) {
-                    auto *cxx_arr = static_cast<DataArrayBase *>(array);
-                    *dl_managed_tensor = cxx_arr->as_dlpack(device, stream, max_version);
+                    auto* cxx_arr = static_cast<DataArrayBase *>(array);
+                    *dl_tensor = cxx_arr->as_dlpack(device, stream, max_version);
                 },
-                array, dl_managed_tensor, device, stream, max_version);
+                array, dl_tensor, device, stream, max_version);
+        };
+
+        array.from_dlpack = [](
+            const void *array,
+            DLManagedTensorVersioned *dl_tensor,
+            mts_array_t *new_array
+        ) {
+            return details::catch_exceptions(
+                [](
+                    const void *array,
+                    DLManagedTensorVersioned *dl_tensor,
+                    mts_array_t *new_array
+                ) {
+                    const auto* cxx_arr = static_cast<const DataArrayBase *>(array);
+                    auto new_array_ptr = cxx_arr->from_dlpack(dl_tensor);
+
+                    auto new_array_cxx = DataArrayBase::to_mts_array(std::move(new_array_ptr));
+                    *new_array = std::move(new_array_cxx).release();
+                },
+                array, dl_tensor, new_array);
         };
 
         array.shape = [](const void* array, const uintptr_t** shape, uintptr_t* shape_count) {
@@ -1052,6 +1180,13 @@ public:
         const int64_t* stream,
         DLPackVersion max_version
     ) = 0;
+
+    /// Create a new `DataArrayBase` from a DLPack tensor. The returned
+    /// `DataArrayBase` takes ownership of the DLPack tensor and will call its
+    /// deleter when it goes out of scope.
+    virtual std::unique_ptr<DataArrayBase> from_dlpack(
+        DLManagedTensorVersioned* dl_tensor
+    ) const = 0;
 
     /// Make a copy of this DataArrayBase and return the new array. The new
     /// array is expected to have the same data origin and dtype, but live on
@@ -1373,6 +1508,112 @@ public:
         return managed.release();
     }
 
+    std::unique_ptr<DataArrayBase> from_dlpack(DLManagedTensorVersioned *dl_managed_tensor) const override {
+        // RAII guard to ensure dl_managed_tensor is deleted if any error occurs
+        struct AutoDeleteDLManagedTensor {
+            DLManagedTensorVersioned* ptr;
+            ~AutoDeleteDLManagedTensor() {
+                if (ptr != nullptr && ptr->deleter != nullptr) {
+                    ptr->deleter(ptr);
+                }
+            }
+        };
+
+        auto dl_managed_tensor_guard = AutoDeleteDLManagedTensor{dl_managed_tensor};
+
+        if (dl_managed_tensor == nullptr) {
+            throw Error("dlpack tensor is null in SimpleDataArray::from_dlpack");
+        }
+
+        if (dl_managed_tensor->version.major != DLPACK_MAJOR_VERSION) {
+            throw Error(
+                "DLPack version mismatch in SimpleDataArray::from_dlpack: expected major " +
+                std::to_string(DLPACK_MAJOR_VERSION) + ", got " +
+                std::to_string(dl_managed_tensor->version.major) + "." +
+                std::to_string(dl_managed_tensor->version.minor)
+            );
+        }
+
+        auto dl_tensor = dl_managed_tensor->dl_tensor;
+
+        if (dl_tensor.device.device_type != kDLCPU) {
+            throw Error(
+                "SimpleDataArray::from_dlpack only supports CPU device (kDLCPU), "
+                "got device type " + std::to_string(dl_tensor.device.device_type)
+            );
+        }
+
+        auto shape = std::vector<uintptr_t>();
+        for (int i = 0; i < dl_tensor.ndim; i++) {
+            shape.push_back(static_cast<uintptr_t>(dl_tensor.shape[i]));
+        }
+
+        auto dtype = dl_tensor.dtype;
+        if (dtype.lanes != 1) {
+            throw Error("SimpleDataArray::from_dlpack only supports DLPack tensors with lanes == 1");
+        }
+
+        std::unique_ptr<DataArrayBase> result;
+        if (dtype.code == kDLFloat && dtype.bits == 64) {
+            result = std::make_unique<SimpleDataArray<double>>(
+                std::move(shape),
+                details::vector_from_dlpack<double>(dl_tensor)
+            );
+        } else if (dtype.code == kDLFloat && dtype.bits == 32) {
+            result = std::make_unique<SimpleDataArray<float>>(
+                std::move(shape),
+                details::vector_from_dlpack<float>(dl_tensor)
+            );
+        } else if (dtype.code == kDLInt && dtype.bits == 8) {
+            result = std::make_unique<SimpleDataArray<int8_t>>(
+                std::move(shape),
+                details::vector_from_dlpack<int8_t>(dl_tensor)
+            );
+        } else if (dtype.code == kDLInt && dtype.bits == 16) {
+            result = std::make_unique<SimpleDataArray<int16_t>>(
+                std::move(shape),
+                details::vector_from_dlpack<int16_t>(dl_tensor)
+            );
+        } else if (dtype.code == kDLInt && dtype.bits == 32) {
+            result = std::make_unique<SimpleDataArray<int32_t>>(
+                std::move(shape),
+                details::vector_from_dlpack<int32_t>(dl_tensor)
+            );
+        } else if (dtype.code == kDLInt && dtype.bits == 64) {
+            result = std::make_unique<SimpleDataArray<int64_t>>(
+                std::move(shape),
+                details::vector_from_dlpack<int64_t>(dl_tensor)
+            );
+        } else if (dtype.code == kDLUInt && dtype.bits == 8) {
+            result = std::make_unique<SimpleDataArray<uint8_t>>(
+                std::move(shape),
+                details::vector_from_dlpack<uint8_t>(dl_tensor)
+            );
+        } else if (dtype.code == kDLUInt && dtype.bits == 16) {
+            result = std::make_unique<SimpleDataArray<uint16_t>>(
+                std::move(shape),
+                details::vector_from_dlpack<uint16_t>(dl_tensor)
+            );
+        } else if (dtype.code == kDLUInt && dtype.bits == 32) {
+            result = std::make_unique<SimpleDataArray<uint32_t>>(
+                std::move(shape),
+                details::vector_from_dlpack<uint32_t>(dl_tensor)
+            );
+        } else if (dtype.code == kDLUInt && dtype.bits == 64) {
+            result = std::make_unique<SimpleDataArray<uint64_t>>(
+                std::move(shape),
+                details::vector_from_dlpack<uint64_t>(dl_tensor)
+            );
+        } else {
+            throw metatensor::Error(
+                "unsupported DLDataType in default_create_array: code="
+                + std::to_string(dtype.code) + " bits=" + std::to_string(dtype.bits)
+            );
+        }
+
+        return result;
+    }
+
     /// Get a pointer to the data managed by this SimpleDataArray
     T* data() {
         return data_->data();
@@ -1493,6 +1734,11 @@ public:
     [[noreturn]]
     DLManagedTensorVersioned *as_dlpack(DLDevice, const int64_t*, DLPackVersion) override {
         throw metatensor::Error("can not call `as_dlpack` for an EmtpyDataArray");
+    }
+
+    [[noreturn]]
+    std::unique_ptr<DataArrayBase> from_dlpack(DLManagedTensorVersioned*) const override {
+        throw metatensor::Error("can not call `from_dlpack` for an EmtpyDataArray");
     }
 
     const std::vector<uintptr_t>& shape() const & override {

--- a/metatensor-core/src/blocks.rs
+++ b/metatensor-core/src/blocks.rs
@@ -150,7 +150,7 @@ impl TensorBlock {
     /// one of the underlying `mts_array_t` data arrays
     pub fn try_clone(&self) -> Result<TensorBlock, Error> {
         // Try to clone the values
-        let values = self.values.try_clone()?;
+        let values = self.values.copy(self.values.device()?)?;
 
         // Try to clone all gradient blocks
         let mut gradients = HashMap::new();

--- a/metatensor-core/src/c_api/status.rs
+++ b/metatensor-core/src/c_api/status.rs
@@ -13,14 +13,6 @@ struct LastError {
     custom_data_deleter: Option<unsafe extern "C" fn(*mut c_void)>,
 }
 
-impl std::ops::Drop for LastError {
-    fn drop(&mut self) {
-        if let Some(deleter) = self.custom_data_deleter {
-            unsafe { deleter(self.custom_data) };
-        }
-    }
-}
-
 // Save the last error message in thread local storage.
 //
 // This is marginally better than a standard global static value because it
@@ -118,11 +110,21 @@ impl From<Error> for mts_status_t {
             return mts_status_t::MTS_CALLBACK_ERROR;
         }
 
-        LAST_ERROR.set(LastError {
-            message: CString::new(format!("{}", error)).expect("error message contains a null byte"),
-            origin: CString::new("metatensor-core").expect("invalid C string"),
-            custom_data: std::ptr::null_mut(),
-            custom_data_deleter: None,
+        LAST_ERROR.with(|last_error| {
+            let mut last_error = last_error.borrow_mut();
+            // if there is a custom data deleter, call it to free the custom data
+            if let Some(deleter) = last_error.custom_data_deleter {
+                unsafe {
+                    deleter(last_error.custom_data);
+                }
+            }
+
+            *last_error = LastError {
+                message: CString::new(format!("{}", error)).expect("error message contains a null byte"),
+                origin: CString::new("metatensor-core").expect("invalid C string"),
+                custom_data: std::ptr::null_mut(),
+                custom_data_deleter: None,
+            };
         });
 
         match error {
@@ -182,14 +184,15 @@ pub unsafe extern "C" fn mts_last_error(
 ) -> mts_status_t {
     let status = std::panic::catch_unwind(|| {
         LAST_ERROR.with(|last_error| {
+            let last_error = last_error.borrow();
             if !message.is_null() {
-                *message = last_error.borrow().message.as_ptr();
+                *message = last_error.message.as_ptr();
             }
             if !origin.is_null() {
-                *origin = last_error.borrow().origin.as_ptr();
+                *origin = last_error.origin.as_ptr();
             }
             if !data.is_null() {
-                *data = last_error.borrow().custom_data;
+                *data = last_error.custom_data;
             }
         });
     });
@@ -246,11 +249,22 @@ pub unsafe extern "C" fn mts_set_last_error(
             CString::from(CStr::from_ptr(origin))
         };
 
-        LAST_ERROR.set(LastError {
-            message: message,
-            origin: origin,
-            custom_data: data,
-            custom_data_deleter: data_deleter,
+        LAST_ERROR.with(|last_error| {
+            let mut last_error = last_error.borrow_mut();
+
+            // if there is a custom data deleter, call it to free the custom data
+            if let Some(deleter) = last_error.custom_data_deleter {
+                unsafe {
+                    deleter(last_error.custom_data);
+                }
+            }
+
+            *last_error = LastError {
+                message: message,
+                origin: origin,
+                custom_data: data,
+                custom_data_deleter: data_deleter,
+            };
         });
         Ok(())
     })

--- a/metatensor-core/src/data.rs
+++ b/metatensor-core/src/data.rs
@@ -1,6 +1,5 @@
 use std::os::raw::c_void;
 use std::sync::Mutex;
-use std::ptr::NonNull;
 
 use once_cell::sync::Lazy;
 
@@ -170,6 +169,29 @@ pub struct mts_array_t {
         max_version: DLPackVersion,
     ) -> mts_status_t>,
 
+    /// Create a new array from a DLPack tensor, taking ownership of the
+    /// tensor's data.
+    ///
+    /// The `new_array` output parameter should be filled with an `mts_array_t`
+    /// representing the new array, with the same array origin as the current
+    /// one. The implementation should take ownership of the data in
+    /// `dl_managed_tensor`, and is responsible for calling the tensor's
+    /// `deleter` function when the data is no longer needed.
+    ///
+    /// Importantly, the `dl_managed_tensor` and thus the new array might have a
+    /// different device and/or data type than the current one, and the
+    /// implementation should handle this correctly or return an error.
+    ///
+    /// This function should return `MTS_SUCCESS` on success, or
+    /// `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
+    /// should call `mts_set_last_error` with an appropriate error message
+    /// before returning.
+    pub from_dlpack: Option<unsafe extern "C" fn(
+        array: *const c_void,
+        dl_managed_tensor: *mut DLManagedTensorVersioned,
+        new_array: *mut mts_array_t,
+    ) -> mts_status_t>,
+
     /// Get the shape of the array managed by this `mts_array_t` in the `*shape`
     /// pointer, and the number of dimension (size of the `*shape` array) in
     /// `*shape_count`. If the array is a single scalar, `shape_count` should be
@@ -328,6 +350,7 @@ impl mts_array_t {
             device: self.device,
             dtype: self.dtype,
             as_dlpack: self.as_dlpack,
+            from_dlpack: self.from_dlpack,
             shape: self.shape,
             reshape: self.reshape,
             swap_axes: self.swap_axes,
@@ -347,6 +370,7 @@ impl mts_array_t {
             device: None,
             dtype: None,
             as_dlpack: None,
+            from_dlpack: None,
             shape: None,
             reshape: None,
             swap_axes: None,
@@ -427,12 +451,33 @@ impl mts_array_t {
             crate::c_api::add_error_context("calling mts_array_t.as_dlpack failed");
             return Err(Error::CallbackError);
         }
-        assert!(!dl_managed_tensor.is_null(), "mts_array_t.as_dlpack returned a null pointer on success");
-        let ptr = NonNull::new(dl_managed_tensor).expect("pointer is null, this should not happen");
+        debug_assert!(!dl_managed_tensor.is_null(), "mts_array_t.as_dlpack returned a null pointer on success");
         let tensor = unsafe {
-            DLPackTensor::from_ptr(ptr)
+            DLPackTensor::from_ptr(dl_managed_tensor)
         };
         return Ok(tensor);
+    }
+
+    /// Create a new array from a DLPack tensor, taking ownership of the
+    /// tensor's data.
+    #[allow(clippy::wrong_self_convention)]
+    pub fn from_dlpack(
+        &self,
+        tensor: DLPackTensor,
+    ) -> Result<mts_array_t, Error> {
+        let function = self.from_dlpack.expect("mts_array_t.from_dlpack function is NULL");
+
+        let mut new_array = mts_array_t::null();
+        let status = unsafe {
+            function(self.ptr, tensor.into_raw().as_ptr(), &mut new_array)
+        };
+
+        if !status.is_success() {
+            crate::c_api::add_error_context("calling mts_array_t.from_dlpack failed");
+            return Err(Error::CallbackError);
+        }
+
+        return Ok(new_array);
     }
 
     /// Get the shape of this array, this can be empty if the array has no shape
@@ -640,6 +685,7 @@ mod tests {
                 device: Some(TestArray::device_cpu),
                 dtype: Some(TestArray::dtype_f64),
                 as_dlpack: None,
+                from_dlpack: None,
                 shape: Some(TestArray::shape),
                 reshape: Some(TestArray::reshape),
                 swap_axes: Some(TestArray::swap_axes),
@@ -659,6 +705,7 @@ mod tests {
                 device: Some(TestArray::device_cpu),
                 dtype: Some(TestArray::dtype_f64),
                 as_dlpack: None,
+                from_dlpack: None,
                 shape: Some(TestArray::shape),
                 reshape: Some(TestArray::reshape),
                 swap_axes: Some(TestArray::swap_axes),
@@ -679,6 +726,7 @@ mod tests {
                 device: Some(TestArray::device_cuda),
                 dtype: Some(TestArray::dtype_f64),
                 as_dlpack: None,
+                from_dlpack: None,
                 shape: Some(TestArray::shape),
                 reshape: Some(TestArray::reshape),
                 swap_axes: Some(TestArray::swap_axes),
@@ -699,6 +747,7 @@ mod tests {
                 device: Some(TestArray::device_cpu),
                 dtype: Some(TestArray::dtype_f32),
                 as_dlpack: None,
+                from_dlpack: None,
                 shape: Some(TestArray::shape),
                 reshape: Some(TestArray::reshape),
                 swap_axes: Some(TestArray::swap_axes),

--- a/metatensor-core/src/data.rs
+++ b/metatensor-core/src/data.rs
@@ -211,10 +211,10 @@ pub struct mts_array_t {
         axis_2: usize,
     ) -> mts_status_t>,
 
-    /// Create a new array with the same options as the current one (data type,
-    /// data location, etc.) and the requested `shape`; and store it in
-    /// `new_array`. The number of elements in the `shape` array should be given
-    /// in `shape_count`.
+    /// Create a new array with the same options as the current one (array
+    /// origin, data type, device, etc.) and the requested `shape`; and store it
+    /// in `new_array`. The number of elements in the `shape` array should be
+    /// given in `shape_count`.
     ///
     /// The new array should be filled with the scalar value from `fill_value`,
     /// which must be an `mts_array_t` containing a single scalar (empty shape)
@@ -236,8 +236,8 @@ pub struct mts_array_t {
 
     /// Make a copy of this `array` and return the new array in `new_array`.
     ///
-    /// The new array is expected to have the same data origin and parameters
-    /// (data type, data location, etc.)
+    /// The new array is expected to have the same array origin and data type as
+    /// the original one, but live on the given `device`.
     ///
     /// This function should return `MTS_SUCCESS` on success, or
     /// `MTS_CALLBACK_ERROR` on failure. In case of failure, the implementation
@@ -245,6 +245,7 @@ pub struct mts_array_t {
     /// before returning.
     pub copy: Option<unsafe extern "C" fn(
         array: *const c_void,
+        device: DLDevice,
         new_array: *mut mts_array_t,
     ) -> mts_status_t>,
 
@@ -563,12 +564,12 @@ impl mts_array_t {
 
     /// Try to copy this `mts_array_t`. This can fail if the external data can
     /// not be copied for some reason
-    pub fn try_clone(&self) -> Result<mts_array_t, Error> {
+    pub fn copy(&self, device: DLDevice) -> Result<mts_array_t, Error> {
         let function = self.copy.expect("mts_array_t.copy function is NULL");
 
         let mut new_array = mts_array_t::null();
         let status = unsafe {
-            function(self.ptr, &mut new_array)
+            function(self.ptr, device, &mut new_array)
         };
 
         if !status.is_success() {

--- a/metatensor-core/src/labels/array.rs
+++ b/metatensor-core/src/labels/array.rs
@@ -371,72 +371,72 @@ unsafe extern "C" fn labels_array_move_data(
     })
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use crate::labels::Labels;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::labels::Labels;
 
-//     #[test]
-//     fn labels_values_array_shape() {
-//         let labels = Labels::new(&["x", "y"], vec![1.into(), 2.into(), 3.into(), 4.into()]).unwrap();
-//         let arr = labels.values();
+    #[test]
+    fn labels_values_array_shape() {
+        let labels = Labels::from_vec(&["x", "y"], vec![1, 2, 3, 4]).unwrap();
+        let values = labels.values();
 
-//         let shape = arr.shape().unwrap();
-//         assert_eq!(shape, &[2, 2]);
-//     }
+        let shape = values.shape().unwrap();
+        assert_eq!(shape, &[2, 2]);
+    }
 
-//     #[test]
-//     fn labels_values_array_origin() {
-//         let labels = Labels::new(&["a"], vec![10.into()]).unwrap();
-//         let arr = labels.values();
+    #[test]
+    fn labels_values_array_origin() {
+        let labels = Labels::from_vec(&["a"], vec![10]).unwrap();
+        let values = labels.values();
 
-//         let origin = arr.origin().unwrap();
-//         let name = crate::data::get_data_origin(origin);
-//         assert_eq!(name, "metatensor.labels");
-//     }
+        let origin = values.origin().unwrap();
+        let name = crate::data::get_data_origin(origin);
+        assert_eq!(name, "metatensor.Labels");
+    }
 
-//     #[test]
-//     fn labels_values_array_copy() {
-//         let labels = Labels::new(&["a"], vec![10.into(), 20.into()]).unwrap();
-//         let arr = labels.values();
+    #[test]
+    fn labels_values_array_copy() {
+        let labels = Labels::from_vec(&["a"], vec![10, 20]).unwrap();
+        let values = labels.values();
 
-//         let cloned = arr.try_clone().unwrap();
-//         let shape = cloned.shape().unwrap();
-//         assert_eq!(shape, &[2, 1]);
-//     }
+        let cloned = values.copy(DLDevice::cpu()).unwrap();
+        let shape = cloned.shape().unwrap();
+        assert_eq!(shape, &[2, 1]);
+    }
 
-//     #[test]
-//     fn empty_labels_values_array() {
-//         let labels = Labels::new(&["a", "b"], Vec::new()).unwrap();
-//         let arr = labels.values();
+    #[test]
+    fn empty_labels_values_array() {
+        let labels = Labels::from_vec(&["a", "b"], Vec::new()).unwrap();
+        let values = labels.values();
 
-//         let shape = arr.shape().unwrap();
-//         assert_eq!(shape, &[0, 2]);
-//     }
+        let shape = values.shape().unwrap();
+        assert_eq!(shape, &[0, 2]);
+    }
 
-//     #[test]
-//     fn labels_values_array_device() {
-//         let labels = Labels::new(&["x"], vec![1.into(), 2.into()]).unwrap();
-//         let arr = labels.values();
+    #[test]
+    fn labels_values_array_device() {
+        let labels = Labels::from_vec(&["x"], vec![1, 2]).unwrap();
+        let values = labels.values();
 
-//         let device = arr.device().unwrap();
-//         let cpu = DLDevice::cpu();
-//         assert_eq!(device.device_type, cpu.device_type);
-//         assert_eq!(device.device_id, cpu.device_id);
-//     }
+        let device = values.device().unwrap();
+        let cpu = DLDevice::cpu();
+        assert_eq!(device.device_type, cpu.device_type);
+        assert_eq!(device.device_id, cpu.device_id);
+    }
 
-//     #[test]
-//     fn labels_values_array_as_dlpack() {
-//         let labels = Labels::new(&["a", "b"], vec![1.into(), 2.into(), 3.into(), 4.into()]).unwrap();
-//         let arr = labels.values();
+    #[test]
+    fn labels_values_array_as_dlpack() {
+        let labels = Labels::from_vec(&["a", "b"], vec![1, 2, 3, 4]).unwrap();
+        let values = labels.values();
 
-//         let cpu = DLDevice::cpu();
-//         let version = DLPackVersion::current();
-//         let tensor = arr.as_dlpack(cpu, None, version).unwrap();
+        let cpu = DLDevice::cpu();
+        let version = DLPackVersion::current();
+        let tensor = values.as_dlpack(cpu, None, version).unwrap();
 
-//         assert_eq!(tensor.n_dims(), 2);
-//         assert_eq!(tensor.dtype().code, DLDataTypeCode::kDLInt);
-//         assert_eq!(tensor.dtype().bits, 32);
-//         assert_eq!(tensor.shape(), &[2, 2]);
-//     }
-// }
+        assert_eq!(tensor.n_dims(), 2);
+        assert_eq!(tensor.dtype().code, DLDataTypeCode::kDLInt);
+        assert_eq!(tensor.dtype().bits, 32);
+        assert_eq!(tensor.shape(), &[2, 2]);
+    }
+}

--- a/metatensor-core/src/labels/array.rs
+++ b/metatensor-core/src/labels/array.rs
@@ -3,6 +3,7 @@
 use std::os::raw::c_void;
 use std::sync::{Arc, OnceLock};
 
+use dlpk::DLPackTensor;
 use dlpk::sys::{
     DLDataType, DLDataTypeCode, DLDevice, DLManagedTensorVersioned,
     DLPackVersion, DLTensor,
@@ -43,6 +44,7 @@ pub(super) fn create_array_from_vec(values: Vec<LabelValue>, count: usize, size:
         device: Some(labels_array_device),
         dtype: Some(labels_array_dtype),
         as_dlpack: Some(labels_array_as_dlpack),
+        from_dlpack: Some(labels_array_from_dlpack),
         shape: Some(labels_array_shape),
         reshape: Some(labels_array_reshape),
         swap_axes: Some(labels_array_swap_axes),
@@ -258,6 +260,81 @@ unsafe extern "C" fn labels_array_as_dlpack(
     })
 }
 
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+unsafe extern "C" fn labels_array_from_dlpack(
+    array: *const c_void,
+    dl_managed_tensor: *mut DLManagedTensorVersioned,
+    new_array: *mut mts_array_t,
+) -> mts_status_t {
+    catch_unwind(|| {
+        check_pointers_non_null!(array, new_array, dl_managed_tensor);
+
+        let dl_tensor = std::ptr::NonNull::new(dl_managed_tensor)
+            .ok_or_else(|| Error::InvalidParameter("dl_managed_tensor pointer is null".into()))?;
+
+        let dl_tensor = DLPackTensor::from_raw(dl_tensor);
+
+        let version = dl_tensor.version();
+        let current_dl_version = DLPackVersion::current();
+        if version.major != current_dl_version.major {
+            return Err(Error::InvalidParameter(format!(
+                "unsupported DLPack version: got {}.{}, expected major version {}",
+                version.major, version.minor, current_dl_version.major
+            )));
+        }
+
+        if dl_tensor.device() != DLDevice::cpu() {
+            return Err(Error::InvalidParameter(
+                "labels values can not be created from dlpack tensors that are not on CPU".into()
+            ))
+        }
+
+        let values_ptr: *const i32 = dl_tensor.data_ptr()
+            .map_err(|e| Error::InvalidParameter(format!("failed to get data pointer from DLPack tensor: {}", e)))?;
+
+        let shape = dl_tensor.shape();
+        if shape.len() != 2 {
+            return Err(Error::InvalidParameter(format!(
+                "expected 2D tensor for labels values, got shape={:?}", shape
+            )));
+        }
+
+        let strides = dl_tensor.strides().map_or_else(|| {
+                // If strides are not provided, we assume the tensor is contiguous
+                // in row-major order.
+                [shape[1], 1]
+            }, |s| {
+                assert!(s.len() == 2, "expected 2D tensor for labels values, got strides={:?}", s);
+                [s[0], s[1]]
+            });
+
+        let mut values;
+        if (strides == [shape[1], 1]) || (shape[0] == 1 && strides[1] == 1) || shape[2] == 1 {
+            // If the data is contiguous, we can read it directly as a single slice.
+            let slice = unsafe { std::slice::from_raw_parts(values_ptr, (shape[0] * shape[1]) as usize) };
+            values = slice.to_vec();
+        } else {
+            // otherwise we need to copy the data into a contiguous Vec one element at a time.
+            values = vec![0; (shape[0] * shape[1]) as usize];
+            for i in 0..shape[0] {
+                for j in 0..shape[1] {
+                    let offset = i * strides[0] + j * strides[1];
+                    let value = unsafe {
+                        values_ptr.offset(offset as isize).read()
+                    };
+                    values[(i * shape[1] + j) as usize] = value;
+                }
+            }
+        }
+
+        *new_array = create_array_from_vec(values, shape[0] as usize, shape[1] as usize);
+
+        Ok(())
+    })
+}
+
+
 unsafe extern "C" fn labels_array_shape(
     array: *const c_void,
     shape: *mut *const usize,
@@ -296,6 +373,7 @@ unsafe extern "C" fn labels_array_copy(
             device: Some(labels_array_device),
             dtype: Some(labels_array_dtype),
             as_dlpack: Some(labels_array_as_dlpack),
+            from_dlpack: Some(labels_array_from_dlpack),
             shape: Some(labels_array_shape),
             reshape: Some(labels_array_reshape),
             swap_axes: Some(labels_array_swap_axes),
@@ -445,5 +523,29 @@ mod tests {
         assert_eq!(tensor.dtype().code, DLDataTypeCode::kDLInt);
         assert_eq!(tensor.dtype().bits, 32);
         assert_eq!(tensor.shape(), &[2, 2]);
+    }
+
+    #[test]
+    fn labels_values_array_from_dlpack() {
+        let labels = Labels::from_vec(&["a", "b"], vec![1, 2, 3, 4]).unwrap();
+        let values = labels.values();
+
+        let cpu = DLDevice::cpu();
+        let version = DLPackVersion::current();
+        let dl_tensor = values.as_dlpack(cpu, None, version).unwrap();
+
+        let new_array = values.from_dlpack(dl_tensor).unwrap();
+
+        let shape = new_array.shape().unwrap();
+        assert_eq!(shape, &[2, 2]);
+
+        let new_array_dlpack = new_array.as_dlpack(cpu, None, version).unwrap();
+        let new_array_slice = unsafe {
+            std::slice::from_raw_parts(
+                new_array_dlpack.data_ptr::<i32>().unwrap(),
+                4
+            )
+        };
+        assert_eq!(labels.values_cpu(), new_array_slice);
     }
 }

--- a/metatensor-core/src/labels/array.rs
+++ b/metatensor-core/src/labels/array.rs
@@ -274,10 +274,17 @@ unsafe extern "C" fn labels_array_shape(
 
 unsafe extern "C" fn labels_array_copy(
     array: *const c_void,
+    device: DLDevice,
     new_array: *mut mts_array_t,
 ) -> mts_status_t {
     catch_unwind(|| {
         check_pointers_non_null!(array, new_array);
+
+        if device != DLDevice::cpu() {
+            return Err(Error::InvalidParameter(
+                "labels values owned by metatensor-core only exist on CPU".into()
+            ))
+        }
 
         let array = array.cast::<LabelsValuesArray>();
         Arc::increment_strong_count(array);

--- a/metatensor-core/src/labels/mod.rs
+++ b/metatensor-core/src/labels/mod.rs
@@ -916,7 +916,7 @@ mod tests {
     fn from_array_lazy_values() {
         // Create a labels array, then build Labels from it
         let original = Labels::from_vec(&["x", "y"], vec![1, 2, 3, 4]).unwrap();
-        let array = original.values().try_clone().unwrap();
+        let array = original.values().copy(DLDevice::cpu()).unwrap();
 
         let labels = Labels::new(&["x", "y"], array).unwrap();
         assert_eq!(labels.count(), 2);
@@ -933,10 +933,10 @@ mod tests {
         let values = vec![1, 10, 2, 20, 3, 30];
         let labels = Labels::from_vec(dimensions, values.clone()).unwrap();
 
-        let values = labels.values().try_clone().unwrap();
+        let values = labels.values().copy(DLDevice::cpu()).unwrap();
         let labels_safe = Labels::new(dimensions, values).unwrap();
 
-        let values = labels.values().try_clone().unwrap();
+        let values = labels.values().copy(DLDevice::cpu()).unwrap();
         let labels_unchecked = unsafe {
             Labels::new_unchecked_uniqueness(dimensions, values).unwrap()
         };

--- a/metatensor-core/tests/cpp/blocks.cpp
+++ b/metatensor-core/tests/cpp/blocks.cpp
@@ -119,7 +119,7 @@ TEST_CASE("Blocks") {
             BrokenDataArray(std::vector<size_t> shape): metatensor::SimpleDataArray<double>(std::move(shape)) {}
 
             [[noreturn]]
-            std::unique_ptr<DataArrayBase> copy() const override {
+            std::unique_ptr<DataArrayBase> copy(DLDevice) const override {
                 throw std::runtime_error("can not copy this!");
             }
         };

--- a/metatensor-core/tests/cpp/data.cpp
+++ b/metatensor-core/tests/cpp/data.cpp
@@ -7,7 +7,7 @@
 using namespace metatensor;
 
 TEST_CASE("Data Array") {
-    auto data = std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({2, 3, 4}));
+    auto data = std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({2, 3, 4}));
     auto array = DataArrayBase::to_mts_array(std::move(data));
 
     SECTION("origin") {
@@ -46,7 +46,7 @@ TEST_CASE("Data Array") {
 }
 
 TEST_CASE("SimpleDataArray<double> - as_dlpack()") {
-    auto data = std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({2, 3, 4}));
+    auto data = std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({2, 3, 4}));
     {
         auto view = data->view();
         view(1, 1, 0) = 1.2345;
@@ -72,7 +72,7 @@ TEST_CASE("SimpleDataArray<double> - as_dlpack()") {
 
 TEST_CASE("SimpleDataArray<float> - as_dlpack()") {
     // Create float-backed array via C++ class, expose through mts_array_t
-    auto data = std::unique_ptr<SimpleDataArray<float>>(new SimpleDataArray<float>({2, 3, 4}));
+    auto data = std::make_unique<SimpleDataArray<float>>(SimpleDataArray<float>({2, 3, 4}));
     {
         auto view = data->view();
         view(1, 1, 0) = 3.1415F;
@@ -98,7 +98,7 @@ TEST_CASE("SimpleDataArray<float> - as_dlpack()") {
 }
 
 TEST_CASE("SimpleDataArray<int32_t> - as_dlpack()") {
-    auto data = std::unique_ptr<SimpleDataArray<int32_t>>(new SimpleDataArray<int32_t>({2, 3, 4}));
+    auto data = std::make_unique<SimpleDataArray<int32_t>>(SimpleDataArray<int32_t>({2, 3, 4}));
     {
         auto view = data->view();
         view(1, 1, 0) = 42;
@@ -121,6 +121,34 @@ TEST_CASE("SimpleDataArray<int32_t> - as_dlpack()") {
 
     const auto* data_ptr = dlpack_array.data();
     CHECK(data_ptr[16] == 42);
+}
+
+TEST_CASE("SimpleDataArray - from_dlpack()") {
+    auto double_data = std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({2, 3, 4}));
+    auto double_array = DataArrayBase::to_mts_array(std::move(double_data));
+
+    auto int_data = std::make_unique<SimpleDataArray<int16_t>>(SimpleDataArray<int16_t>({2, 3, 4}));
+    auto int_array = DataArrayBase::to_mts_array(std::move(int_data));
+
+    auto* double_dl_tensor = double_array.as_dlpack({kDLCPU, 0}, nullptr, {DLPACK_MAJOR_VERSION, DLPACK_MINOR_VERSION});
+    auto* int_dl_tensor = int_array.as_dlpack({kDLCPU, 0}, nullptr, {DLPACK_MAJOR_VERSION, DLPACK_MINOR_VERSION});
+
+    auto new_double_array = double_array.from_dlpack(double_dl_tensor);
+    // create an array of a different type from the source array
+    auto new_int_array = double_array.from_dlpack(int_dl_tensor);
+
+    auto device = DLDevice{kDLCPU, 0};
+    auto version = DLPackVersion{DLPACK_MAJOR_VERSION, DLPACK_MINOR_VERSION};
+
+    CHECK(
+        new_double_array.as_dlpack_array<double>(device, nullptr, version)
+        == double_array.as_dlpack_array<double>(device, nullptr, version)
+    );
+
+    CHECK(
+        new_int_array.as_dlpack_array<int16_t>(device, nullptr, version)
+        == int_array.as_dlpack_array<int16_t>(device, nullptr, version)
+    );
 }
 
 TEST_CASE("DLPackArray<T> - construction and access") {
@@ -240,7 +268,7 @@ TEST_CASE("DLPackArray<T> - nullptr construction") {
 }
 
 TEST_CASE("SimpleDataArray - device()") {
-    auto data = std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({2, 3}));
+    auto data = std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({2, 3}));
 
     // direct call to device()
     CHECK(data->device().device_type == kDLCPU);
@@ -282,7 +310,7 @@ TEST_CASE("DLPackArray<T> - device()") {
 }
 
 TEST_CASE("TensorBlock::values() with device parameter") {
-    auto data = std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({2, 3}, 1.0));
+    auto data = std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({2, 3}, 1.0));
     auto samples = Labels({"s"}, {{0}, {1}});
     auto properties = Labels({"p"}, {{0}, {1}, {2}});
 
@@ -310,7 +338,7 @@ TEST_CASE("TensorBlock::values() with device parameter") {
 }
 
 TEST_CASE("SimpleDataArray - DLPack version mismatch") {
-    auto data = std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({2, 2}));
+    auto data = std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({2, 2}));
 
     DLDevice cpu_device = {kDLCPU, 0};
 
@@ -370,7 +398,7 @@ TEST_CASE("SimpleDataArray - dtype()") {
     }
 
     SECTION("via mts_array_t callback") {
-        auto data = std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({2, 3}));
+        auto data = std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({2, 3}));
         auto array = DataArrayBase::to_mts_array(std::move(data));
 
         CHECK(array.dtype().code == kDLFloat);

--- a/metatensor-core/tests/cpp/tensor.cpp
+++ b/metatensor-core/tests/cpp/tensor.cpp
@@ -284,7 +284,7 @@ TEST_CASE("TensorMap") {
             BrokenDataArray(std::vector<size_t> shape): metatensor::SimpleDataArray<double>(std::move(shape)) {}
 
             [[noreturn]]
-            std::unique_ptr<DataArrayBase> copy() const override {
+            std::unique_ptr<DataArrayBase> copy(DLDevice) const override {
                 throw std::runtime_error("can not copy this!");
             }
         };

--- a/metatensor-torch/include/metatensor/torch/array.hpp
+++ b/metatensor-torch/include/metatensor/torch/array.hpp
@@ -61,6 +61,8 @@ public:
 
     DLManagedTensorVersioned* as_dlpack(DLDevice device, const int64_t* stream, DLPackVersion max_version) override;
 
+    std::unique_ptr<DataArrayBase> from_dlpack(DLManagedTensorVersioned *dl_tensor) const override;
+
     const std::vector<uintptr_t>& shape() const & override;
 
     void reshape(const std::vector<uintptr_t>& shape) override;

--- a/metatensor-torch/include/metatensor/torch/array.hpp
+++ b/metatensor-torch/include/metatensor/torch/array.hpp
@@ -52,7 +52,7 @@ public:
 
     DLDataType dtype() const override;
 
-    std::unique_ptr<metatensor::DataArrayBase> copy() const override;
+    std::unique_ptr<metatensor::DataArrayBase> copy(DLDevice device) const override;
 
     std::unique_ptr<metatensor::DataArrayBase> create(
         std::vector<uintptr_t> shape,

--- a/metatensor-torch/src/array.cpp
+++ b/metatensor-torch/src/array.cpp
@@ -88,8 +88,10 @@ mts_data_origin_t TorchDataArray::origin() const {
     return TORCH_DATA_ORIGIN;
 }
 
-std::unique_ptr<metatensor::DataArrayBase> TorchDataArray::copy() const {
-    return std::unique_ptr<DataArrayBase>(new TorchDataArray(this->tensor().clone()));
+std::unique_ptr<metatensor::DataArrayBase> TorchDataArray::copy(DLDevice device) const {
+    auto torch_device = dlpack_device_to_torch(device);
+    auto tensor_copy = this->tensor().to(torch_device, /*non_blocking=*/true, /*copy=*/true);
+    return std::unique_ptr<DataArrayBase>(new TorchDataArray(std::move(tensor_copy)));
 }
 
 std::unique_ptr<metatensor::DataArrayBase> TorchDataArray::create(

--- a/metatensor-torch/src/array.cpp
+++ b/metatensor-torch/src/array.cpp
@@ -8,6 +8,8 @@
 #include "metatensor/torch/array.hpp"
 #include <ATen/DLConvertor.h>
 
+#include <torch/version.h>
+
 using namespace metatensor_torch;
 
 
@@ -60,6 +62,110 @@ torch::Device metatensor_torch::dlpack_device_to_torch(DLDevice device) {
 
     return torch::Device(type);
 }
+
+static DLDevice torch_device_to_dlpack(torch::Device device) {
+    DLDeviceType dl_type;
+    switch (device.type()) {
+    case torch::DeviceType::CPU:
+        dl_type = kDLCPU;
+        break;
+    case torch::DeviceType::CUDA:
+        dl_type = kDLCUDA;
+        break;
+    case torch::DeviceType::HIP:
+        dl_type = kDLROCM;
+        break;
+    case torch::DeviceType::MPS:
+        dl_type = kDLMetal;
+        break;
+    case torch::DeviceType::XPU:
+        dl_type = kDLOneAPI;
+        break;
+    case torch::DeviceType::XLA:
+        dl_type = kDLTrn;
+        break;
+    case torch::DeviceType::Vulkan:
+        dl_type = kDLVulkan;
+        break;
+    case torch::DeviceType::Meta:
+        dl_type = kDLExtDev;
+        break;
+    default:
+        throw metatensor::Error(
+            "unsupported torch device in torch_device_to_dlpack: " +
+            std::string(c10::DeviceTypeName(device.type())));
+    }
+
+    return DLDevice{dl_type, static_cast<int32_t>(device.index() < 0 ? 0 : device.index())};
+}
+
+static DLDataType torch_dtype_to_dlpack(torch::ScalarType dtype) {
+    DLDataType dt;
+    dt.lanes = 1;
+
+    switch (dtype) {
+    case torch::kFloat16:
+        dt.code = kDLFloat;
+        dt.bits = 16;
+        break;
+    case torch::kFloat32:
+        dt.code = kDLFloat;
+        dt.bits = 32;
+        break;
+    case torch::kFloat64:
+        dt.code = kDLFloat;
+        dt.bits = 64;
+        break;
+    case torch::kBFloat16:
+        dt.code = kDLBfloat;
+        dt.bits = 16;
+        break;
+    case torch::kInt8:
+        dt.code = kDLInt;
+        dt.bits = 8;
+        break;
+    case torch::kInt16:
+        dt.code = kDLInt;
+        dt.bits = 16;
+        break;
+    case torch::kInt32:
+        dt.code = kDLInt;
+        dt.bits = 32;
+        break;
+    case torch::kInt64:
+        dt.code = kDLInt;
+        dt.bits = 64;
+        break;
+    case torch::kUInt8:
+        dt.code = kDLUInt;
+        dt.bits = 8;
+        break;
+    case torch::kBool:
+        dt.code = kDLBool;
+        dt.bits = 8;
+        break;
+    case torch::kComplexHalf:
+        dt.code = kDLComplex;
+        dt.bits = 32;
+        break;
+    case torch::kComplexFloat:
+        dt.code = kDLComplex;
+        dt.bits = 64;
+        break;
+    case torch::kComplexDouble:
+        dt.code = kDLComplex;
+        dt.bits = 128;
+        break;
+    default:
+        throw metatensor::Error(
+            "unknown or unsupported torch dtype in torch_dtype_to_dlpack: " +
+            std::string(c10::toString(dtype))
+        );
+    }
+
+    return dt;
+}
+
 
 // We need to register a data origin with metatensor, that will be used for all
 // mts_array_t containing a C++ torch tensor. This is initialized to 0 (meaning
@@ -118,6 +224,7 @@ std::unique_ptr<metatensor::DataArrayBase> TorchDataArray::create(
     c10::Scalar scalar_val;
     auto code = fill_value_dlpack->dl_tensor.dtype.code;
     auto bits = fill_value_dlpack->dl_tensor.dtype.bits;
+    assert(fill_value_dlpack->dl_tensor.dtype.lanes == 1);
 
     auto expected_dtype = this->dtype();
     if (code != expected_dtype.code || bits != expected_dtype.bits) {
@@ -193,7 +300,6 @@ std::unique_ptr<metatensor::DataArrayBase> TorchDataArray::create(
 
 // Wraps legacy DLManagedTensor in DLManagedTensorVersioned. Required because
 // at::toDLPack() returns the legacy format.
-// TODO: Replace with at::toDLPackVersioned() when our MSTorchV is 2.9.
 static void dlpack_versioned_deleter(DLManagedTensorVersioned* self) {
     if (self != nullptr) {
         // Retrieve the legacy tensor stored in the context
@@ -208,120 +314,28 @@ static void dlpack_versioned_deleter(DLManagedTensorVersioned* self) {
 }
 
 DLDevice TorchDataArray::device() const {
-    auto torch_dev = tensor_.device();
-
-    DLDeviceType dl_type;
-    switch (torch_dev.type()) {
-    case torch::DeviceType::CPU:
-        dl_type = kDLCPU;
-        break;
-    case torch::DeviceType::CUDA:
-        dl_type = kDLCUDA;
-        break;
-    case torch::DeviceType::HIP:
-        dl_type = kDLROCM;
-        break;
-    case torch::DeviceType::MPS:
-        dl_type = kDLMetal;
-        break;
-    case torch::DeviceType::XPU:
-        dl_type = kDLOneAPI;
-        break;
-    case torch::DeviceType::XLA:
-        dl_type = kDLTrn;
-        break;
-    case torch::DeviceType::Vulkan:
-        dl_type = kDLVulkan;
-        break;
-    case torch::DeviceType::Meta:
-        dl_type = kDLExtDev;
-        break;
-    default:
-        throw metatensor::Error(
-            "TorchDataArray::device(): unsupported torch device type: "
-            + std::string(c10::DeviceTypeName(torch_dev.type())));
-    }
-
-    return DLDevice{dl_type, static_cast<int32_t>(torch_dev.index() < 0 ? 0 : torch_dev.index())};
+    return torch_device_to_dlpack(tensor_.device());
 }
 
 DLDataType TorchDataArray::dtype() const {
-    auto scalar_type = tensor_.scalar_type();
-
-    DLDataType dt;
-    dt.lanes = 1;
-
-    switch (scalar_type) {
-    case torch::kFloat16:
-        dt.code = kDLFloat; dt.bits = 16;
-        break;
-    case torch::kFloat32:
-        dt.code = kDLFloat; dt.bits = 32;
-        break;
-    case torch::kFloat64:
-        dt.code = kDLFloat; dt.bits = 64;
-        break;
-    case torch::kBFloat16:
-        dt.code = kDLBfloat; dt.bits = 16;
-        break;
-    case torch::kInt8:
-        dt.code = kDLInt; dt.bits = 8;
-        break;
-    case torch::kInt16:
-        dt.code = kDLInt; dt.bits = 16;
-        break;
-    case torch::kInt32:
-        dt.code = kDLInt; dt.bits = 32;
-        break;
-    case torch::kInt64:
-        dt.code = kDLInt; dt.bits = 64;
-        break;
-    case torch::kUInt8:
-        dt.code = kDLUInt; dt.bits = 8;
-        break;
-    case torch::kBool:
-        dt.code = kDLBool; dt.bits = 8;
-        break;
-    case torch::kComplexHalf:
-        dt.code = kDLComplex; dt.bits = 32;
-        break;
-    case torch::kComplexFloat:
-        dt.code = kDLComplex; dt.bits = 64;
-        break;
-    case torch::kComplexDouble:
-        dt.code = kDLComplex; dt.bits = 128;
-        break;
-    default:
-        throw metatensor::Error(
-            "TorchDataArray::dtype(): unsupported torch scalar type: "
-            + std::string(c10::toString(scalar_type)));
-    }
-
-    return dt;
+    return torch_dtype_to_dlpack(tensor_.scalar_type());
 }
 
-
 DLManagedTensorVersioned* TorchDataArray::as_dlpack(DLDevice device, const int64_t* stream, DLPackVersion max_version) {
-    // Uses the existing ATen API which returns legacy DLManagedTensor, then
-    // wraps it in DLManagedTensorVersioned. Replace the wrapping below with
-    // at::toDLPackVersioned() when PyTorch exposes it in stable releases.
     DLPackVersion mta_version = {DLPACK_MAJOR_VERSION, DLPACK_MINOR_VERSION};
     bool major_mismatch = max_version.major != mta_version.major;
     bool minor_too_high = max_version.minor < mta_version.minor;
     if (major_mismatch || minor_too_high) {
-        throw metatensor::Error("TorchDataArray supports DLPack version " +
-                                std::to_string(mta_version.major) + "." +
-                                std::to_string(mta_version.minor) +
-                                ". Caller requested incompatible version " +
-                                std::to_string(max_version.major) + "." +
-                                std::to_string(max_version.minor));
+        throw metatensor::Error(
+            "TorchDataArray supports DLPack version " + std::to_string(mta_version.major) + "." +
+            std::to_string(mta_version.minor) + ". Caller requested incompatible version " +
+            std::to_string(max_version.major) + "." + std::to_string(max_version.minor)
+        );
     }
     torch::Device target_device = dlpack_device_to_torch(device);
     torch::Tensor tensor_to_pack = this->tensor_;
 
     if (tensor_to_pack.device() != target_device) {
-        // consumers should handle synchronization via the stream, but this is
-        // the default argument.
         tensor_to_pack = tensor_to_pack.to(target_device, /*non_blocking=*/false);
     }
 
@@ -370,21 +384,14 @@ DLManagedTensorVersioned* TorchDataArray::as_dlpack(DLDevice device, const int64
         // ignore stream for all other devices for now
     }
 
-    // Legacy dlpack interface for maximal Torch compatibility
+#if TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 9
+    return at::toDLPackVersioned(tensor_to_pack);
+
+#elif TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR <= 8
+    // at::toDLPackVersioned() is available starting in 2.9, so we use the
+    // legacy at::toDLPack() and wrap it in a versioned struct below.
     DLManagedTensor* legacy_tensor = at::toDLPack(tensor_to_pack);
-    // Compare the device
-    if (legacy_tensor->dl_tensor.device.device_type != device.device_type ||
-        legacy_tensor->dl_tensor.device.device_id != device.device_id) {
 
-        // Cleanup the legacy tensor we just created before throwing
-        if (legacy_tensor->deleter != nullptr) {
-            legacy_tensor->deleter(legacy_tensor);
-        }
-
-        throw metatensor::Error(
-            "TorchDataArray: Requested device does not match tensor device");
-    }
-    // Wrap into a versioned struct
     auto* versioned_tensor = new DLManagedTensorVersioned();
     versioned_tensor->version = mta_version;
     // Setup context, keeping the legacy variant for the deleter
@@ -394,6 +401,49 @@ DLManagedTensorVersioned* TorchDataArray::as_dlpack(DLDevice device, const int64
     // Copy metadata
     versioned_tensor->dl_tensor = legacy_tensor->dl_tensor;
     return versioned_tensor;
+#else
+    throw metatensor::Error(
+        "unsupported PyTorch version for DLPack export: " +
+        std::to_string(TORCH_VERSION_MAJOR) + "." + std::to_string(TORCH_VERSION_MINOR)
+    );
+#endif
+}
+
+/// Use a full DLManagedTensorVersioned as the context for the legacy deleter
+/// This is used for PyTorch <=2.8, which does not have at::toDLPackVersioned()
+struct ManagedTensorCtx {
+    DLManagedTensorVersioned* versioned_tensor;
+};
+
+std::unique_ptr<metatensor::DataArrayBase> TorchDataArray::from_dlpack(DLManagedTensorVersioned *dl_tensor) const {
+#if TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 9
+    auto tensor = at::fromDLPackVersioned(dl_tensor);
+#elif TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR <= 8
+    // create a DLManagedTensor that wraps a DLManagedTensorVersioned, so we
+    // can use at::fromDLPack() for PyTorch <=2.8
+    auto* managed_tensor = new DLManagedTensor();
+    managed_tensor->dl_tensor = dl_tensor->dl_tensor;
+    managed_tensor->manager_ctx = new ManagedTensorCtx{dl_tensor};
+    managed_tensor->deleter = [](DLManagedTensor* self) {
+        if (self != nullptr) {
+            auto* ctx = static_cast<ManagedTensorCtx*>(self->manager_ctx);
+            if (ctx != nullptr && ctx->versioned_tensor != nullptr && ctx->versioned_tensor->deleter != nullptr) {
+                ctx->versioned_tensor->deleter(ctx->versioned_tensor);
+            }
+            delete ctx;
+            delete self;
+        }
+    };
+
+    auto tensor = at::fromDLPack(managed_tensor);
+#else
+    throw metatensor::Error(
+        "unsupported PyTorch version for DLPack import: " +
+        std::to_string(TORCH_VERSION_MAJOR) + "." + std::to_string(TORCH_VERSION_MINOR)
+    );
+#endif
+
+    return std::unique_ptr<metatensor::DataArrayBase>(new TorchDataArray(std::move(tensor)));
 }
 
 const std::vector<uintptr_t>& TorchDataArray::shape() const & {

--- a/metatensor-torch/tests/CMakeLists.txt
+++ b/metatensor-torch/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-padded")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-exit-time-destructors")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-global-constructors")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-poison-system-directories")
 endif()
 
 file(GLOB ALL_TESTS *.cpp)

--- a/metatensor-torch/tests/array.cpp
+++ b/metatensor-torch/tests/array.cpp
@@ -356,4 +356,63 @@ TEST_CASE("DLPack conversion") {
             dl_managed->deleter(dl_managed);
         }
     }
+
+    SECTION("create from dlpack") {
+        auto float_tensor = torch::rand({2, 3}, torch::TensorOptions().dtype(torch::kF32));
+        auto float_array = TorchDataArray(float_tensor);
+
+        auto int_tensor = torch::ones({4, 7, 8, 1}, torch::TensorOptions().dtype(torch::kI32));
+        auto int_array = TorchDataArray(int_tensor);
+
+        auto* float_dlpack = float_array.as_dlpack(
+            /*device=*/{kDLCPU, 0},
+            /*stream=*/nullptr,
+            /*max_version=*/version
+        );
+
+        auto* int_dlpack = int_array.as_dlpack(
+            /*device=*/{kDLCPU, 0},
+            /*stream=*/nullptr,
+            /*max_version=*/version
+        );
+
+        auto new_float_array = float_array.from_dlpack(float_dlpack);
+        // use a different source array dtype
+        auto new_int_array = float_array.from_dlpack(int_dlpack);
+
+        auto new_float_tensor = dynamic_cast<TorchDataArray*>(new_float_array.get())->tensor();
+        auto new_int_tensor = dynamic_cast<TorchDataArray*>(new_int_array.get())->tensor();
+
+        CHECK(torch::all(new_float_tensor == float_tensor).item<bool>());
+        CHECK(torch::all(new_int_tensor == int_tensor).item<bool>());
+
+        // test SimpleDataArray::from_dlpack with a non-contiguous tensor created by torch
+        auto base_tensor = torch::zeros({10, 10}, torch::TensorOptions().dtype(torch::kF64));
+        auto sliced_tensor = base_tensor.slice(0, 0, 10, 2).slice(1, 0, 10, 2).t();
+        CHECK(!sliced_tensor.is_contiguous());
+        CHECK(sliced_tensor.strides() == std::vector<int64_t>{2, 20});
+
+        auto sliced_array = TorchDataArray(sliced_tensor);
+        auto* sliced_dlpack = sliced_array.as_dlpack(
+            /*device=*/{kDLCPU, 0},
+            /*stream=*/nullptr,
+            /*max_version=*/version
+        );
+
+        auto cxx_array = metatensor::DataArrayBase::to_mts_array(
+            std::make_unique<metatensor::SimpleDataArray<int8_t>>(metatensor::SimpleDataArray<int8_t>({}))
+        );
+
+        auto new_cxx_array = cxx_array.from_dlpack(sliced_dlpack);
+
+        CHECK(new_cxx_array.origin() == cxx_array.origin());
+        CHECK(new_cxx_array.origin() != float_array.origin());
+
+        auto* cxx_dlpack = cxx_array.as_dlpack({kDLCPU, 0}, nullptr, version);
+
+        auto tensor_from_cxx = float_array.from_dlpack(cxx_dlpack);
+
+        auto recovered_tensor = dynamic_cast<TorchDataArray*>(tensor_from_cxx.get())->tensor();
+        CHECK(torch::all(recovered_tensor == sliced_tensor).item<bool>());
+    }
 }

--- a/metatensor-torch/tests/array.cpp
+++ b/metatensor-torch/tests/array.cpp
@@ -5,8 +5,24 @@ using namespace metatensor_torch;
 
 #include <catch.hpp>
 
+static std::vector<std::pair<torch::Device, DLDevice>> available_devices() {
+    auto devices = std::vector<std::pair<torch::Device, DLDevice>>();
+
+    devices.emplace_back(torch::kCPU, DLDevice{kDLCPU, 0});
+
+    if (torch::cuda::is_available()) {
+        devices.emplace_back(torch::Device(torch::kCUDA, 0), DLDevice{kDLCUDA, 0});
+    }
+
+    if (torch::mps::is_available()) {
+        devices.emplace_back(torch::Device(torch::kMPS, 0), DLDevice{kDLMetal, 0});
+    }
+
+    return devices;
+}
+
 TEST_CASE("Arrays") {
-    auto tensor = torch::zeros({2, 3, 4}, torch::TensorOptions().dtype(torch::kF64));
+    auto tensor = torch::zeros({2, 3, 4}, torch::TensorOptions().dtype(torch::kF32));
     auto array = TorchDataArray(tensor);
 
     SECTION("origin") {
@@ -49,21 +65,32 @@ TEST_CASE("Arrays") {
     }
 
     SECTION("new arrays") {
-        auto copy = array.copy();
+        auto copy = array.copy({kDLCPU, 0});
         auto* copy_ptr = dynamic_cast<TorchDataArray*>(copy.get());
 
         CHECK(copy_ptr->tensor().data_ptr() != array.tensor().data_ptr());
-        CHECK((copy_ptr->tensor().sizes() == std::vector<int64_t>{2, 3, 4}));
-        CHECK(copy_ptr->tensor().dtype() == torch::kF64);
+        CHECK(copy_ptr->tensor().sizes() == std::vector<int64_t>{2, 3, 4});
+        CHECK(copy_ptr->tensor().dtype() == torch::kF32);
+
+
+        // make a copy on device
+        for (auto [device, dl_device]: available_devices()) {
+            auto device_copy = array.copy(dl_device);
+            auto* device_copy_ptr = dynamic_cast<TorchDataArray*>(device_copy.get());
+
+            CHECK(device_copy_ptr->tensor().sizes() == std::vector<int64_t>{2, 3, 4});
+            CHECK(device_copy_ptr->tensor().dtype() == torch::kF32);
+            CHECK(device_copy_ptr->tensor().device() == device);
+        }
 
         auto fill_value = metatensor::DataArrayBase::to_mts_array(
-            std::make_unique<TorchDataArray>(torch::zeros({}, torch::kF64))
+            std::make_unique<TorchDataArray>(torch::zeros({}, torch::kF32))
         );
         auto created = array.create({5, 6}, std::move(fill_value));
         auto* created_ptr = dynamic_cast<TorchDataArray*>(created.get());
 
         CHECK((created_ptr->tensor().sizes() == std::vector<int64_t>{5, 6}));
-        CHECK(created_ptr->tensor().dtype() == torch::kF64);
+        CHECK(created_ptr->tensor().dtype() == torch::kF32);
     }
 
     SECTION("create with any dtype") {
@@ -289,38 +316,43 @@ TEST_CASE("DLPack conversion") {
     }
 
     SECTION("device transfer") {
-        if (torch::cuda::is_available()) {
-            auto opts = torch::TensorOptions().dtype(torch::kF64);
-            auto cuda_tensor = torch::rand({10}, opts.device(torch::kCUDA));
+        for (auto [device, dl_device]: available_devices()) {
+            if (device.is_mps() && TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR < 8) {
+                // MPS DLPack support was added in PyTorch 2.8
+                continue;
+            }
+
+            auto opts = torch::TensorOptions().dtype(torch::kF32);
+            auto cuda_tensor = torch::rand({10}, opts.device(device));
             auto cuda_array = TorchDataArray(cuda_tensor);
 
-            // CUDA -> CUDA (Same device)
-            auto* dl_managed = cuda_array.as_dlpack(/*device=*/{kDLCUDA, 0}, /*stream=*/nullptr, /*max_version=*/version);
-            CHECK(dl_managed->dl_tensor.device.device_type == kDLCUDA);
+            // transfer to the same device
+            auto* dl_managed = cuda_array.as_dlpack(/*device=*/dl_device, /*stream=*/nullptr, /*max_version=*/version);
+            CHECK(dl_managed->dl_tensor.device.device_type == dl_device.device_type);
             dl_managed->deleter(dl_managed);
 
-            // CUDA -> CPU (Explicit Transfer)
+            // transfer to CPU
             dl_managed = cuda_array.as_dlpack(/*device=*/{kDLCPU, 0}, /*stream=*/nullptr, /*max_version=*/version);
 
             CHECK(dl_managed->dl_tensor.device.device_type == kDLCPU);
 
             // Verify data is readable on CPU
-            auto* data = static_cast<double*>(dl_managed->dl_tensor.data);
+            auto* data = static_cast<float*>(dl_managed->dl_tensor.data);
             REQUIRE(data != nullptr);
 
             auto cpu_reference = cuda_tensor.to(torch::kCPU);
             for (int64_t i = 0; i < cpu_reference.numel(); ++i) {
-                CHECK(data[i] == cpu_reference[i].item<double>());
+                CHECK(data[i] == cpu_reference[i].item<float>());
             }
 
             dl_managed->deleter(dl_managed);
 
-            // CPU -> CUDA (Explicit Transfer)
+            // cpu to device
             auto cpu_tensor = torch::rand({10, 10}, opts.device(torch::kCPU));
             auto cpu_array = TorchDataArray(cpu_tensor);
 
-            dl_managed = cpu_array.as_dlpack(/*device=*/{kDLCUDA, 0}, /*stream=*/nullptr, /*max_version=*/version);
-            CHECK(dl_managed->dl_tensor.device.device_type == kDLCUDA);
+            dl_managed = cpu_array.as_dlpack(/*device=*/dl_device, /*stream=*/nullptr, /*max_version=*/version);
+            CHECK(dl_managed->dl_tensor.device.device_type == dl_device.device_type);
             dl_managed->deleter(dl_managed);
         }
     }

--- a/python/metatensor_core/metatensor/_c_api.py
+++ b/python/metatensor_core/metatensor/_c_api.py
@@ -220,7 +220,7 @@ mts_array_t._fields_ = [
     ("reshape", CFUNCTYPE(mts_status_t, ctypes.c_void_p, POINTER(c_uintptr_t), c_uintptr_t)),
     ("swap_axes", CFUNCTYPE(mts_status_t, ctypes.c_void_p, c_uintptr_t, c_uintptr_t)),
     ("create", CFUNCTYPE(mts_status_t, ctypes.c_void_p, POINTER(c_uintptr_t), c_uintptr_t, mts_array_t, POINTER(mts_array_t))),
-    ("copy", CFUNCTYPE(mts_status_t, ctypes.c_void_p, POINTER(mts_array_t))),
+    ("copy", CFUNCTYPE(mts_status_t, ctypes.c_void_p, DLDevice, POINTER(mts_array_t))),
     ("move_data", CFUNCTYPE(mts_status_t, ctypes.c_void_p, ctypes.c_void_p, POINTER(mts_data_movement_t), c_uintptr_t)),
 ]
 

--- a/python/metatensor_core/metatensor/_c_api.py
+++ b/python/metatensor_core/metatensor/_c_api.py
@@ -216,6 +216,7 @@ mts_array_t._fields_ = [
     ("device", CFUNCTYPE(mts_status_t, ctypes.c_void_p, POINTER(DLDevice))),
     ("dtype", CFUNCTYPE(mts_status_t, ctypes.c_void_p, POINTER(DLDataType))),
     ("as_dlpack", CFUNCTYPE(mts_status_t, ctypes.c_void_p, POINTER(POINTER(DLManagedTensorVersioned)), DLDevice, POINTER(ctypes.c_int64), DLPackVersion)),
+    ("from_dlpack", CFUNCTYPE(mts_status_t, ctypes.c_void_p, POINTER(DLManagedTensorVersioned), POINTER(mts_array_t))),
     ("shape", CFUNCTYPE(mts_status_t, ctypes.c_void_p, POINTER(POINTER(c_uintptr_t)), POINTER(c_uintptr_t))),
     ("reshape", CFUNCTYPE(mts_status_t, ctypes.c_void_p, POINTER(c_uintptr_t), c_uintptr_t)),
     ("swap_axes", CFUNCTYPE(mts_status_t, ctypes.c_void_p, c_uintptr_t, c_uintptr_t)),

--- a/python/metatensor_core/metatensor/_data/_array.py
+++ b/python/metatensor_core/metatensor/_data/_array.py
@@ -573,19 +573,23 @@ def _mts_array_device_pytorch(this, device_ptr):
     try:
         device_type, device_id = tensor.__dlpack_device__()
         device_ptr[0] = DLDevice(device_type=device_type, device_id=device_id)
-    except Exception:
-        # Fallback for older torch version that don't have __dlpack_device__
+    except Exception as e:
+        # Fallback for older torch version that don't support all devices in
+        # `__dlpack_device__``
         torch_dev = tensor.device
-        if torch_dev.type == "cpu":
-            device_ptr[0] = DLDevice(device_type=DLDeviceType.kDLCPU, device_id=0)
-        elif torch_dev.type == "cuda":
+        device_id = torch_dev.index if torch_dev.index is not None else 0
+        if torch_dev.type == "meta":
             device_ptr[0] = DLDevice(
-                device_type=DLDeviceType.kDLCUDA, device_id=torch_dev.index or 0
+                device_type=DLDeviceType.kDLExtDev, device_id=device_id
             )
-        elif torch_dev.type == "meta":
-            device_ptr[0] = DLDevice(device_type=DLDeviceType.kDLExtDev, device_id=0)
+        elif torch_dev.type == "mps":
+            device_ptr[0] = DLDevice(
+                device_type=DLDeviceType.kDLMetal, device_id=device_id
+            )
         else:
-            raise ValueError(f"unsupported torch device type: {torch_dev.type}")
+            raise ValueError(
+                f"__dlpack_device__ failed for tensor with device={torch_dev}"
+            ) from e
 
 
 _MTS_ARRAY_DEVICE_NUMPY = _cast_to_ctype_functype(_mts_array_device_numpy, "device")

--- a/python/metatensor_core/metatensor/_data/_array.py
+++ b/python/metatensor_core/metatensor/_data/_array.py
@@ -537,6 +537,27 @@ def _mts_array_as_dlpack(this, dl_managed_tensor_ptr_ptr, device, stream, max_ve
     )
 
 
+@catch_exceptions
+def _mts_array_from_dlpack(this, dl_tensor, new_array):
+    """
+    Implementation of `mts_array_t.from_dlpack`.
+
+    This function takes ownership of the given `DLManagedTensorVersioned` pointer
+    and creates a new array from it.
+    """
+
+    wrapper = _KNOWN_ARRAY_WRAPPERS[this]
+
+    if _is_numpy_array(wrapper.array):
+        array = np.from_dlpack(DLPackArray(dl_tensor))
+    elif _is_torch_array(wrapper.array):
+        array = torch.from_dlpack(DLPackArray(dl_tensor))
+    else:
+        raise ValueError(f"unknown array type: {type(wrapper.array)}")
+
+    new_array[0] = create_mts_array(array)
+
+
 # ============================================================================ #
 # Setup mts_array_t function pointers
 # ============================================================================ #
@@ -550,7 +571,6 @@ def _cast_to_ctype_functype(function, field_name):
     raise ValueError(f"no field named {field_name} in mts_array_t")
 
 
-_MTS_ARRAY_AS_DLPACK = _cast_to_ctype_functype(_mts_array_as_dlpack, "as_dlpack")
 _MTS_ARRAY_SHAPE = _cast_to_ctype_functype(_mts_array_shape, "shape")
 _MTS_ARRAY_RESHAPE = _cast_to_ctype_functype(_mts_array_reshape, "reshape")
 _MTS_ARRAY_SWAP_AXES = _cast_to_ctype_functype(_mts_array_swap_axes, "swap_axes")
@@ -558,6 +578,8 @@ _MTS_ARRAY_CREATE = _cast_to_ctype_functype(_mts_array_create, "create")
 _MTS_ARRAY_COPY = _cast_to_ctype_functype(_mts_array_copy, "copy")
 _MTS_ARRAY_DESTROY = _cast_to_ctype_functype(_mts_array_destroy, "destroy")
 _MTS_ARRAY_MOVE_DATA = _cast_to_ctype_functype(_mts_array_move_data, "move_data")
+_MTS_ARRAY_AS_DLPACK = _cast_to_ctype_functype(_mts_array_as_dlpack, "as_dlpack")
+_MTS_ARRAY_FROM_DLPACK = _cast_to_ctype_functype(_mts_array_from_dlpack, "from_dlpack")
 
 
 @catch_exceptions
@@ -706,6 +728,7 @@ _DEFAULT_MTS_ARRAY = mts_array_t(
     device=_MTS_ARRAY_DUMMY_DEVICE,
     dtype=_MTS_ARRAY_DUMMY_DTYPE,
     as_dlpack=_MTS_ARRAY_AS_DLPACK,
+    from_dlpack=_MTS_ARRAY_FROM_DLPACK,
     shape=_MTS_ARRAY_SHAPE,
     reshape=_MTS_ARRAY_RESHAPE,
     swap_axes=_MTS_ARRAY_SWAP_AXES,

--- a/python/metatensor_core/metatensor/_data/_array.py
+++ b/python/metatensor_core/metatensor/_data/_array.py
@@ -323,13 +323,33 @@ def _mts_array_create(this, shape_ptr, shape_count, fill_value, new_array):
 
 
 @catch_exceptions
-def _mts_array_copy(this, new_array):
+def _mts_array_copy(this, device, new_array):
     wrapper = _KNOWN_ARRAY_WRAPPERS[this]
 
     if _is_numpy_array(wrapper.array):
+        if device.device_type != DLDeviceType.kDLCPU:
+            raise ValueError(
+                f"can not copy numpy array to non-cpu device: {device.device_type}"
+            )
         array = wrapper.array.copy()
     elif _is_torch_array(wrapper.array):
-        array = wrapper.array.clone()
+        array = wrapper.array
+
+        if array.device.type == "meta":
+            # for some reason, meta device is not supported by __dlpack_device__
+            current_device = DLDeviceType.kDLExtDev
+            current_id = 0
+        else:
+            (current_device, current_id) = wrapper.array.__dlpack_device__()
+
+        if current_device != device.device_type or current_id != device.device_id:
+            dlpack = wrapper.array.__dlpack__(
+                dl_device=(device.device_type.value, int(device.device_id)),
+                max_version=(1, 0),
+            )
+            array = torch.from_dlpack(dlpack)
+        else:
+            array = wrapper.array.clone()
 
     new_array[0] = create_mts_array(array)
 

--- a/python/metatensor_core/metatensor/_status.py
+++ b/python/metatensor_core/metatensor/_status.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import atexit
 import ctypes
 import functools
 import sys
@@ -117,23 +116,3 @@ def _get_exception(status=None):
         return ctypes.cast(user_data, ctypes.py_object).value
 
     return MetatensorError(message.value.decode("utf8"), status=status)
-
-
-def _clear_last_error():
-    """
-    Clear the last error that happened if it was caused by a Python exception, to
-    avoid trying to free the exception object after Python itself is unloaded.
-    """
-    from ._c_lib import _get_library
-
-    try:
-        lib = _get_library()
-        origin = ctypes.c_char_p()
-        status = lib.mts_last_error(None, ctypes.byref(origin), None)
-        if status == mts_status_t.MTS_SUCCESS and origin.value == b"Python exception":
-            lib.mts_set_last_error(None, None, None, None)
-    except Exception:
-        pass
-
-
-atexit.register(_clear_last_error)

--- a/python/metatensor_core/tests/data.py
+++ b/python/metatensor_core/tests/data.py
@@ -44,6 +44,20 @@ def free_mts_array(array):
     array.destroy(array.ptr)
 
 
+def call_as_dlpack(mts_array, dl_device):
+    dl_tensor = ctypes.POINTER(DLManagedTensorVersioned)()
+    check_status(
+        mts_array.as_dlpack(
+            mts_array.ptr,
+            ctypes.byref(dl_tensor),
+            dl_device,
+            None,  # stream
+            DLPackVersion(1, 0),
+        )
+    )
+    return dl_tensor
+
+
 class MtsArrayMixin:
     def test_origin(self):
         array = self.create_array((2, 3, 4))
@@ -200,7 +214,7 @@ class MtsArrayMixin:
         free_mts_array(mts_array)
         free_mts_array(mts_array_other)
 
-    def test_dlpack(self):
+    def test_as_dlpack(self):
         for device, dl_device in self.available_devices():
             if device == "mps" and torch.__version__ < "2.8.0":
                 pytest.skip("DLPack support for MPS requires PyTorch 2.8+")
@@ -209,25 +223,13 @@ class MtsArrayMixin:
             array = self.create_array((2, 3), device=device)
             mts_array = metatensor._data.create_mts_array(array)
 
-            # Prepare a pointer to receive the DLManagedTensorVersioned
-            dl_managed_ptr = ctypes.POINTER(DLManagedTensorVersioned)()
-            version = DLPackVersion(1, 0)
-
-            check_status(
-                mts_array.as_dlpack(
-                    mts_array.ptr,
-                    ctypes.byref(dl_managed_ptr),
-                    dl_device,
-                    None,  # stream
-                    version,
-                )
-            )
+            dl_managed_tensor = call_as_dlpack(mts_array, dl_device)
 
             # Check we got a valid pointer back
-            assert bool(dl_managed_ptr)
+            assert bool(dl_managed_tensor)
 
             # Dereference to check contents
-            managed = dl_managed_ptr.contents
+            managed = dl_managed_tensor.contents
             dl_tensor = managed.dl_tensor
 
             # Verify Metadata
@@ -245,24 +247,18 @@ class MtsArrayMixin:
 
             # IMPORTANT: Call the deleter to cleanup the C-side resources (and
             # refcounts) This emulates what a consumer (like another library) would do.
-            managed.deleter(dl_managed_ptr)
+            managed.deleter(dl_managed_tensor)
 
             # also check getting the data back to CPU
-            check_status(
-                mts_array.as_dlpack(
-                    mts_array.ptr,
-                    ctypes.byref(dl_managed_ptr),
-                    DLDevice(DLDeviceType.kDLCPU, 0),
-                    None,  # stream
-                    version,
-                )
+            dl_managed_tensor = call_as_dlpack(
+                mts_array, DLDevice(DLDeviceType.kDLCPU, 0)
             )
 
             # Check we got a valid pointer back
-            assert bool(dl_managed_ptr)
+            assert bool(dl_managed_tensor)
 
             # Dereference to check contents
-            managed = dl_managed_ptr.contents
+            managed = dl_managed_tensor.contents
             dl_tensor = managed.dl_tensor
 
             # Verify Metadata
@@ -272,9 +268,61 @@ class MtsArrayMixin:
             assert dl_tensor.shape[0] == 2
             assert dl_tensor.shape[1] == 3
 
-            managed.deleter(dl_managed_ptr)
+            managed.deleter(dl_managed_tensor)
 
             free_mts_array(mts_array)
+
+    def test_from_dlpack(self):
+        for device, dl_device in self.available_devices():
+            if device == "mps" and torch.__version__ < "2.8.0":
+                pytest.skip("DLPack support for MPS requires PyTorch 2.8+")
+
+                f32_array = self.create_array(
+                    (2, 3), device=device, dtype=self.dtype_from_numpy(np.float32)
+                )
+                mts_f32_array = metatensor._data.create_mts_array(f32_array)
+
+                i8_array = self.create_array(
+                    (20, 2, 7), device=device, dtype=self.dtype_from_numpy(np.int8)
+                )
+                mts_i8_array = metatensor._data.create_mts_array(i8_array)
+
+                f32_dl_tensor = call_as_dlpack(mts_f32_array, dl_device)
+                i8_dl_tensor = call_as_dlpack(mts_i8_array, dl_device)
+
+                new_f32_array = mts_array_t()
+                check_status(
+                    mts_f32_array.from_dlpack(
+                        mts_f32_array.ptr, f32_dl_tensor, new_f32_array
+                    )
+                )
+
+                new_i8_array = mts_array_t()
+                check_status(
+                    mts_f32_array.from_dlpack(
+                        mts_f32_array.ptr, i8_dl_tensor, new_i8_array
+                    )
+                )
+
+                assert_equal(
+                    self.to_numpy(f32_array),
+                    self.to_numpy(
+                        metatensor._data.mts_array_to_python_array(new_f32_array)
+                    ),
+                )
+
+                assert_equal(
+                    self.to_numpy(i8_array),
+                    self.to_numpy(
+                        metatensor._data.mts_array_to_python_array(new_i8_array)
+                    ),
+                )
+
+                free_mts_array(mts_f32_array)
+                free_mts_array(mts_i8_array)
+
+                free_mts_array(new_f32_array)
+                free_mts_array(new_i8_array)
 
 
 class TestNumpyData(MtsArrayMixin):
@@ -318,6 +366,9 @@ class TestNumpyData(MtsArrayMixin):
 
     def to_numpy(self, array):
         return np.array(array)
+
+    def dtype_from_numpy(self, dtype):
+        return dtype
 
     def available_devices(self):
         return [("cpu", DLDevice(DLDeviceType.kDLCPU, 0))]
@@ -372,6 +423,9 @@ if HAS_TORCH:
 
         def to_numpy(self, array):
             return array.cpu().numpy()
+
+        def dtype_from_numpy(self, dtype):
+            return torch.tensor(np.array([], dtype=dtype)).dtype
 
         def available_devices(self):
             devices = [("cpu", DLDevice(DLDeviceType.kDLCPU, 0))]

--- a/python/metatensor_core/tests/data.py
+++ b/python/metatensor_core/tests/data.py
@@ -136,20 +136,24 @@ class MtsArrayMixin:
 
     def test_copy(self):
         array = self.create_array((2, 3, 4))
-        array[1, :, :] = 3
-        array[1, 2, :] = 5
         mts_array = metatensor._data.create_mts_array(array)
 
-        copy = mts_array_t()
-        check_status(mts_array.copy(mts_array.ptr, copy))
+        for device, dl_device in self.available_devices():
+            if device == "mps" and torch.__version__ < "2.8.0":
+                pytest.skip("DLPack support for MPS requires PyTorch 2.8+")
 
-        array_copy = metatensor._data.mts_array_to_python_array(copy)
-        assert id(array_copy) != id(array)
+            copy = mts_array_t()
+            # copy from CPU to the given device
+            check_status(mts_array.copy(mts_array.ptr, dl_device, copy))
 
-        assert_equal(self.to_numpy(array_copy), self.to_numpy(array))
+            array_copy = metatensor._data.mts_array_to_python_array(copy)
+            assert id(array_copy) != id(array)
+
+            assert_equal(self.to_numpy(array_copy), self.to_numpy(array))
+
+            free_mts_array(copy)
 
         free_mts_array(mts_array)
-        free_mts_array(copy)
 
     def test_move_data(self):
         array = self.create_array((2, 3, 8))
@@ -196,68 +200,81 @@ class MtsArrayMixin:
         free_mts_array(mts_array)
         free_mts_array(mts_array_other)
 
-    def get_available_devices():
-        devices = [("cpu", DLDevice(1, 0))]
-        if HAS_TORCH and torch.cuda.is_available():
-            devices.append(("cuda", DLDevice(2, 0)))
-        if can_use_mps_backend():
-            devices.append(("mps", DLDevice(8, 0)))
-        return devices
+    def test_dlpack(self):
+        for device, dl_device in self.available_devices():
+            if device == "mps" and torch.__version__ < "2.8.0":
+                pytest.skip("DLPack support for MPS requires PyTorch 2.8+")
 
-    @pytest.mark.parametrize("device, dldevice", get_available_devices())
-    def test_dlpack(self, device, dldevice):
-        if device == "mps" and torch.__version__ < "2.8.0":
-            pytest.skip("DLPack support for MPS requires PyTorch 2.8+")
+            # Create a sample array
+            array = self.create_array((2, 3), device=device)
+            mts_array = metatensor._data.create_mts_array(array)
 
-        # Create a sample array
-        array = self.create_array((2, 3))
-        if self.expected_origin() == "python.numpy" and device != "cpu":
-            pytest.skip("NumPy only supports CPU")
-        if not device:
-            pytest.skip()
-        if isinstance(array, torch.Tensor):
-            array = torch.asarray(array, device=device)
-        mts_array = metatensor._data.create_mts_array(array)
+            # Prepare a pointer to receive the DLManagedTensorVersioned
+            dl_managed_ptr = ctypes.POINTER(DLManagedTensorVersioned)()
+            version = DLPackVersion(1, 0)
 
-        # Prepare a pointer to receive the DLManagedTensorVersioned
-        dl_managed_ptr = ctypes.POINTER(DLManagedTensorVersioned)()
-        version = DLPackVersion(1, 0)
-
-        check_status(
-            mts_array.as_dlpack(
-                mts_array.ptr,
-                ctypes.byref(dl_managed_ptr),
-                dldevice,
-                None,  # stream
-                version,
+            check_status(
+                mts_array.as_dlpack(
+                    mts_array.ptr,
+                    ctypes.byref(dl_managed_ptr),
+                    dl_device,
+                    None,  # stream
+                    version,
+                )
             )
-        )
 
-        # Check we got a valid pointer back
-        assert bool(dl_managed_ptr)
+            # Check we got a valid pointer back
+            assert bool(dl_managed_ptr)
 
-        # Dereference to check contents
-        managed = dl_managed_ptr.contents
-        dl_tensor = managed.dl_tensor
+            # Dereference to check contents
+            managed = dl_managed_ptr.contents
+            dl_tensor = managed.dl_tensor
 
-        # Verify Metadata
-        assert managed.version.major == 1
-        assert managed.version.minor <= 3
-        assert dl_tensor.ndim == 2
-        assert dl_tensor.shape[0] == 2
-        assert dl_tensor.shape[1] == 3
+            # Verify Metadata
+            assert managed.version.major == 1
+            assert managed.version.minor <= 3
+            assert dl_tensor.ndim == 2
+            assert dl_tensor.shape[0] == 2
+            assert dl_tensor.shape[1] == 3
 
-        # Verify Data Pointer matches the source array
-        if self.expected_origin() == "python.numpy":
-            assert dl_tensor.data == array.ctypes.data
-        elif self.expected_origin() == "python.torch":
-            assert dl_tensor.data == array.data_ptr()
+            # Verify Data Pointer matches the source array
+            if self.expected_origin() == "python.numpy":
+                assert dl_tensor.data == array.ctypes.data
+            elif self.expected_origin() == "python.torch":
+                assert dl_tensor.data == array.data_ptr()
 
-        # IMPORTANT: Call the deleter to cleanup the C-side resources (and refcounts)
-        # This emulates what a consumer (like another library) would do.
-        managed.deleter(dl_managed_ptr)
+            # IMPORTANT: Call the deleter to cleanup the C-side resources (and
+            # refcounts) This emulates what a consumer (like another library) would do.
+            managed.deleter(dl_managed_ptr)
 
-        free_mts_array(mts_array)
+            # also check getting the data back to CPU
+            check_status(
+                mts_array.as_dlpack(
+                    mts_array.ptr,
+                    ctypes.byref(dl_managed_ptr),
+                    DLDevice(DLDeviceType.kDLCPU, 0),
+                    None,  # stream
+                    version,
+                )
+            )
+
+            # Check we got a valid pointer back
+            assert bool(dl_managed_ptr)
+
+            # Dereference to check contents
+            managed = dl_managed_ptr.contents
+            dl_tensor = managed.dl_tensor
+
+            # Verify Metadata
+            assert managed.version.major == 1
+            assert managed.version.minor <= 3
+            assert dl_tensor.ndim == 2
+            assert dl_tensor.shape[0] == 2
+            assert dl_tensor.shape[1] == 3
+
+            managed.deleter(dl_managed_ptr)
+
+            free_mts_array(mts_array)
 
 
 class TestNumpyData(MtsArrayMixin):
@@ -280,7 +297,9 @@ class TestNumpyData(MtsArrayMixin):
     def expected_origin(self):
         return "python.numpy"
 
-    def create_array(self, shape, dtype=np.float64):
+    def create_array(self, shape, dtype=np.float64, device="cpu"):
+        assert device == "cpu"
+
         if dtype == np.bool_:
             return np.ones(shape, dtype=dtype)
         elif dtype in [
@@ -299,6 +318,9 @@ class TestNumpyData(MtsArrayMixin):
 
     def to_numpy(self, array):
         return np.array(array)
+
+    def available_devices(self):
+        return [("cpu", DLDevice(DLDeviceType.kDLCPU, 0))]
 
 
 if HAS_TORCH:
@@ -331,9 +353,9 @@ if HAS_TORCH:
         def expected_origin(self):
             return "python.torch"
 
-        def create_array(self, shape, dtype=torch.float32):
+        def create_array(self, shape, dtype=torch.float32, device="cpu"):
             if dtype == torch.bool:
-                return torch.ones(shape, dtype=dtype)
+                return torch.ones(shape, dtype=dtype, device=device)
             elif dtype in [
                 torch.int64,
                 torch.int32,
@@ -344,12 +366,20 @@ if HAS_TORCH:
                 torch.uint16,
                 torch.uint8,
             ]:
-                return torch.randint(0, 42, shape, dtype=dtype)
+                return torch.randint(0, 42, shape, dtype=dtype, device=device)
             else:
-                return torch.rand(shape, dtype=dtype)
+                return torch.rand(shape, dtype=dtype, device=device)
 
         def to_numpy(self, array):
-            return array.numpy()
+            return array.cpu().numpy()
+
+        def available_devices(self):
+            devices = [("cpu", DLDevice(DLDeviceType.kDLCPU, 0))]
+            if HAS_TORCH and torch.cuda.is_available():
+                devices.append(("cuda", DLDevice(DLDeviceType.kDLCUDA, 0)))
+            if can_use_mps_backend():
+                devices.append(("mps", DLDevice(DLDeviceType.kDLMetal, 0)))
+            return devices
 
 
 def _get_shape(mts_array, test):

--- a/rust/metatensor-sys/Cargo.toml
+++ b/rust/metatensor-sys/Cargo.toml
@@ -26,7 +26,7 @@ default = []
 static = []
 
 [dependencies]
-dlpk = "0.1.5"
+dlpk = "0.2.0"
 
 [build-dependencies]
 cmake = "0.1"

--- a/rust/metatensor-sys/src/c_api.rs
+++ b/rust/metatensor-sys/src/c_api.rs
@@ -158,6 +158,7 @@ pub struct mts_array_t {
     pub copy: ::std::option::Option<
         unsafe extern "C" fn(
             array: *const ::std::os::raw::c_void,
+            device: DLDevice,
             new_array: *mut mts_array_t,
         ) -> mts_status_t,
     >,

--- a/rust/metatensor-sys/src/c_api.rs
+++ b/rust/metatensor-sys/src/c_api.rs
@@ -125,6 +125,13 @@ pub struct mts_array_t {
             max_version: DLPackVersion,
         ) -> mts_status_t,
     >,
+    pub from_dlpack: ::std::option::Option<
+        unsafe extern "C" fn(
+            array: *const ::std::os::raw::c_void,
+            dl_managed_tensor: *mut DLManagedTensorVersioned,
+            new_array: *mut mts_array_t,
+        ) -> mts_status_t,
+    >,
     pub shape: ::std::option::Option<
         unsafe extern "C" fn(
             array: *const ::std::os::raw::c_void,
@@ -177,7 +184,7 @@ fn bindgen_test_layout_mts_array_t() {
     let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<mts_array_t>(),
-        96usize,
+        104usize,
         "Size of mts_array_t"
     );
     assert_eq!(
@@ -216,33 +223,38 @@ fn bindgen_test_layout_mts_array_t() {
         "Offset of field: mts_array_t::as_dlpack"
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).shape) as usize - ptr as usize },
+        unsafe { ::std::ptr::addr_of!((*ptr).from_dlpack) as usize - ptr as usize },
         48usize,
+        "Offset of field: mts_array_t::from_dlpack"
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).shape) as usize - ptr as usize },
+        56usize,
         "Offset of field: mts_array_t::shape"
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).reshape) as usize - ptr as usize },
-        56usize,
+        64usize,
         "Offset of field: mts_array_t::reshape"
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).swap_axes) as usize - ptr as usize },
-        64usize,
+        72usize,
         "Offset of field: mts_array_t::swap_axes"
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).create) as usize - ptr as usize },
-        72usize,
+        80usize,
         "Offset of field: mts_array_t::create"
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).copy) as usize - ptr as usize },
-        80usize,
+        88usize,
         "Offset of field: mts_array_t::copy"
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).move_data) as usize - ptr as usize },
-        88usize,
+        96usize,
         "Offset of field: mts_array_t::move_data"
     );
 }

--- a/rust/metatensor-sys/src/lib.rs
+++ b/rust/metatensor-sys/src/lib.rs
@@ -51,6 +51,7 @@ impl mts_array_t {
             device: None,
             dtype: None,
             as_dlpack: None,
+            from_dlpack: None,
             shape: None,
             reshape: None,
             swap_axes: None,

--- a/rust/metatensor/Cargo.toml
+++ b/rust/metatensor/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 
 [dependencies]
 metatensor-sys = {version = "0.2.0-rc2", path="../metatensor-sys"}
-dlpk = { version = "0.1.5", features = ["ndarray", "half", "sync"]}
+dlpk = { version = "0.2.0", features = ["ndarray", "half", "sync"]}
 half = "<2.5"
 
 once_cell = "1"
@@ -38,7 +38,7 @@ bench = ["dep:criterion"]
 # pin for compatibility with rustc 1.74
 tempfile = "=3.24.0"
 half = "<2.5"
-dlpk = { version = "0.1.5", features = ["ndarray", "half", "sync"]}
+dlpk = { version = "0.2.0", features = ["ndarray", "half", "sync"]}
 
 
 [[bench]]

--- a/rust/metatensor/src/data/array.rs
+++ b/rust/metatensor/src/data/array.rs
@@ -22,19 +22,19 @@ pub trait Array: std::any::Any + Send + Sync {
     /// Get the array as a mutable `Any` reference
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
 
-    /// Create a new array with the same options as the current one (data type,
-    /// data location, etc.) and the requested `shape`.
+    /// Create a new array with the same array origin, data type, and device as
+    /// the current one, but with the requested `shape`.
     ///
     /// The new array should be filled with the scalar value from `fill_value`,
-    /// which must be an `MtsArray` with shape `(1,)` and the same dtype as
-    /// this array.
+    /// which must be an `MtsArray` with shape `(1,)` and the same dtype as this
+    /// array.
     fn create(&self, shape: &[usize], fill_value: MtsArray) -> Box<dyn Array>;
 
     /// Make a copy of this `array`
     ///
-    /// The new array is expected to have the same data origin and parameters
-    /// (data type, data location, etc.)
-    fn copy(&self) -> Box<dyn Array>;
+    /// The new array is expected to have the same array origin and data type,
+    /// but live on the given device.
+    fn copy(&self, device: DLDevice) -> Box<dyn Array>;
 
     /// Get the shape of the array. This can be empty if the array has no shape
     /// (e.g. a scalar).
@@ -293,15 +293,16 @@ unsafe extern "C" fn rust_array_create(
 /// Implementation of `mts_array_t.copy` using `RustArray`
 unsafe extern "C" fn rust_array_copy(
     array: *const c_void,
-    array_storage: *mut mts_array_t,
+    device: DLDevice,
+    new_array: *mut mts_array_t
 ) -> mts_status_t {
     crate::errors::catch_unwind(|| {
-        check_pointers!(array, array_storage);
+        check_pointers!(array, new_array);
         let array = array.cast::<RustArray>();
 
-        let new_array = (*array).impl_.copy();
-        let new_array = MtsArray::from(new_array);
-        *array_storage = new_array.into_raw();
+        let copy = (*array).impl_.copy(device);
+        let copy = MtsArray::from(copy);
+        *new_array = copy.into_raw();
 
         Ok(())
     })

--- a/rust/metatensor/src/data/array.rs
+++ b/rust/metatensor/src/data/array.rs
@@ -86,6 +86,11 @@ pub trait Array: std::any::Any + Send + Sync {
         stream: Option<i64>,
         max_version: DLPackVersion
     ) -> Result<DLPackTensor, Error>;
+
+    /// Create a new array from a `DLPack` tensor, taking ownership of the
+    /// tensor's data.
+    #[allow(clippy::wrong_self_convention)]
+    fn from_dlpack(&self, dl_tensor: DLPackTensor) -> Result<Box<dyn Array>, Error>;
 }
 
 pub (super) struct RustArray {
@@ -121,6 +126,7 @@ impl From<Box<dyn Array>> for MtsArray {
             device: Some(rust_array_device),
             dtype: Some(rust_array_dtype),
             as_dlpack: Some(rust_array_as_dlpack),
+            from_dlpack: Some(rust_array_from_dlpack),
             shape: Some(rust_array_shape),
             reshape: Some(rust_array_reshape),
             swap_axes: Some(rust_array_swap_axes),
@@ -348,18 +354,37 @@ unsafe extern "C" fn rust_array_move_data(
 /// Implementation of `mts_array_t.as_dlpack` using `RustArray`
 unsafe extern "C" fn rust_array_as_dlpack(
     array: *mut c_void,
-    out: *mut *mut DLManagedTensorVersioned,
+    dl_tensor: *mut *mut DLManagedTensorVersioned,
     device: DLDevice,
     stream: *const i64,
     max_version: DLPackVersion,
 ) -> mts_status_t {
     crate::errors::catch_unwind(|| {
-        check_pointers!(array, out);
+        check_pointers!(array, dl_tensor);
         let array = array.cast::<RustArray>();
         let stream_opt = stream.as_ref().copied();
         let tensor = (*array).impl_.as_dlpack(device, stream_opt, max_version)?;
 
-        *out = tensor.into_raw().as_ptr();
+        *dl_tensor = tensor.into_raw().as_ptr();
+
+        Ok(())
+    })
+}
+
+/// Implementation of `mts_array_t.from_dlpack` using `RustArray`
+unsafe extern "C" fn rust_array_from_dlpack(
+    array: *const c_void,
+    dl_tensor: *mut DLManagedTensorVersioned,
+    new_array: *mut mts_array_t,
+) -> mts_status_t {
+    crate::errors::catch_unwind(|| {
+        check_pointers!(array, dl_tensor, new_array);
+        let array = array.cast::<RustArray>();
+        let dl_tensor = DLPackTensor::from_ptr(dl_tensor);
+
+        let new_rust_array = (*array).impl_.from_dlpack(dl_tensor)?;
+
+        *new_array = MtsArray::from(new_rust_array).into_raw();
 
         Ok(())
     })

--- a/rust/metatensor/src/data/array_ref.rs
+++ b/rust/metatensor/src/data/array_ref.rs
@@ -1,4 +1,3 @@
-use std::ptr::NonNull;
 use std::sync::{Arc, RwLock};
 
 use ndarray::ArrayD;
@@ -167,7 +166,6 @@ impl<'a> ArrayRef<'a> {
             check_status(function(self.array.ptr, &mut tensor, device, stream_c, max_version))?;
         }
 
-        let tensor = NonNull::new(tensor).expect("got a NULL DLManagedTensorVersioned from `as_dlpack`");
         let tensor = unsafe {
             dlpk::DLPackTensor::from_ptr(tensor)
         };
@@ -439,7 +437,6 @@ impl<'a> ArrayRefMut<'a> {
             ))?;
         }
 
-        let tensor = NonNull::new(tensor).expect("got a NULL DLManagedTensorVersioned from `as_dlpack`");
         let tensor = unsafe {
             dlpk::DLPackTensor::from_ptr(tensor)
         };

--- a/rust/metatensor/src/data/array_ref.rs
+++ b/rust/metatensor/src/data/array_ref.rs
@@ -223,11 +223,11 @@ impl<'a> ArrayRef<'a> {
     /// Copy the data in this array, if supported by the underlying data.
     ///
     /// This corresponds to `mts_array_t.copy`, but with a more convenient API.
-    pub fn copy(&self) -> Result<MtsArray, Error> {
+    pub fn copy(&self, device: DLDevice) -> Result<MtsArray, Error> {
         let function = self.array.copy.expect("mts_array_t.copy function is NULL");
         let mut new_array = mts_array_t::null();
         unsafe {
-            check_status(function(self.array.ptr, &mut new_array))?;
+            check_status(function(self.array.ptr, device, &mut new_array))?;
         }
 
         return Ok(MtsArray::from_raw(new_array));
@@ -521,11 +521,11 @@ impl<'a> ArrayRefMut<'a> {
     /// Copy the data in this array, if supported by the underlying data.
     ///
     /// This corresponds to `mts_array_t.copy`, but with a more convenient API.
-    pub fn copy(&self) -> Result<MtsArray, Error> {
+    pub fn copy(&self, device: DLDevice) -> Result<MtsArray, Error> {
         let function = self.array.copy.expect("mts_array_t.copy function is NULL");
         let mut new_array = mts_array_t::null();
         unsafe {
-            check_status(function(self.array.ptr, &mut new_array))?;
+            check_status(function(self.array.ptr, device, &mut new_array))?;
         }
 
         return Ok(MtsArray::from_raw(new_array));

--- a/rust/metatensor/src/data/empty.rs
+++ b/rust/metatensor/src/data/empty.rs
@@ -35,7 +35,8 @@ impl Array for EmptyArray {
         Box::new(EmptyArray { shape: shape.to_vec() })
     }
 
-    fn copy(&self) -> Box<dyn Array> {
+    fn copy(&self, device: DLDevice) -> Box<dyn Array> {
+        assert_eq!(device, DLDevice::cpu());
         Box::new(EmptyArray { shape: self.shape.clone() })
     }
 

--- a/rust/metatensor/src/data/empty.rs
+++ b/rust/metatensor/src/data/empty.rs
@@ -77,6 +77,10 @@ impl Array for EmptyArray {
     ) -> Result<DLPackTensor, Error> {
         panic!("can not call Array::as_dlpack() for EmptyArray");
     }
+
+    fn from_dlpack(&self, _dlpack_tensor: DLPackTensor) -> Result<Box<dyn Array>, Error> {
+        panic!("can not call Array::from_dlpack() for EmptyArray");
+    }
 }
 
 #[cfg(test)]

--- a/rust/metatensor/src/data/external.rs
+++ b/rust/metatensor/src/data/external.rs
@@ -237,11 +237,11 @@ impl MtsArray {
     /// Copy the data in this array, if supported by the underlying data.
     ///
     /// This corresponds to `mts_array_t.copy`, but with a more convenient API.
-    pub fn copy(&self) -> Result<MtsArray, Error> {
+    pub fn copy(&self, device: DLDevice) -> Result<MtsArray, Error> {
         let function = self.array.copy.expect("mts_array_t.copy function is NULL");
         let mut new_array = mts_array_t::null();
         unsafe {
-            check_status(function(self.array.ptr, &mut new_array))?;
+            check_status(function(self.array.ptr, device, &mut new_array))?;
         }
 
         return Ok(MtsArray::from_raw(new_array));

--- a/rust/metatensor/src/data/external.rs
+++ b/rust/metatensor/src/data/external.rs
@@ -1,4 +1,3 @@
-use std::ptr::NonNull;
 use std::sync::{Arc, RwLock, RwLockReadGuard};
 
 use ndarray::ArrayD;
@@ -155,12 +154,22 @@ impl MtsArray {
             check_status(function(self.array.ptr, &mut tensor, device, stream_c, max_version))?;
         }
 
-        let tensor = NonNull::new(tensor).expect("got a NULL DLManagedTensorVersioned from `as_dlpack`");
         let tensor = unsafe {
             dlpk::DLPackTensor::from_ptr(tensor)
         };
 
         return Ok(tensor);
+    }
+
+    pub fn from_dlpack(&self, dlpack_tensor: dlpk::DLPackTensor) -> Result<MtsArray, Error> {
+        let function = self.array.from_dlpack.expect("mts_array_t.from_dlpack function is NULL");
+
+        let mut new_array = mts_array_t::null();
+        unsafe {
+            check_status(function(self.array.ptr, dlpack_tensor.into_raw().as_ptr(), &mut new_array))?;
+        }
+
+        return Ok(MtsArray::from_raw(new_array));
     }
 
     /// Get the shape of this array.

--- a/rust/metatensor/src/data/ndarray_array.rs
+++ b/rust/metatensor/src/data/ndarray_array.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, RwLock, TryLockError};
 
 use dlpk::sys::{DLDevice, DLPackVersion, DLDataType};
-use dlpk::{DLPackTensor, GetDLPackDataType, DLPackPointerCast};
+use dlpk::{DLDataTypeCode, DLPackPointerCast, DLPackTensor, GetDLPackDataType};
 
 use crate::errors::Error;
 use crate::c_api::mts_data_movement_t;
@@ -251,6 +251,65 @@ where
 
         Ok(tensor)
     }
+
+    #[allow(clippy::enum_glob_use)]
+    fn from_dlpack(&self, dlpack_tensor: DLPackTensor) -> Result<Box<dyn Array>, Error> {
+        use DLDataTypeCode::*;
+
+        let dtype = dlpack_tensor.dtype();
+
+        if dtype.lanes != 1 {
+            return Err(Error {
+                code: Some(crate::c_api::MTS_INVALID_PARAMETER_ERROR),
+                message: "Only DLPack tensors with lanes == 1 are supported".into(),
+            });
+        }
+
+        let map_error = |e| Error {
+            code: Some(crate::c_api::MTS_INVALID_PARAMETER_ERROR),
+            message: format!("failed to convert DLPack to ndarray: {:?}", e),
+        };
+
+        if dtype.code == kDLFloat && dtype.bits == 64 {
+            let array: ndarray::ArrayD<f64> = dlpack_tensor.try_into().map_err(map_error)?;
+            return Ok(Box::new(Arc::new(RwLock::new(array))));
+        } else if dtype.code == kDLFloat && dtype.bits == 32 {
+            let array: ndarray::ArrayD<f32> = dlpack_tensor.try_into().map_err(map_error)?;
+            return Ok(Box::new(Arc::new(RwLock::new(array))));
+        } else if dtype.code == kDLInt && dtype.bits == 8 {
+            let array: ndarray::ArrayD<i8> = dlpack_tensor.try_into().map_err(map_error)?;
+            return Ok(Box::new(Arc::new(RwLock::new(array))));
+        } else if dtype.code == kDLInt && dtype.bits == 16 {
+            let array: ndarray::ArrayD<i16> = dlpack_tensor.try_into().map_err(map_error)?;
+            return Ok(Box::new(Arc::new(RwLock::new(array))));
+        } else if dtype.code == kDLInt && dtype.bits == 32 {
+            let array: ndarray::ArrayD<i32> = dlpack_tensor.try_into().map_err(map_error)?;
+            return Ok(Box::new(Arc::new(RwLock::new(array))));
+        } else if dtype.code == kDLInt && dtype.bits == 64 {
+            let array: ndarray::ArrayD<i64> = dlpack_tensor.try_into().map_err(map_error)?;
+            return Ok(Box::new(Arc::new(RwLock::new(array))));
+        } else if dtype.code == kDLUInt && dtype.bits == 8 {
+            let array: ndarray::ArrayD<u8> = dlpack_tensor.try_into().map_err(map_error)?;
+            return Ok(Box::new(Arc::new(RwLock::new(array))));
+        } else if dtype.code == kDLUInt && dtype.bits == 16 {
+            let array: ndarray::ArrayD<u16> = dlpack_tensor.try_into().map_err(map_error)?;
+            return Ok(Box::new(Arc::new(RwLock::new(array))));
+        } else if dtype.code == kDLUInt && dtype.bits == 32 {
+            let array: ndarray::ArrayD<u32> = dlpack_tensor.try_into().map_err(map_error)?;
+            return Ok(Box::new(Arc::new(RwLock::new(array))));
+        } else if dtype.code == kDLUInt && dtype.bits == 64 {
+            let array: ndarray::ArrayD<u64> = dlpack_tensor.try_into().map_err(map_error)?;
+            return Ok(Box::new(Arc::new(RwLock::new(array))));
+        } else if dtype.code == kDLBool && dtype.bits == 8 {
+            let array: ndarray::ArrayD<bool> = dlpack_tensor.try_into().map_err(map_error)?;
+            return Ok(Box::new(Arc::new(RwLock::new(array))));
+        } else {
+            return Err(Error {
+                code: Some(crate::c_api::MTS_INVALID_PARAMETER_ERROR),
+                message: format!("Unsupported DLPack dtype {}", dtype),
+            });
+        }
+    }
 }
 
 #[cfg(test)]
@@ -367,5 +426,41 @@ mod tests {
             Err(e) => assert!(e.message.contains("version"), "{}", e.message),
             Ok(_) => panic!("expected error for incompatible DLPack version"),
         }
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn from_dlpack() {
+        let mut f64_data = ndarray::Array::<f64, _>::zeros(vec![2, 3]);
+        f64_data[[0, 0]] = 1.573;
+        f64_data[[1, 2]] = -42.0;
+        let f64_array = MtsArray::from(f64_data);
+
+        let mut i16_data = ndarray::Array::<i16, _>::zeros(vec![2, 5, 10]);
+        i16_data[[0, 1, 3]] = 3;
+        i16_data[[1, 2, 4]] = -42;
+        let i16_array = MtsArray::from(i16_data);
+
+        let f64_dl_tensor = f64_array.as_dlpack(DLDevice::cpu(), None, DLPackVersion::current()).unwrap();
+        let i16_dl_tensor = i16_array.as_dlpack(DLDevice::cpu(), None, DLPackVersion::current()).unwrap();
+
+        let new_f64_array = f64_array.from_dlpack(f64_dl_tensor).unwrap();
+        let new_i16_array = i16_array.from_dlpack(i16_dl_tensor).unwrap();
+
+        assert_eq!(f64_array.origin().unwrap(), i16_array.origin().unwrap());
+        assert_eq!(new_f64_array.origin().unwrap(), f64_array.origin().unwrap());
+        assert_eq!(new_i16_array.origin().unwrap(), i16_array.origin().unwrap());
+
+        let new_f64_dl_tensor = new_f64_array.as_dlpack(DLDevice::cpu(), None, DLPackVersion::current()).unwrap();
+        let new_i16_dl_tensor = new_i16_array.as_dlpack(DLDevice::cpu(), None, DLPackVersion::current()).unwrap();
+
+        let new_f64_data: ndarray::ArrayD<f64> = new_f64_dl_tensor.try_into().unwrap();
+        let new_i16_data: ndarray::ArrayD<i16> = new_i16_dl_tensor.try_into().unwrap();
+
+        assert_eq!(new_f64_data[[0, 0]], 1.573);
+        assert_eq!(new_f64_data[[1, 2]], -42.0);
+
+        assert_eq!(new_i16_data[[0, 1, 3]], 3);
+        assert_eq!(new_i16_data[[1, 2, 4]], -42);
     }
 }

--- a/rust/metatensor/src/data/ndarray_array.rs
+++ b/rust/metatensor/src/data/ndarray_array.rs
@@ -44,7 +44,8 @@ where
         return Box::new(Arc::new(RwLock::new(array)));
     }
 
-    fn copy(&self) -> Box<dyn Array> {
+    fn copy(&self, device: DLDevice) -> Box<dyn Array> {
+        assert_eq!(device, DLDevice::cpu(), "Rust ndarray data can only be copied to CPU device");
         return Box::new(self.clone());
     }
 


### PR DESCRIPTION
This is required to finish the transition of Labels to use mts_array_t, since we will want to move labels back on device in `keys_to_properties`/`keys_to_samples`.

This is now possible by doing 

```
keys_dl_tensor = current_cpu_keys.values.as_dlpack()

new_array = block.values.from_dlpack(keys_dl_tensor)
new_array_device = new_array.copy(block.values.device)
```

We need both `from_dlpack` and a `device` parameter in `copy`, because the array backend used for keys might not support the device used by the block values.


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
