### PR TITLE
Only check major version in as_dlpack

### DIFF
--- a/metatensor-core/include/metatensor/arrays.hpp
+++ b/metatensor-core/include/metatensor/arrays.hpp
@@ -1449,18 +1449,13 @@ public:
             throw Error("`stream` must be null for CPU data");
         }
 
-        DLPackVersion mta_version = {DLPACK_MAJOR_VERSION, DLPACK_MINOR_VERSION};
-        // SEMVER, so major must match, and the MTA minor must be below the minor(caller)
-        bool major_mismatch = max_version.major != mta_version.major;
-        bool minor_too_high = max_version.minor < mta_version.minor;
-        if (major_mismatch || minor_too_high) {
+        if (max_version.major != DLPACK_MAJOR_VERSION) {
             throw Error(
-                "SimpleDataArray supports DLPack version " +
-                std::to_string(mta_version.major) + "." +
-                std::to_string(mta_version.minor) +
-                ". Caller requested incompatible version " +
-                std::to_string(max_version.major) + "." +
-                std::to_string(max_version.minor)
+                "invalid `max_version` in SimpleDataArray::as_dlpack: "
+                "we got v" + std::to_string(max_version.major) + "." +
+                std::to_string(max_version.minor) + ", but we support v" +
+                std::to_string(DLPACK_MAJOR_VERSION) + "." +
+                std::to_string(DLPACK_MINOR_VERSION)
             );
         }
 
@@ -1482,7 +1477,7 @@ public:
         // point to existing data and setup manager
         ctx->data = this->data_;
         auto managed = std::make_unique<DLManagedTensorVersioned>();
-        managed->version = mta_version;
+        managed->version = {DLPACK_MAJOR_VERSION, DLPACK_MINOR_VERSION};
         managed->flags = 0;
         managed->deleter = DLPackDeleter;
 

--- a/metatensor-core/src/labels/array.rs
+++ b/metatensor-core/src/labels/array.rs
@@ -217,8 +217,12 @@ unsafe extern "C" fn labels_array_as_dlpack(
         // minimum minor version requirement.
         if max_version.major != current.major {
             return Err(Error::InvalidParameter(
-                format!("`max_version` too high in as_dlpack: got {}, we support {}", max_version.major, current.major)
-            ))
+                format!(
+                    "invalid `max_version` in LabelsArray::as_dlpack: \
+                    we got v{}.{}, but we support v{}.{})",
+                    max_version.major, max_version.minor, current.major, current.minor
+                )
+            ));
         }
 
         let array = array.cast::<LabelsValuesArray>();

--- a/metatensor-core/tests/check-cxx-install.rs
+++ b/metatensor-core/tests/check-cxx-install.rs
@@ -44,18 +44,15 @@ fn check_cxx_install() {
     // configure cmake for the test cmake project
     let mut cmake_config = utils::cmake_config(&tests_source_dir, &build_dir);
     cmake_config.arg(format!("-DCMAKE_PREFIX_PATH={}", metatensor_cmake_prefix.display()));
-    let output = cmake_config.output().expect("failed to execute cmake");
-    utils::check_output(&output, "configuring test project with cmake");
+    utils::run_command(cmake_config, "cmake configuration");
 
     // build the code, linking to metatensor
-    let mut cmake_build = utils::cmake_build(&build_dir);
-    let output = cmake_build.output().expect("failed to execute cmake");
-    utils::check_output(&output, "building test project with cmake");
+    let cmake_build = utils::cmake_build(&build_dir);
+    utils::run_command(cmake_build, "cmake build");
 
     // run the executables
-    let mut ctest = utils::ctest(&build_dir);
-    let output = ctest.output().expect("failed to execute ctest");
-    utils::check_output(&output, "running tests with ctest");
+    let ctest = utils::ctest(&build_dir);
+    utils::run_command(ctest, "ctest");
 }
 
 
