### PR TITLE
Allow to move data out of metatensor_torch::TensorBlock

### DIFF
--- a/metatensor-core/include/metatensor/block.hpp
+++ b/metatensor-core/include/metatensor/block.hpp
@@ -97,7 +97,7 @@ public:
     TensorBlock clone() const {
         auto copy = TensorBlock();
         copy.is_view_ = false;
-        copy.block_ = mts_block_copy(this->block_);
+        copy.block_ = mts_block_copy(this->as_mts_block_t());
         details::check_pointer(copy.block_);
         return copy;
     }
@@ -109,7 +109,7 @@ public:
     /// does not contain any data.
     TensorBlock clone_metadata_only() const {
         auto block = TensorBlock(
-            std::unique_ptr<EmptyDataArray>(new EmptyDataArray(this->values_shape())),
+            std::make_unique<EmptyDataArray>(EmptyDataArray(this->values_shape())),
             this->samples(),
             this->components(),
             this->properties()
@@ -205,15 +205,10 @@ public:
     ///                 before those; its properties must match those of the
     ///                 original `TensorBlock`.
     void add_gradient(const std::string& parameter, TensorBlock gradient) {
-        if (is_view_) {
-            throw Error(
-                "can not call TensorBlock::add_gradient on this block since "
-                "it is a view inside a TensorMap"
-            );
-        }
+        this->check_not_view("add_gradient");
 
         details::check_status(mts_block_add_gradient(
-            block_,
+            this->as_mts_block_t(),
             parameter.c_str(),
             gradient.release()
         ));
@@ -224,7 +219,7 @@ public:
         const char*const * parameters = nullptr;
         uintptr_t count = 0;
         details::check_status(mts_block_gradients_list(
-            block_,
+            this->as_mts_block_t(),
             &parameters,
             &count
         ));
@@ -245,7 +240,13 @@ public:
     TensorBlock gradient(const std::string& parameter) const {
         mts_block_t* gradient_block = nullptr;
         details::check_status(
-            mts_block_gradient(block_, parameter.c_str(), &gradient_block)
+            mts_block_gradient(
+                // const cast is fine here because we return a view,
+                // which can not be modified
+                const_cast<TensorBlock*>(this)->as_mts_block_t(),
+                parameter.c_str(),
+                &gradient_block
+            )
         );
         details::check_pointer(gradient_block);
         return TensorBlock::unsafe_view_from_ptr(gradient_block);
@@ -255,17 +256,25 @@ public:
     ///
     /// The block pointer is still managed by the current `TensorBlock`
     mts_block_t* as_mts_block_t() & {
-        if (is_view_) {
+        if (block_ == nullptr) {
             throw Error(
-                "can not call non-const TensorBlock::as_mts_block_t on this "
-                "block since it is a view inside a TensorMap"
+                "Can not access this TensorBlock, it has been moved inside a "
+                "TensorMap or another TensorBlock"
             );
         }
+
         return block_;
     }
 
     /// const version of `as_mts_block_t`
     const mts_block_t* as_mts_block_t() const & {
+        if (block_ == nullptr) {
+            throw Error(
+                "Can not access this TensorBlock, it has been moved inside a "
+                "TensorMap or another TensorBlock"
+            );
+        }
+
         return block_;
     }
 
@@ -294,14 +303,14 @@ public:
         std::memset(&array, 0, sizeof(array));
 
         details::check_status(
-            mts_block_data(block_, &array)
+            mts_block_data(this->as_mts_block_t(), &array)
         );
         return MtsArray(array);
     }
 
     /// Get the labels in this block associated with the given `axis`.
     Labels labels(uintptr_t axis) const {
-        const auto* ptr = mts_block_labels(block_, axis);
+        const auto* ptr = mts_block_labels(this->as_mts_block_t(), axis);
         details::check_pointer(ptr);
         return Labels(ptr);
     }
@@ -424,9 +433,21 @@ private:
         std::memset(&array, 0, sizeof(array));
 
         details::check_status(
-            mts_block_data(block_, &array)
+            mts_block_data(
+                const_cast<TensorBlock*>(this)->as_mts_block_t(),
+                &array
+            )
         );
         return MtsArray(array);
+    }
+
+    void check_not_view(const char* method_name) const {
+        if (is_view_) {
+            throw Error(
+                "can not call TensorBlock::" + std::string(method_name) +
+                " on this block since it is inside a TensorMap or another TensorBlock"
+            );
+        }
     }
 
     /// Release the `mts_block_t` pointer corresponding to this `TensorBlock`.
@@ -434,12 +455,7 @@ private:
     /// The block pointer is **no longer** managed by the current `TensorBlock`,
     /// and should manually be freed when no longer required.
     mts_block_t* release() {
-         if (is_view_) {
-            throw Error(
-                "can not call TensorBlock::release on this "
-                "block since it is a view inside a TensorMap"
-            );
-        }
+        this->check_not_view("release");
         auto* ptr = block_;
         block_ = nullptr;
         is_view_ = false;

--- a/metatensor-core/tests/cpp/blocks.cpp
+++ b/metatensor-core/tests/cpp/blocks.cpp
@@ -11,7 +11,7 @@ static void check_loaded_block(metatensor::TensorBlock& block);
 TEST_CASE("Blocks") {
     SECTION("no components") {
         auto block = TensorBlock(
-            std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({3, 2})),
+            std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({3, 2})),
             Labels({"samples"}, {{0}, {1}, {4}}),
             {},
             Labels({"properties"}, {{5}, {3}})
@@ -32,7 +32,7 @@ TEST_CASE("Blocks") {
         components.emplace_back(Labels({"component_1"}, {{-1}, {0}, {1}}));
         components.emplace_back(Labels({"component_2"}, {{-4}, {1}}));
         auto block = TensorBlock(
-            std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({3, 3, 2, 2})),
+            std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({3, 3, 2, 2})),
             Labels({"samples"}, {{0}, {1}, {4}}),
             components,
             Labels({"properties"}, {{5}, {3}})
@@ -58,7 +58,7 @@ TEST_CASE("Blocks") {
         components.emplace_back(Labels({"component"}, {{-1}, {0}, {1}}));
         auto properties = Labels({"properties"}, {{5}, {3}});
         auto block = TensorBlock(
-            std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({3, 3, 2})),
+            std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({3, 3, 2})),
             Labels({"samples"}, {{0}, {1}, {4}}),
             components,
             properties
@@ -69,7 +69,7 @@ TEST_CASE("Blocks") {
         components.emplace_back(Labels({"component"}, {{-1}, {0}, {1}}));
 
         auto gradient = TensorBlock(
-            std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({2, 1, 3, 2})),
+            std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({2, 1, 3, 2})),
             Labels({"sample", "parameter"}, {{0, -2}, {2, 3}}),
             components,
             properties
@@ -104,7 +104,7 @@ TEST_CASE("Blocks") {
 
     SECTION("clone") {
         auto block = TensorBlock(
-            std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({3, 2})),
+            std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({3, 2})),
             Labels({"samples"}, {{0}, {1}, {4}}),
             {},
             Labels({"properties"}, {{5}, {3}})
@@ -144,7 +144,7 @@ TEST_CASE("Blocks") {
         components.emplace_back(Labels({"component_1"}, {{-1}, {0}, {1}}));
         components.emplace_back(Labels({"component_2"}, {{-4}, {1}}));
         auto block = TensorBlock(
-            std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({3, 3, 2, 2})),
+            std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({3, 3, 2, 2})),
             Labels({"samples"}, {{0}, {1}, {4}}),
             components,
             Labels({"properties"}, {{5}, {3}})
@@ -168,7 +168,7 @@ TEST_CASE("Blocks") {
 
     SECTION("empty labels") {
         auto block = TensorBlock(
-            std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({3, 0})),
+            std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({3, 0})),
             Labels({"samples"}, {{0}, {1}, {4}}),
             {},
             Labels({"properties"})

--- a/metatensor-core/tests/cpp/tensor.cpp
+++ b/metatensor-core/tests/cpp/tensor.cpp
@@ -269,7 +269,7 @@ TEST_CASE("TensorMap") {
     SECTION("clone") {
         auto blocks = std::vector<TensorBlock>();
         blocks.push_back(TensorBlock(
-            std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({3, 2})),
+            std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({3, 2})),
             Labels({"samples"}, {{0}, {1}, {4}}),
             {},
             Labels({"properties"}, {{5}, {3}})
@@ -426,13 +426,13 @@ TensorMap test_tensor_map() {
     components.emplace_back(Labels({"component"}, {{0}}));
 
     auto block_1 = TensorBlock(
-        std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({3, 1, 1}, 1.0)),
+        std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({3, 1, 1}, 1.0)),
         Labels({"samples"}, {{0}, {2}, {4}}),
         components,
         Labels({"properties"}, {{0}})
     );
     auto gradient_1 = TensorBlock(
-        std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({2, 1, 1}, 11.0)),
+        std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({2, 1, 1}, 11.0)),
         Labels({"sample", "parameter"}, {{0, -2}, {2, 3}}),
         components,
         Labels({"properties"}, {{0}})
@@ -442,13 +442,13 @@ TensorMap test_tensor_map() {
     blocks.emplace_back(std::move(block_1));
 
     auto block_2 = TensorBlock(
-        std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({3, 1, 3}, 2.0)),
+        std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({3, 1, 3}, 2.0)),
         Labels({"samples"}, {{0}, {1}, {3}}),
         components,
         Labels({"properties"}, {{3}, {4}, {5}})
     );
     auto gradient_2 = TensorBlock(
-        std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({3, 1, 3}, 12.0)),
+        std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({3, 1, 3}, 12.0)),
         Labels({"sample", "parameter"}, {{0, -2}, {0, 3}, {2, -2}}),
         components,
         Labels({"properties"}, {{3}, {4}, {5}})
@@ -460,13 +460,13 @@ TensorMap test_tensor_map() {
     components = std::vector<Labels>();
     components.emplace_back(Labels({"component"}, {{0}, {1}, {2}}));
     auto block_3 = TensorBlock(
-        std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({4, 3, 1}, 3.0)),
+        std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({4, 3, 1}, 3.0)),
         Labels({"samples"}, {{0}, {3}, {6}, {8}}),
         components,
         Labels({"properties"}, {{0}})
     );
     auto gradient_3 = TensorBlock(
-        std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({1, 3, 1}, 13.0)),
+        std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({1, 3, 1}, 13.0)),
         Labels({"sample", "parameter"}, {{1, -2}}),
         components,
         Labels({"properties"}, {{0}})
@@ -476,13 +476,13 @@ TensorMap test_tensor_map() {
     blocks.emplace_back(std::move(block_3));
 
     auto block_4 = TensorBlock(
-        std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({4, 3, 1}, 4.0)),
+        std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({4, 3, 1}, 4.0)),
         Labels({"samples"}, {{0}, {1}, {2}, {5}}),
         components,
         Labels({"properties"}, {{0}})
     );
     auto gradient_4 = TensorBlock(
-        std::unique_ptr<SimpleDataArray<double>>(new SimpleDataArray<double>({2, 3, 1}, 14.0)),
+        std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({2, 3, 1}, 14.0)),
         Labels({"sample", "parameter"}, {{0, 1}, {3, 3}}),
         components,
         Labels({"properties"}, {{0}})

--- a/metatensor-torch/CHANGELOG.md
+++ b/metatensor-torch/CHANGELOG.md
@@ -24,6 +24,10 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
   imported as `from metatensor.torch import ...`
 - `TensorMap.keys_to_samples` and `TensorMap.keys_to_properties` now take an
   optional `fill_value` parameter that will be used instead of 0 for missing entries when merging blocks.
+- `TensorBlock::as_metatensor()` in C++ has been replaced by
+  `TensorBlock::release`, which moves the data out of the `TensorBlockHolder`.
+- `TensorMap` now takes full ownership of the blocks passed to it, they are no
+  longer usable afterward.
 
 ### Removed
 

--- a/metatensor-torch/include/metatensor/torch/block.hpp
+++ b/metatensor-torch/include/metatensor/torch/block.hpp
@@ -161,10 +161,6 @@ public:
     /// Implementation of __repr__/__str__ for Python
     std::string repr() const;
 
-    /// Get the underlying metatensor TensorBlock
-    const metatensor::TensorBlock& as_metatensor() const {
-        return block_;
-    }
 
     /// Load a serialized TensorBlock from the given path
     static TensorBlock load(const std::string& path);
@@ -179,6 +175,12 @@ public:
     /// Serialize and save a TensorBlock to an in-memory buffer (represented as
     /// a `torch::Tensor` of bytes)
     torch::Tensor save_buffer() const;
+
+    /// Move the `metatensor::TensorBlock` out of this class.
+    ///
+    /// This leaves the `TensorBlockHolder` in an empty state that should no
+    /// longer be used.
+    metatensor::TensorBlock release();
 
 private:
     /// Create a TensorBlockHolder containing gradients with respect to

--- a/metatensor-torch/include/metatensor/torch/tensor.hpp
+++ b/metatensor-torch/include/metatensor/torch/tensor.hpp
@@ -25,14 +25,7 @@ using TensorMap = torch::intrusive_ptr<TensorMapHolder>;
 class METATENSOR_TORCH_EXPORT TensorMapHolder: public torch::CustomClassHolder {
 public:
     /// Create a new `TensorMapHolder` for TorchScript.
-    ///
-    /// In contrast to the TensorMap constructor, this does not move from the
-    /// different blocks, but instead create new ones using the same data and
-    /// metadata, but with incremented reference count.
-    TensorMapHolder(
-        Labels keys,
-        const std::vector<TensorBlock>& blocks
-    );
+    TensorMapHolder(Labels keys, std::vector<TensorBlock> blocks);
 
     /// Make a copy of this `TensorMap`, including all the data contained inside
     TensorMap copy() const;

--- a/metatensor-torch/src/block.cpp
+++ b/metatensor-torch/src/block.cpp
@@ -321,7 +321,7 @@ void TensorBlockHolder::save(const std::string& path) const {
         );
     }
 
-    metatensor::io::save(path, this->as_metatensor());
+    metatensor::io::save(path, this->block_);
 }
 
 torch::Tensor TensorBlockHolder::save_buffer() const {
@@ -339,7 +339,7 @@ torch::Tensor TensorBlockHolder::save_buffer() const {
             ", only float64 is supported"
         );
     }
-    auto buffer = metatensor::io::save_buffer(this->as_metatensor());
+    auto buffer = metatensor::io::save_buffer(this->block_);
     // move the buffer to the heap so it can escape this function
     // `torch::from_blob` does not take ownership of the data,
     // so we need to register a custom deleter to clean up when
@@ -358,4 +358,9 @@ torch::Tensor TensorBlockHolder::save_buffer() const {
         deleter,
         options
     );
+}
+
+metatensor::TensorBlock TensorBlockHolder::release() {
+    auto block = std::move(block_);
+    return block;
 }

