### PR TITLE
Better privacy indicator for `metatensor_operations._utils` functions

### DIFF
--- a/python/metatensor_operations/metatensor_operations/_add.py
+++ b/python/metatensor_operations/metatensor_operations/_add.py
@@ -8,9 +8,9 @@ from ._backend import (
     torch_jit_script,
 )
 from ._utils import (
-    _check_blocks_raise,
-    _check_same_gradients_raise,
-    _check_same_keys_raise,
+    check_blocks_raise,
+    check_same_gradients_raise,
+    check_same_keys_raise,
 )
 
 
@@ -119,15 +119,15 @@ def add(A: TensorMap, B: Union[int, float, TensorMap]) -> TensorMap:
             blocks.append(_add_block_constant(block=block_A, constant=B))
 
     elif is_tensor_map:
-        _check_same_keys_raise(A, B, "add")
+        check_same_keys_raise(A, B, "add")
         for key, block_A in A.items():
             block_B = B[key]
-            _check_blocks_raise(
+            check_blocks_raise(
                 block_A,
                 block_B,
                 fname="add",
             )
-            _check_same_gradients_raise(
+            check_same_gradients_raise(
                 block_A,
                 block_B,
                 fname="add",

--- a/python/metatensor_operations/metatensor_operations/_allclose.py
+++ b/python/metatensor_operations/metatensor_operations/_allclose.py
@@ -2,9 +2,9 @@ from . import _dispatch
 from ._backend import TensorBlock, TensorMap, torch_jit_script
 from ._utils import (
     NotEqualError,
-    _check_blocks_impl,
-    _check_same_gradients_impl,
-    _check_same_keys_impl,
+    check_blocks_impl,
+    check_same_gradients_impl,
+    check_same_keys_impl,
 )
 
 
@@ -12,7 +12,7 @@ def _allclose_impl(
     tensor_1: TensorMap, tensor_2: TensorMap, rtol: float, atol: float, equal_nan: bool
 ) -> str:
     """Abstract function to perform an allclose operation between two TensorMaps."""
-    message = _check_same_keys_impl(tensor_1, tensor_2, "allclose")
+    message = check_same_keys_impl(tensor_1, tensor_2, "allclose")
     if message != "":
         return f"the tensor maps have different keys: {message}"
 
@@ -45,7 +45,7 @@ def _allclose_block_impl(
     ):
         return "values are not allclose"
 
-    check_blocks_message = _check_blocks_impl(
+    check_blocks_message = check_blocks_impl(
         block_1,
         block_2,
         fname="allclose",
@@ -53,7 +53,7 @@ def _allclose_block_impl(
     if check_blocks_message != "":
         return check_blocks_message
 
-    check_same_gradient_message = _check_same_gradients_impl(
+    check_same_gradient_message = check_same_gradients_impl(
         block_1,
         block_2,
         check=["samples", "properties", "components"],

--- a/python/metatensor_operations/metatensor_operations/_divide.py
+++ b/python/metatensor_operations/metatensor_operations/_divide.py
@@ -8,9 +8,9 @@ from ._backend import (
     torch_jit_script,
 )
 from ._utils import (
-    _check_blocks_raise,
-    _check_same_gradients_raise,
-    _check_same_keys_raise,
+    check_blocks_raise,
+    check_same_gradients_raise,
+    check_same_keys_raise,
 )
 
 
@@ -140,15 +140,15 @@ def divide(A: TensorMap, B: Union[float, int, TensorMap]) -> TensorMap:
         for block_A in A.blocks():
             blocks.append(_divide_block_constant(block=block_A, constant=B))
     elif is_tensor_map:
-        _check_same_keys_raise(A, B, "divide")
+        check_same_keys_raise(A, B, "divide")
         for key, block_A in A.items():
             block_B = B.block(key)
-            _check_blocks_raise(
+            check_blocks_raise(
                 block_A,
                 block_B,
                 fname="divide",
             )
-            _check_same_gradients_raise(
+            check_same_gradients_raise(
                 block_A,
                 block_B,
                 fname="divide",

--- a/python/metatensor_operations/metatensor_operations/_dot.py
+++ b/python/metatensor_operations/metatensor_operations/_dot.py
@@ -2,7 +2,7 @@ from typing import List
 
 from . import _dispatch
 from ._backend import TensorBlock, TensorMap, torch_jit_script
-from ._utils import _check_same_keys_raise
+from ._utils import check_same_keys_raise
 
 
 def _dot_block(block_1: TensorBlock, block_2: TensorBlock) -> TensorBlock:
@@ -102,7 +102,7 @@ def dot(tensor_1: TensorMap, tensor_2: TensorMap) -> TensorMap:
             ``B``; and the ``components`` equal to the ``components`` of ``A``
 
     """
-    _check_same_keys_raise(tensor_1, tensor_2, "dot")
+    check_same_keys_raise(tensor_1, tensor_2, "dot")
 
     blocks: List[TensorBlock] = []
     for key, block_1 in tensor_1.items():

--- a/python/metatensor_operations/metatensor_operations/_empty_like.py
+++ b/python/metatensor_operations/metatensor_operations/_empty_like.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Union
 
 from . import _dispatch
 from ._backend import TensorBlock, TensorMap, torch_jit_script
-from ._utils import _check_gradient_presence_raise
+from ._utils import check_gradient_presence_raise
 
 
 @torch_jit_script
@@ -42,7 +42,7 @@ def empty_like_block(
     if gradients is None:
         gradients = block.gradients_list()
     else:
-        _check_gradient_presence_raise(
+        check_gradient_presence_raise(
             block=block, parameters=gradients, fname="empty_like"
         )
 

--- a/python/metatensor_operations/metatensor_operations/_equal.py
+++ b/python/metatensor_operations/metatensor_operations/_equal.py
@@ -2,15 +2,15 @@ from . import _dispatch
 from ._backend import TensorBlock, TensorMap, torch_jit_script
 from ._utils import (
     NotEqualError,
-    _check_blocks_impl,
-    _check_same_gradients_impl,
-    _check_same_keys_impl,
+    check_blocks_impl,
+    check_same_gradients_impl,
+    check_same_keys_impl,
 )
 
 
 def _equal_impl(tensor_1: TensorMap, tensor_2: TensorMap) -> str:
     """Abstract function to perform an equal operation between two TensorMaps."""
-    message = _check_same_keys_impl(tensor_1, tensor_2, "equal")
+    message = check_same_keys_impl(tensor_1, tensor_2, "equal")
     if message != "":
         return f"the tensor maps have different keys: {message}"
 
@@ -29,11 +29,11 @@ def _equal_block_impl(block_1: TensorBlock, block_2: TensorBlock) -> str:
     if not _dispatch.all(block_1.values == block_2.values):
         return "values are not equal"
 
-    check_blocks_message = _check_blocks_impl(block_1, block_2, fname="equal")
+    check_blocks_message = check_blocks_impl(block_1, block_2, fname="equal")
     if check_blocks_message != "":
         return check_blocks_message
 
-    check_same_gradient_message = _check_same_gradients_impl(
+    check_same_gradient_message = check_same_gradients_impl(
         block_1, block_2, fname="equal"
     )
     if check_same_gradient_message != "":

--- a/python/metatensor_operations/metatensor_operations/_equal_metadata.py
+++ b/python/metatensor_operations/metatensor_operations/_equal_metadata.py
@@ -9,9 +9,9 @@ from ._backend import (
 )
 from ._utils import (
     NotEqualError,
-    _check_blocks_impl,
-    _check_same_gradients_impl,
-    _check_same_keys_impl,
+    check_blocks_impl,
+    check_same_gradients_impl,
+    check_same_keys_impl,
 )
 
 
@@ -27,7 +27,7 @@ def _equal_metadata_impl(
         if not isinstance_metatensor(tensor_2, "TensorMap"):
             return f"`tensor_2` must be a metatensor TensorMap, not {type(tensor_2)}"
 
-    message = _check_same_keys_impl(tensor_1, tensor_2, "equal_metadata_raise")
+    message = check_same_keys_impl(tensor_1, tensor_2, "equal_metadata_raise")
     if message != "":
         return message
 
@@ -57,7 +57,7 @@ def _equal_metadata_block_impl(
         if not isinstance_metatensor(block_2, "TensorBlock"):
             return f"`block_2` must be a metatensor TensorBlock, not {type(block_2)}"
 
-    check_blocks_message = _check_blocks_impl(
+    check_blocks_message = check_blocks_impl(
         block_1,
         block_2,
         "equal_metadata_block_raise",
@@ -68,7 +68,7 @@ def _equal_metadata_block_impl(
         return check_blocks_message
 
     if check_gradients:
-        check_same_gradient_message = _check_same_gradients_impl(
+        check_same_gradient_message = check_same_gradients_impl(
             block_1,
             block_2,
             "equal_metadata_block_raise",

--- a/python/metatensor_operations/metatensor_operations/_join.py
+++ b/python/metatensor_operations/metatensor_operations/_join.py
@@ -10,9 +10,9 @@ from ._backend import (
     torch_jit_script,
 )
 from ._utils import (
-    _check_blocks_raise,
-    _check_same_gradients_raise,
-    _check_same_keys_raise,
+    check_blocks_raise,
+    check_same_gradients_raise,
+    check_same_keys_raise,
 )
 
 
@@ -183,8 +183,8 @@ def _join_block_samples(
     n_joined_samples = 0
     for block in blocks:
         n_joined_samples += block.values.shape[0]
-        _check_blocks_raise(first_block, block, fname, ["components", "properties"])
-        _check_same_gradients_raise(first_block, block, fname, ["components"])
+        check_blocks_raise(first_block, block, fname, ["components", "properties"])
+        check_same_gradients_raise(first_block, block, fname, ["components"])
 
     shape = list(first_block.values.shape)
     shape[0] = n_joined_samples
@@ -307,8 +307,8 @@ def _join_block_properties(
     n_joined_properties = 0
     for block in blocks:
         n_joined_properties += block.values.shape[-1]
-        _check_blocks_raise(first_block, block, fname, ["samples", "components"])
-        _check_same_gradients_raise(first_block, block, fname, ["components"])
+        check_blocks_raise(first_block, block, fname, ["samples", "components"])
+        check_same_gradients_raise(first_block, block, fname, ["components"])
 
         if block.properties.names != property_names:
             has_different_property_names = True
@@ -593,7 +593,7 @@ def join(
 
     if different_keys == "error":
         for ts_to_join in tensors[1:]:
-            _check_same_keys_raise(tensors[0], ts_to_join, "join")
+            check_same_keys_raise(tensors[0], ts_to_join, "join")
     elif different_keys == "intersection":
         tensors = _tensors_intersection(tensors)
     elif different_keys == "union":

--- a/python/metatensor_operations/metatensor_operations/_lstsq.py
+++ b/python/metatensor_operations/metatensor_operations/_lstsq.py
@@ -10,17 +10,17 @@ from ._backend import (
     torch_jit_script,
 )
 from ._utils import (
-    _check_blocks_raise,
-    _check_same_gradients_raise,
-    _check_same_keys_raise,
+    check_blocks_raise,
+    check_same_gradients_raise,
+    check_same_keys_raise,
 )
 
 
 def _lstsq_block(
     X: TensorBlock, Y: TensorBlock, rcond: Optional[float], driver: Optional[str] = None
 ) -> TensorBlock:
-    _check_blocks_raise(X, Y, check=["samples", "components"], fname="lstsq")
-    _check_same_gradients_raise(X, Y, check=["samples", "components"], fname="lstsq")
+    check_blocks_raise(X, Y, check=["samples", "components"], fname="lstsq")
+    check_same_gradients_raise(X, Y, check=["samples", "components"], fname="lstsq")
 
     # reshape components together with the samples
     X_n_properties = X.values.shape[-1]
@@ -145,7 +145,7 @@ def lstsq(
             stacklevel=1,
         )
 
-    _check_same_keys_raise(X, Y, "lstsq")
+    check_same_keys_raise(X, Y, "lstsq")
 
     blocks: List[TensorBlock] = []
     for key, X_block in X.items():

--- a/python/metatensor_operations/metatensor_operations/_multiply.py
+++ b/python/metatensor_operations/metatensor_operations/_multiply.py
@@ -8,9 +8,9 @@ from ._backend import (
     torch_jit_script,
 )
 from ._utils import (
-    _check_blocks_raise,
-    _check_same_gradients_raise,
-    _check_same_keys_raise,
+    check_blocks_raise,
+    check_same_gradients_raise,
+    check_same_keys_raise,
 )
 
 
@@ -135,11 +135,11 @@ def multiply(A: TensorMap, B: Union[float, int, TensorMap]) -> TensorMap:
         for block_A in A.blocks():
             blocks.append(_multiply_block_constant(block=block_A, constant=B))
     elif is_tensor_map:
-        _check_same_keys_raise(A, B, "multiply")
+        check_same_keys_raise(A, B, "multiply")
         for key, block_A in A.items():
             block_B = B[key]
-            _check_blocks_raise(block_A, block_B, fname="multiply")
-            _check_same_gradients_raise(block_A, block_B, fname="multiply")
+            check_blocks_raise(block_A, block_B, fname="multiply")
+            check_same_gradients_raise(block_A, block_B, fname="multiply")
             blocks.append(_multiply_block_block(block_1=block_A, block_2=block_B))
     else:
         if torch_jit_is_scripting():

--- a/python/metatensor_operations/metatensor_operations/_ones_like.py
+++ b/python/metatensor_operations/metatensor_operations/_ones_like.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Union
 
 from . import _dispatch
 from ._backend import TensorBlock, TensorMap, torch_jit_script
-from ._utils import _check_gradient_presence_raise
+from ._utils import check_gradient_presence_raise
 
 
 @torch_jit_script
@@ -42,7 +42,7 @@ def ones_like_block(
     if gradients is None:
         gradients = block.gradients_list()
     else:
-        _check_gradient_presence_raise(
+        check_gradient_presence_raise(
             block=block, parameters=gradients, fname="ones_like"
         )
 

--- a/python/metatensor_operations/metatensor_operations/_random_like.py
+++ b/python/metatensor_operations/metatensor_operations/_random_like.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Union
 
 from . import _dispatch
 from ._backend import TensorBlock, TensorMap, torch_jit_script
-from ._utils import _check_gradient_presence_raise
+from ._utils import check_gradient_presence_raise
 
 
 @torch_jit_script
@@ -45,7 +45,7 @@ def random_uniform_like_block(
     if gradients is None:
         gradients = block.gradients_list()
     else:
-        _check_gradient_presence_raise(
+        check_gradient_presence_raise(
             block=block, parameters=gradients, fname="random_uniform_like"
         )
 

--- a/python/metatensor_operations/metatensor_operations/_solve.py
+++ b/python/metatensor_operations/metatensor_operations/_solve.py
@@ -8,7 +8,7 @@ from ._backend import (
     torch_jit_annotate,
     torch_jit_script,
 )
-from ._utils import _check_same_gradients_raise, _check_same_keys_raise
+from ._utils import check_same_gradients_raise, check_same_keys_raise
 
 
 @torch_jit_script
@@ -39,7 +39,7 @@ def _solve_block(X: TensorBlock, Y: TensorBlock) -> TensorBlock:
     Y_n_properties = Y.values.shape[-1]
     Y_values = Y.values.reshape(-1, Y_n_properties)
 
-    _check_same_gradients_raise(X, Y, fname="solve")
+    check_same_gradients_raise(X, Y, fname="solve")
 
     for parameter, X_gradient in X.gradients():
         X_gradient_values = X_gradient.values.reshape(-1, X_n_properties)
@@ -123,7 +123,7 @@ def solve(X: TensorMap, Y: TensorMap) -> TensorMap:
     >>> print(c.block().values)
     [[ 9.67680334 42.12534656]]
     """
-    _check_same_keys_raise(X, Y, "solve")
+    check_same_keys_raise(X, Y, "solve")
 
     for X_block in X.blocks():
         shape = X_block.values.shape

--- a/python/metatensor_operations/metatensor_operations/_utils.py
+++ b/python/metatensor_operations/metatensor_operations/_utils.py
@@ -9,25 +9,25 @@ class NotEqualError(Exception):
     pass
 
 
-def _check_same_keys(a: TensorMap, b: TensorMap, fname: str) -> bool:
+def check_same_keys(a: TensorMap, b: TensorMap, fname: str) -> bool:
     """
     Returns true if the keys of 2 TensorMaps are the same, without specification of the
     order, and false otherwise.
     """
-    return not bool(_check_same_keys_impl(a, b, fname))
+    return not bool(check_same_keys_impl(a, b, fname))
 
 
-def _check_same_keys_raise(a: TensorMap, b: TensorMap, fname: str) -> None:
+def check_same_keys_raise(a: TensorMap, b: TensorMap, fname: str) -> None:
     """
     If the keys of 2 TensorMaps are not the same, raises a NotEqualError, otherwise
     returns None.
     """
-    message = _check_same_keys_impl(a, b, fname)
+    message = check_same_keys_impl(a, b, fname)
     if message != "":
         raise NotEqualError(message)
 
 
-def _check_same_keys_impl(a: TensorMap, b: TensorMap, fname: str) -> str:
+def check_same_keys_impl(a: TensorMap, b: TensorMap, fname: str) -> str:
     """
     Checks if the keys of 2 TensorMaps are the same, without specification of the order.
     Returns an empty str if they are the same, otherwise returns a str message of a
@@ -63,7 +63,7 @@ def _check_same_keys_impl(a: TensorMap, b: TensorMap, fname: str) -> str:
     return ""
 
 
-def _check_blocks(
+def check_blocks(
     a: TensorBlock,
     b: TensorBlock,
     fname: str,
@@ -73,10 +73,10 @@ def _check_blocks(
     Checks if the metadata of 2 TensorBlocks are the same. If not, returns false.
     Otherwise returns true.
     """
-    return not bool(_check_blocks_impl(a, b, fname, check))
+    return not bool(check_blocks_impl(a, b, fname, check))
 
 
-def _check_blocks_raise(
+def check_blocks_raise(
     a: TensorBlock,
     b: TensorBlock,
     fname: str,
@@ -88,7 +88,7 @@ def _check_blocks_raise(
     Otherwise returns it None.
 
     The message associated with the exception will contain more information on where the
-    two :py:class:`TensorBlock` differ. See :py:func:`_check_blocks_impl` for more
+    two :py:class:`TensorBlock` differ. See :py:func:`check_blocks_impl` for more
     information on when two :py:class:`TensorBlock` are considered as equal.
 
     :param a: first :py:class:`TensorBlock` for check
@@ -104,12 +104,12 @@ def _check_blocks_raise(
     :raises: :py:class:`ValueError` if an invalid prop name in :param check: is
         given. See :param check: description for valid prop names
     """
-    message = _check_blocks_impl(a, b, fname, check)
+    message = check_blocks_impl(a, b, fname, check)
     if message != "":
         raise NotEqualError(message)
 
 
-def _check_blocks_impl(
+def check_blocks_impl(
     a: TensorBlock,
     b: TensorBlock,
     fname: str,
@@ -173,7 +173,7 @@ def _check_blocks_impl(
     return ""
 
 
-def _check_same_gradients(
+def check_same_gradients(
     a: TensorBlock,
     b: TensorBlock,
     fname: str,
@@ -197,10 +197,10 @@ def _check_same_gradients(
         ``'all'`` to check everything. Defaults to ``'all'``. If you only want to check
         if the two blocks have the same gradients, pass an empty list ``check=[]``.
     """
-    return not bool(_check_same_gradients_impl(a, b, fname, check))
+    return not bool(check_same_gradients_impl(a, b, fname, check))
 
 
-def _check_same_gradients_raise(
+def check_same_gradients_raise(
     a: TensorBlock,
     b: TensorBlock,
     fname: str,
@@ -211,7 +211,7 @@ def _check_same_gradients_raise(
 
     The message associated with the exception will contain more information on where the
     gradients of the two :py:class:`TensorBlock` differ. See
-    :py:func:`_check_same_gradients_impl` for more information on when gradients of
+    :py:func:`check_same_gradients_impl` for more information on when gradients of
     :py:class:`TensorBlock` are considered as equal.
 
     :param a: first :py:class:`TensorBlock` for check
@@ -228,12 +228,12 @@ def _check_same_gradients_raise(
     :raises: :py:class:`ValueError` if an invalid prop name in :param check: is
         given. See :param check: description for valid prop names
     """
-    message = _check_same_gradients_impl(a, b, fname, check)
+    message = check_same_gradients_impl(a, b, fname, check)
     if message != "":
         raise NotEqualError(message)
 
 
-def _check_same_gradients_impl(
+def check_same_gradients_impl(
     a: TensorBlock,
     b: TensorBlock,
     fname: str,
@@ -311,7 +311,7 @@ def _check_same_gradients_impl(
     return ""
 
 
-def _check_gradient_presence_raise(
+def check_gradient_presence_raise(
     block: TensorBlock,
     parameters: List[str],
     fname: str,

--- a/python/metatensor_operations/metatensor_operations/_zeros_like.py
+++ b/python/metatensor_operations/metatensor_operations/_zeros_like.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Union
 
 from . import _dispatch
 from ._backend import TensorBlock, TensorMap, torch_jit_script
-from ._utils import _check_gradient_presence_raise
+from ._utils import check_gradient_presence_raise
 
 
 @torch_jit_script
@@ -42,7 +42,7 @@ def zeros_like_block(
     if gradients is None:
         gradients = block.gradients_list()
     else:
-        _check_gradient_presence_raise(
+        check_gradient_presence_raise(
             block=block, parameters=gradients, fname="zeros_like"
         )
 


### PR DESCRIPTION
Just some drive-by cleanup for this code. Since the module is already private there is no point marking the functions as private as well.

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