@@ -97,18 +94,15 @@ fn check_python_install() {
     // configure cmake for the test cmake project
     let mut cmake_config = utils::cmake_config(&source_dir, &build_dir);
     cmake_config.arg(format!("-DCMAKE_PREFIX_PATH={}", metatensor_cmake_prefix.display()));
-    let output = cmake_config.output().expect("failed to execute cmake");
-    utils::check_output(&output, "configuring test project with cmake");
+    utils::run_command(cmake_config, "cmake configuration");
 
     // build the code, linking to metatensor
-    let mut cmake_build = utils::cmake_build(&build_dir);
-    let output = cmake_build.output().expect("failed to execute cmake");
-    utils::check_output(&output, "building test project with cmake");
+    let cmake_build = utils::cmake_build(&build_dir);
+    utils::run_command(cmake_build, "cmake build");
 
     // run the executables
-    let mut ctest = utils::ctest(&build_dir);
-    let output = ctest.output().expect("failed to execute ctest");
-    utils::check_output(&output, "running tests with ctest");
+    let ctest = utils::ctest(&build_dir);
+    utils::run_command(ctest, "ctest");
 }
 
 /// Same test as above, but building metatensor in the same CMake project as the
@@ -138,16 +132,13 @@ fn check_cmake_subdirectory() {
     let mut cmake_config = utils::cmake_config(&source_dir, &build_dir);
     cmake_config.arg("-DUSE_CMAKE_SUBDIRECTORY=ON");
 
-    let output = cmake_config.output().expect("failed to execute cmake");
-    utils::check_output(&output, "configuring test project with cmake");
+    utils::run_command(cmake_config, "cmake configuration");
 
-    // build the code, linking to metatensor-torch
-    let mut cmake_build = utils::cmake_build(&build_dir);
-    let output = cmake_build.output().expect("failed to execute cmake");
-    utils::check_output(&output, "building test project with cmake");
+    // build the code, linking to metatensor
+    let cmake_build = utils::cmake_build(&build_dir);
+    utils::run_command(cmake_build, "cmake build");
 
     // run the executables
-    let mut ctest = utils::ctest(&build_dir);
-    let output = ctest.output().expect("failed to execute ctest");
-    utils::check_output(&output, "running tests with ctest");
+    let ctest = utils::ctest(&build_dir);
+    utils::run_command(ctest, "ctest");
 }