--- a/metatensor-torch/src/tensor.cpp
+++ b/metatensor-torch/src/tensor.cpp
@@ -19,42 +19,7 @@ bool custom_class_is(torch::IValue ivalue) {
     return ivalue.type().get() == expected_type;
 }
 
-static metatensor::TensorBlock block_from_torch(const TensorBlock& block) {
-    auto components = std::vector<metatensor::Labels>();
-    for (const auto& component: block->components()) {
-        components.push_back(component->as_metatensor());
-    }
-
-    // use copy constructors of everything here, incrementing reference count
-    // of the data and metadata
-    auto result = metatensor::TensorBlock(
-        std::make_unique<TorchDataArray>(block->values()),
-        block->samples()->as_metatensor(),
-        components,
-        block->properties()->as_metatensor()
-    );
-
-    for (const auto& parameter: block->gradients_list()) {
-        auto gradient = block_from_torch(TensorBlockHolder::gradient(block, parameter));
-        result.add_gradient(parameter, std::move(gradient));
-    }
-
-    return result;
-}
-
-static std::vector<metatensor::TensorBlock> blocks_from_torch(const std::vector<TensorBlock>& blocks) {
-    auto results = std::vector<metatensor::TensorBlock>();
-    results.reserve(blocks.size());
-    for (const auto& block: blocks) {
-        results.emplace_back(block_from_torch(block));
-    }
-    return results;
-}
-
-
-TensorMapHolder::TensorMapHolder(Labels keys, const std::vector<TensorBlock>& blocks):
-    tensor_(keys->as_metatensor(), blocks_from_torch(blocks))
-{
+static std::vector<metatensor::TensorBlock> blocks_from_torch(Labels keys, std::vector<TensorBlock> blocks) {
     // Block-vs-block device/dtype consistency is enforced by metatensor-core.
     // The torch-specific check below ensures keys (which may live on GPU) are
     // on the same device as the blocks.
@@ -67,7 +32,19 @@ TensorMapHolder::TensorMapHolder(Labels keys, const std::vector<TensorBlock>& bl
             );
         }
     }