--- a/metatensor-core/tests/cpp/data.cpp
+++ b/metatensor-core/tests/cpp/data.cpp
@@ -347,7 +347,8 @@ TEST_CASE("SimpleDataArray - DLPack version mismatch") {
     DLPackVersion old_version = {0, 1};
     CHECK_THROWS_WITH(
         data->as_dlpack(cpu_device, nullptr, old_version),
-        Catch::Matchers::Contains("SimpleDataArray supports DLPack version")
+        "invalid `max_version` in SimpleDataArray::as_dlpack: "
+        "we got v0.1, but we support v1.3"
     );
 
     // Case 2: Request a newer version (1.5)
@@ -361,7 +362,8 @@ TEST_CASE("SimpleDataArray - DLPack version mismatch") {
     DLPackVersion too_new_version = {2, 0};
     CHECK_THROWS_WITH(
         data->as_dlpack(cpu_device, nullptr, too_new_version),
-        Catch::Matchers::Contains("Caller requested incompatible version")
+        "invalid `max_version` in SimpleDataArray::as_dlpack: "
+        "we got v2.0, but we support v1.3"
     );
 
     // Verify we got back the implementation version, not the requested one

--- a/metatensor-core/tests/run-cxx-tests.rs
+++ b/metatensor-core/tests/run-cxx-tests.rs
@@ -15,16 +15,13 @@ fn run_cxx_tests() {
     // configure cmake for the tests
     let mut cmake_config = utils::cmake_config(&source_dir, &build_dir);
     cmake_config.arg("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON");
-    let output = cmake_config.output().expect("failed to execute cmake");
-    utils::check_output(&output, "configuring tests with cmake");
+    utils::run_command(cmake_config, "cmake configuration");
 
-    // build the tests with cmake
-    let mut cmake_build = utils::cmake_build(&build_dir);
-    let output = cmake_build.output().expect("failed to execute cmake");
-    utils::check_output(&output, "building tests with cmake");
+    // build the tests
+    let cmake_build = utils::cmake_build(&build_dir);
+    utils::run_command(cmake_build, "cmake build");
 
     // run the tests
-    let mut ctest = utils::ctest(&build_dir);
-    let output = ctest.output().expect("failed to execute ctest");
-    utils::check_output(&output, "running tests with ctest");
+    let ctest = utils::ctest(&build_dir);
+    utils::run_command(ctest, "ctest");
 }

--- a/metatensor-core/tests/utils/mod.rs
+++ b/metatensor-core/tests/utils/mod.rs
@@ -1,8 +1,9 @@
 #![allow(dead_code)]
 #![allow(clippy::needless_return)]
 
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 fn build_type() -> &'static str {
     // assume that debug assertion means that we are building the code in
@@ -137,33 +138,30 @@ fn python_in_venv(venv_dir: &Path) -> PathBuf {
 /// `python -m venv`, and return the path to the python executable in the venv
 pub fn create_python_venv(build_dir: PathBuf) -> PathBuf {
     if let Some(uv_bin) = find_uv() {
-        let output = Command::new(&uv_bin)
-            .arg("venv")
-            .arg("--clear")
-            .arg(&build_dir)
-            .output()
-            .expect("failed to run uv venv");
-        check_output(&output, "creating virtualenv with uv");
+        let mut cmd = Command::new(&uv_bin);
+        cmd.arg("venv");
+        cmd.arg("--clear");
+        cmd.arg(&build_dir);
+
+        run_command(cmd, "uv venv creation");
     } else {
-        let output = Command::new(find_python())
-            .arg("-m")
-            .arg("venv")
-            .arg(&build_dir)
-            .output()
-            .expect("failed to run python -m venv");
-        check_output(&output, "creating virtualenv with `venv`");
+        let mut cmd = Command::new(find_python());
+        cmd.arg("-m");
+        cmd.arg("venv");
+        cmd.arg(&build_dir);
+
+        run_command(cmd, "python to create virtualenv with `venv`");
 
         // update pip in case the system uses a very old one
         let python = python_in_venv(&build_dir);
-        let output = Command::new(&python)
-            .arg("-m")
-            .arg("pip")
-            .arg("install")
-            .arg("--upgrade")
-            .arg("pip")
-            .output()
-            .expect("failed to upgrade pip");
-        check_output(&output, "upgrading pip in venv");
+        let mut cmd = Command::new(&python);
+        cmd.arg("-m");
+        cmd.arg("pip");
+        cmd.arg("install");
+        cmd.arg("--upgrade");
+        cmd.arg("pip");
+
+        run_command(cmd, "pip upgrade in virtualenv");
     }
 
     python_in_venv(&build_dir)
@@ -205,8 +203,7 @@ fn pip_install(
             cmd.arg(package);
         }
 
-        let output = cmd.output().expect("failed to execute `uv pip install`");
-        check_output(&output, "running `uv pip install`");
+        run_command(cmd, "uv pip install");
     } else {
         let mut cmd = Command::new(python);
         cmd.arg("-m").arg("pip").arg("install");
@@ -226,8 +223,7 @@ fn pip_install(
             cmd.arg(package);
         }
 
-        let output = cmd.output().expect("failed to execute `pip install`");
-        check_output(&output, "running `pip install`");
+        run_command(cmd, "pip install");
     }
 }
 
@@ -241,15 +237,13 @@ pub fn setup_torch_pip(python: &Path) -> PathBuf {
         PipInstallOptions { upgrade: true, no_deps: false, no_build_isolation: false }
     );
 
-    let output = Command::new(python)
-        .arg("-c")
-        .arg("import torch; print(torch.utils.cmake_prefix_path)")
-        .output()
-        .expect("failed to execute Python");
-    check_output(&output, "getting torch cmake prefix from Python");
+    let mut cmd = Command::new(python);
+    cmd.arg("-c");
+    cmd.arg("import torch; print(torch.utils.cmake_prefix_path)");
+
+    let output = run_command(cmd, "python to get torch cmake prefix");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-
     let prefix = PathBuf::from(stdout.trim());
     if !prefix.exists() {
         panic!("'torch.utils.cmake_prefix' at '{}' does not exist", prefix.display());
@@ -273,15 +267,13 @@ pub fn setup_metatensor_pip(python: &Path, source_dir: &Path) -> PathBuf {
         }
     );
 
-    let output = Command::new(python)
-        .arg("-c")
-        .arg("import metatensor; print(metatensor.utils.cmake_prefix_path)")
-        .output()
-        .expect("failed to execute Python");
-    check_output(&output, "getting metatensor cmake prefix from Python");
+    let mut cmd = Command::new(python);
+    cmd.arg("-c");
+    cmd.arg("import metatensor; print(metatensor.utils.cmake_prefix_path)");
+
+    let output = run_command(cmd, "python to get metatensor cmake prefix");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-
     let prefix = PathBuf::from(stdout.trim());
     if !prefix.exists() {
         panic!("'metatensor.utils.cmake_prefix' at '{}' does not exist", prefix.display());
@@ -303,15 +295,13 @@ pub fn setup_metatensor_torch_pip(python: &Path, source_dir: &Path) -> PathBuf {
         }
     );
 
-    let output = Command::new(python)
-        .arg("-c")
-        .arg("import metatensor.torch; print(metatensor.torch.utils.cmake_prefix_path)")
-        .output()
-        .expect("failed to execute Python");
-    check_output(&output, "getting metatensor_torch cmake prefix from Python");
+    let mut cmd = Command::new(python);
+    cmd.arg("-c");
+    cmd.arg("import metatensor.torch; print(metatensor.torch.utils.cmake_prefix_path)");
+
+    let output = run_command(cmd, "python to get metatensor_torch cmake prefix");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-
     let prefix = PathBuf::from(stdout.trim());
     if !prefix.exists() {
         panic!("'metatensor.torch.utils.cmake_prefix' at '{}' does not exist", prefix.display());
@@ -331,16 +321,14 @@ pub fn setup_metatensor_cmake(source_dir: &Path, build_dir: &Path) -> PathBuf {
     let install_prefix = build_dir.join("usr");
     cmake_config.arg(format!("-DCMAKE_INSTALL_PREFIX={}", install_prefix.display()));
 
-    let output = cmake_config.output().expect("failed to execute cmake");
-    check_output(&output, "running metatensor cmake configuration");
+    run_command(cmake_config, "cmake configuration for metatensor");
 
     // build and install metatensor
     let mut cmake_build = cmake_build(build_dir);
     cmake_build.arg("--target");
     cmake_build.arg("install");
 
-    let output = cmake_build.output().expect("failed to execute cmake");
-    check_output(&output, "running metatensor cmake build");
+    run_command(cmake_build, "cmake build for metatensor");
 
     install_prefix
 }
@@ -362,29 +350,72 @@ pub fn setup_metatensor_torch_cmake(source_dir: &Path, build_dir: &Path, cmake_a
         cmake_config.arg(arg);
     }
 
-    let output = cmake_config.output().expect("failed to execute cmake");
-    check_output(&output, "running metatensor_torch cmake configuration");
+    run_command(cmake_config, "cmake configuration for metatensor_torch");
 
     // build and install metatensor
     let mut cmake_build = cmake_build(build_dir);
     cmake_build.arg("--target");
     cmake_build.arg("install");
 
-    let output = cmake_build.output().expect("failed to execute cmake");
-    check_output(&output, "running metatensor_torch cmake build");
+    run_command(cmake_build, "cmake build for metatensor_torch");
 
     install_prefix
 }
 
 
-pub fn check_output(output: &std::process::Output, context: &str) {
-    if !output.status.success() {
+pub fn run_command(mut command: Command, context: &str) -> std::process::Output {
+    write!(std::io::stdout().lock(), "\n\n[Running] {:?}\n\n", command).unwrap();
+
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn().unwrap_or_else(|_| panic!("failed to spawn {}", context));
+
+    let mut child_stdout = child.stdout.take().expect("missing stdout");
+    let mut child_stderr = child.stderr.take().expect("missing stderr");
+
+    let out_handle = std::thread::spawn(move || -> std::io::Result<Vec<u8>> {
+        let mut buf = [0u8; 8192];
+        let mut captured = Vec::new();
+        let mut sink = std::io::stdout().lock();
+        loop {
+            let n = child_stdout.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            sink.write_all(&buf[..n])?;
+            sink.flush()?;
+            captured.extend_from_slice(&buf[..n]);
+        }
+        Ok(captured)
+    });
+
+    let err_handle = std::thread::spawn(move || -> std::io::Result<Vec<u8>> {
+        let mut buf = [0u8; 8192];
+        let mut captured = Vec::new();
+        let mut sink = std::io::stderr().lock();
+        loop {
+            let n = child_stderr.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            sink.write_all(&buf[..n])?;
+            sink.flush()?;
+            captured.extend_from_slice(&buf[..n]);
+        }
+        Ok(captured)
+    });
+
+    let status = child.wait().unwrap_or_else(|_| panic!("failed to run {}", context));
+    let stdout = String::from_utf8_lossy(&out_handle.join().unwrap().unwrap()).into_owned();
+    let stderr = String::from_utf8_lossy(&err_handle.join().unwrap().unwrap()).into_owned();
+
+    if !status.success() {
         panic!(
             "{} failed, status: {}\nstderr:\n\n{}\nstdout:\n\n{}\n",
-            context,
-            output.status,
-            String::from_utf8_lossy(&output.stderr),
-            String::from_utf8_lossy(&output.stdout)
+            context, status, stderr, stdout
         );
     }
+
+    return std::process::Output { status, stdout: stdout.into_bytes(), stderr: stderr.into_bytes() };
 }

--- a/metatensor-torch/src/array.cpp
+++ b/metatensor-torch/src/array.cpp
@@ -327,14 +327,13 @@ DLDataType TorchDataArray::dtype() const {
 }
 
 DLManagedTensorVersioned* TorchDataArray::as_dlpack(DLDevice device, const int64_t* stream, DLPackVersion max_version) {
-    DLPackVersion mta_version = {DLPACK_MAJOR_VERSION, DLPACK_MINOR_VERSION};
-    bool major_mismatch = max_version.major != mta_version.major;
-    bool minor_too_high = max_version.minor < mta_version.minor;
-    if (major_mismatch || minor_too_high) {
+    if (max_version.major != DLPACK_MAJOR_VERSION) {
         throw metatensor::Error(
-            "TorchDataArray supports DLPack version " + std::to_string(mta_version.major) + "." +
-            std::to_string(mta_version.minor) + ". Caller requested incompatible version " +
-            std::to_string(max_version.major) + "." + std::to_string(max_version.minor)
+            "invalid `max_version` in TorchDataArray::as_dlpack: "
+            "we got v" + std::to_string(max_version.major) + "." +
+            std::to_string(max_version.minor) + ", but we support v" +
+            std::to_string(DLPACK_MAJOR_VERSION) + "." +
+            std::to_string(DLPACK_MINOR_VERSION)
         );
     }
     torch::Device target_device = dlpack_device_to_torch(device);
@@ -403,7 +402,7 @@ DLManagedTensorVersioned* TorchDataArray::as_dlpack(DLDevice device, const int64
     DLManagedTensor* legacy_tensor = at::toDLPack(tensor_to_pack);
 
     auto* versioned_tensor = new DLManagedTensorVersioned();
-    versioned_tensor->version = mta_version;
+    versioned_tensor->version = {DLPACK_MAJOR_VERSION, DLPACK_MINOR_VERSION};
     // Setup context, keeping the legacy variant for the deleter
     versioned_tensor->manager_ctx = legacy_tensor;
     versioned_tensor->deleter = dlpack_versioned_deleter;

--- a/metatensor-torch/tests/array.cpp
+++ b/metatensor-torch/tests/array.cpp
@@ -260,22 +260,12 @@ TEST_CASE("DLPack conversion") {
 
         // Major version mismatch
         // If the caller requests a different major version, it should fail.
-        DLPackVersion bad_major = {DLPACK_MAJOR_VERSION + 1, DLPACK_MINOR_VERSION};
+        DLPackVersion bad_major = {2, 2};
         CHECK_THROWS_WITH(
             array.as_dlpack(/*device=*/{kDLCPU, 0}, /*stream=*/nullptr, /*max_version=*/ bad_major),
-            Catch::Matchers::Contains("Caller requested incompatible version")
+            "invalid `max_version` in TorchDataArray::as_dlpack: "
+            "we got v2.2, but we support v1.3"
         );
-
-        // Minor version too old
-        // If the caller supports a lower max minor version than the tensor provides,
-        // we must ensure it throws (as per logic: max_version.minor < mta_version.minor).
-        if (DLPACK_MINOR_VERSION > 0) {
-            DLPackVersion old_minor = {DLPACK_MAJOR_VERSION, DLPACK_MINOR_VERSION - 1};
-            CHECK_THROWS_WITH(
-                array.as_dlpack(/*device=*/{kDLCPU, 0}, /*stream=*/nullptr, /*max_version=*/ old_minor),
-                Catch::Matchers::Contains("Caller requested incompatible version")
-            );
-        }
     }
 
     SECTION("stream synchronization") {

--- a/metatensor-torch/tests/check-torch-install.rs
+++ b/metatensor-torch/tests/check-torch-install.rs
@@ -82,18 +82,15 @@ fn check_torch_install() {
         install_prefix.display(),
     ));
 
-    let output = cmake_config.output().expect("failed to execute cmake");
-    utils::check_output(&output, "configuring test project with cmake");
+    utils::run_command(cmake_config, "cmake configuration");
 
     // build the code, linking to metatensor-torch
-    let mut cmake_build = utils::cmake_build(&build_dir);
-    let output = cmake_build.output().expect("failed to execute cmake");
-    utils::check_output(&output, "building test project with cmake");
+    let cmake_build = utils::cmake_build(&build_dir);
+    utils::run_command(cmake_build, "cmake build");
 
     // run the executables
-    let mut ctest = utils::ctest(&build_dir);
-    let output = ctest.output().expect("could not run ctest");
-    utils::check_output(&output, "running tests with ctest");
+    let ctest = utils::ctest(&build_dir);
+    utils::run_command(ctest, "ctest");
 }
 
 /// Same as above, but using pre-built metatensor-torch from the Python wheel,
@@ -144,18 +141,15 @@ fn check_python_install() {
         metatensor_torch_cmake_prefix.display(),
     ));
 
-    let output = cmake_config.output().expect("failed to execute cmake");
-    utils::check_output(&output, "configuring test project with cmake");
+    utils::run_command(cmake_config, "cmake configuration");
 
     // build the code, linking to metatensor-torch
-    let mut cmake_build = utils::cmake_build(&build_dir);
-    let output = cmake_build.output().expect("failed to execute cmake");
-    utils::check_output(&output, "building test project with cmake");
+    let cmake_build = utils::cmake_build(&build_dir);
+    utils::run_command(cmake_build, "cmake build");
 
     // run the executables
-    let mut ctest = utils::ctest(&build_dir);
-    let output = ctest.output().expect("failed to execute ctest");
-    utils::check_output(&output, "running tests with ctest");
+    let ctest = utils::ctest(&build_dir);
+    utils::run_command(ctest, "ctest");
 }
 
 /// Same test as above, but building metatensor and metatensor-torch in the same
@@ -194,16 +188,13 @@ fn check_cmake_subdirectory() {
     cmake_config.arg(format!("-DCMAKE_PREFIX_PATH={}", pytorch_cmake_prefix.display()));
     cmake_config.arg("-DUSE_CMAKE_SUBDIRECTORY=ON");
 
-    let output = cmake_config.output().expect("failed to execute cmake");
-    utils::check_output(&output, "configuring test project with cmake");
+    utils::run_command(cmake_config, "cmake configuration");
 
     // build the code, linking to metatensor-torch
-    let mut cmake_build = utils::cmake_build(&build_dir);
-    let output = cmake_build.output().expect("failed to execute cmake");
-    utils::check_output(&output, "building test project with cmake");
+    let cmake_build = utils::cmake_build(&build_dir);
+    utils::run_command(cmake_build, "cmake build");
 
     // run the executables
-    let mut ctest = utils::ctest(&build_dir);
-    let output = ctest.output().expect("failed to execute ctest");
-    utils::check_output(&output, "running tests with ctest");
+    let ctest = utils::ctest(&build_dir);
+    utils::run_command(ctest, "ctest");
 }

--- a/metatensor-torch/tests/run-torch-tests.rs
+++ b/metatensor-torch/tests/run-torch-tests.rs
@@ -36,16 +36,13 @@ fn run_torch_tests() {
         pytorch_cmake_prefix.display()
     ));
 
-    let output = cmake_config.output().expect("failed to execute cmake");
-    utils::check_output(&output, "configuring torch tests with cmake");
+    utils::run_command(cmake_config, "cmake configuration");
 
-    // build the tests with cmake
-    let mut cmake_build = utils::cmake_build(&build_dir);
-    let output = cmake_build.output().expect("failed to execute cmake");
-    utils::check_output(&output, "building torch tests with cmake");
+    // build the tests
+    let cmake_build = utils::cmake_build(&build_dir);
+    utils::run_command(cmake_build, "cmake build");
 
     // run the tests
-    let mut ctest = utils::ctest(&build_dir);
-    let output = ctest.output().expect("failed to execute ctest");
-    utils::check_output(&output, "running torch tests with ctest");
+    let ctest = utils::ctest(&build_dir);
+    utils::run_command(ctest, "ctest");
 }

--- a/rust/metatensor/src/data/array.rs
+++ b/rust/metatensor/src/data/array.rs
@@ -366,7 +366,6 @@ unsafe extern "C" fn rust_array_as_dlpack(
         let tensor = (*array).impl_.as_dlpack(device, stream_opt, max_version)?;
 
         *dl_tensor = tensor.into_raw().as_ptr();
-
         Ok(())
     })
 }