+
+    auto results = std::vector<metatensor::TensorBlock>();
+    results.reserve(blocks.size());
+    for (const auto& block: blocks) {
+        results.emplace_back(block->release());
+    }
+    return results;
 }
+
+
+TensorMapHolder::TensorMapHolder(Labels keys, std::vector<TensorBlock> blocks):
+    tensor_(keys->as_metatensor(), blocks_from_torch(keys, std::move(blocks)))
+{}
 
 TensorMap TensorMapHolder::copy() const {
     return torch::make_intrusive<TensorMapHolder>(TensorMapHolder(this->tensor_.clone()));

--- a/metatensor-torch/tests/block.cpp
+++ b/metatensor-torch/tests/block.cpp
@@ -93,4 +93,24 @@ TEST_CASE("Blocks") {
             )
         );
     }
+
+    SECTION("Release") {
+        auto block = torch::make_intrusive<TensorBlockHolder>(
+            torch::full({3, 2}, 11.0),
+            LabelsHolder::create({"s"}, {{0}, {2}, {1}}),
+            std::vector<Labels>{},
+            LabelsHolder::create({"p"}, {{0}, {1}})
+        );
+
+        CHECK(block->samples()->names()[0] == "s");
+
+        auto mts_block = block->release();
+        CHECK(mts_block.samples().names()[0] == std::string("s"));
+
+        CHECK_THROWS_WITH(
+            block->samples(),
+            "Can not access this TensorBlock, it has been moved inside a "
+            "TensorMap or another TensorBlock"
+        );
+    }
 }