--- a/rust/metatensor/src/data/ndarray_array.rs
+++ b/rust/metatensor/src/data/ndarray_array.rs
@@ -220,14 +220,14 @@ where
             });
         }
         let vendored_version = DLPackVersion::current();
-        let major_mismatch = max_version.major != vendored_version.major;
-        let minor_too_high = max_version.minor < vendored_version.minor;
-        if major_mismatch || minor_too_high {
+        if max_version.major != vendored_version.major {
             return Err(Error {
                 code: Some(crate::c_api::MTS_INVALID_PARAMETER_ERROR),
                 message: format!(
-                    "Metatensor supports DLPack version {}.{}. Caller requested incompatible version {}.{}",
-                    vendored_version.major, vendored_version.minor, max_version.major, max_version.minor
+                    "invalid `max_version` in ndarray::ArrayD<T>::as_dlpack: \
+                    we got v{}.{}, but we support v{}.{}",
+                    max_version.major, max_version.minor,
+                    vendored_version.major, vendored_version.minor
                 ),
             });
         }


### PR DESCRIPTION
Trying to use `ExternalCPUArray` with Rust arrays in featomic was failing because the check on the minor version was the wrong way around, but checking again the semantics of `max_version` and how dlpack does versioning, I think we should be OK just checking the major version.



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?