--- a/python/metatensor_torch/tests/operations/manipulate_dimension.py
+++ b/python/metatensor_torch/tests/operations/manipulate_dimension.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 import metatensor.torch as mts
-from metatensor.torch import Labels, TensorMap
+from metatensor.torch import Labels, TensorBlock, TensorMap
 
 
 def get_tensor_map():
@@ -26,8 +26,12 @@ def get_tensor_map():
     )
     keys = Labels.range("block", 2)
     blocks = [
-        tensor.block({"center_type": 6, "neighbor_1_type": 1, "neighbor_2_type": 1}),
-        tensor.block({"center_type": 6, "neighbor_1_type": 6, "neighbor_2_type": 6}),
+        tensor.block(
+            {"center_type": 6, "neighbor_1_type": 1, "neighbor_2_type": 1}
+        ).copy(),
+        tensor.block(
+            {"center_type": 6, "neighbor_1_type": 6, "neighbor_2_type": 6}
+        ).copy(),
     ]
     return TensorMap(keys, blocks)
 
@@ -70,39 +74,40 @@ def test_insert():
 def test_insert_dimension_on_empty_labels():
     """https://github.com/metatensor/metatensor/issues/600"""
 
-    s = mts.Labels.empty(["a", "b"])
-    k = mts.Labels(names=["key"], values=torch.tensor([[0], [1]]))
-    b = mts.TensorBlock(
-        samples=s,
+    samples = Labels.empty(["a", "b"])
+    block = TensorBlock(
+        values=torch.zeros((len(samples), 1)),
+        samples=samples,
         components=[],
-        properties=mts.Labels.single(),
-        values=torch.zeros((len(s), 1)),
+        properties=Labels.single(),
     )
 
-    t = mts.TensorMap(
-        keys=k,
-        blocks=[b, b],
+    tensor = TensorMap(
+        keys=Labels(names=["key"], values=torch.tensor([[0], [1]])),
+        blocks=[block.copy(), block.copy()],
     )
 
-    for block in t:
+    for block in tensor:
         assert block.samples.names == ["a", "b"]
-        assert block.samples.values.shape == (len(s), 2)
+        assert block.samples.values.shape == (len(samples), 2)
 
-    tt = mts.insert_dimension(t, axis="samples", name="d", index=2, values=42)
+    tensor = mts.insert_dimension(tensor, axis="samples", name="d", index=2, values=42)
 
-    for block in tt:
+    for block in tensor:
         assert block.samples.names == ["a", "b", "d"]
-        assert block.samples.values.shape == (len(s), 3)
+        assert block.samples.values.shape == (len(samples), 3)
 
-    tt = mts.insert_dimension(t, axis="properties", name="d", index=0, values=42)
+    tensor = mts.insert_dimension(
+        tensor, axis="properties", name="d", index=0, values=42
+    )
 
-    for block in tt:
+    for block in tensor:
         assert block.properties.names == ["d", "_"]
         assert block.properties.values.shape == (1, 2)
 
     # RuntimeError from the TorchScript interpreter
     with pytest.raises(RuntimeError, match="index 42 is out of bounds"):
-        mts.insert_dimension(t, axis="samples", name="d", index=42, values=42)
+        mts.insert_dimension(tensor, axis="samples", name="d", index=42, values=42)
 
 
 def test_permute():

--- a/python/metatensor_torch/tests/tensor.py
+++ b/python/metatensor_torch/tests/tensor.py
@@ -465,7 +465,7 @@ def test_different_device(device_tensor):
         TensorMap(
             keys=device_tensor.keys,
             blocks=[
-                device_tensor.blocks()[0],
+                device_tensor[0].copy(),
                 TensorBlock(
                     values=torch.tensor([[[3.0, 4.0]]]),
                     samples=Labels.range("samples", 1),


### PR DESCRIPTION
This is a lot faster than re-creating new blocks that share data with the existing ones

From the benchmarks in #1106, before this commit (but with some other improvements to merge later since they are backward compatible):

```
Benchmark results for C++ API:

Function                                      Mean            Std            Min            Max
-----------------------------------------------------------------------------------------------
TensorMap/small                             1.72us         0.61us         1.58us        94.08us
TensorMap/large                             1.21ms         0.03ms         1.17ms         1.34ms

Benchmark results for Torch C++ API:

Function                                      Mean            Std            Min            Max
-----------------------------------------------------------------------------------------------
TensorMap/small                             6.12us         0.84us         5.58us        54.04us
TensorMap/large                             4.84ms         0.06ms         4.72ms         5.07ms

Benchmark results for Torch Python API:

Function                                      Mean            Std            Min            Max
-----------------------------------------------------------------------------------------------
TensorMap/small (cpu)                      42.55µs        23.26µs        39.67µs       992.25µs
TensorMap/large (cpu)                       6.78ms         0.21ms         6.52ms         7.36ms
```

After

```
Benchmark results for C++ API:

Function                                      Mean            Std            Min            Max
-----------------------------------------------------------------------------------------------
TensorMap/small                             1.70us         0.59us         1.54us        60.50us
TensorMap/large                             1.20ms         0.04ms         1.17ms         1.39ms

Benchmark results for Torch C++ API:

Function                                      Mean            Std            Min            Max
-----------------------------------------------------------------------------------------------
TensorMap/small                             2.21us         3.46us         1.88us       745.25us
TensorMap/large                           971.17us        49.41us       921.71us      1225.29us


Benchmark results for Torch Python API:

Function                                      Mean            Std            Min            Max
-----------------------------------------------------------------------------------------------
TensorMap/small (cpu)                      38.87µs        11.99µs        35.54µs       628.33µs
TensorMap/large (cpu)                       3.10ms         0.12ms         2.95ms         3.42ms
```



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?
