### PR TITLE
Select between deep and shallow copies for TensorMap and TensorlBlock

### DIFF
--- a/metatensor-core/CHANGELOG.md
+++ b/metatensor-core/CHANGELOG.md
@@ -99,6 +99,11 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
   `ExternalCpuArray`. It wraps non-Python CUDA data as a `torch.Tensor` via
   DLPack, for use with external array backends that store data on CUDA devices.
 
+#### Changed
+
+- `TensorBlock.copy` and `TensorMap.copy` now accept a `deep` parameter to
+  control whether to perform a deep or shallow copy.
+
 #### Removed
 
 - `LabelsView` has been removed, and with it the following functions:

--- a/metatensor-torch/CHANGELOG.md
+++ b/metatensor-torch/CHANGELOG.md
@@ -28,6 +28,8 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
   `TensorBlock::release`, which moves the data out of the `TensorBlockHolder`.
 - `TensorMap` now takes full ownership of the blocks passed to it, they are no
   longer usable afterward.
+- `TensorBlock::copy` and `TensorMap::copy` now accept a `deep` parameter to
+  control whether to perform a deep or shallow copy.
 
 ### Removed
 

--- a/metatensor-torch/include/metatensor/torch/block.hpp
+++ b/metatensor-torch/include/metatensor/torch/block.hpp
@@ -39,9 +39,12 @@ public:
     /// object, making sure a reference to it is kept around.
     TensorBlockHolder(metatensor::TensorBlock block, torch::IValue parent);
 
-    /// Make a copy of this `TensorBlockHolder`, including all the data
-    /// contained inside
-    TensorBlock copy() const;
+    /// Make a copy of this `TensorBlockHolder`.
+    ///
+    /// If `deep` is `true`, the values and labels will be copied as well;
+    /// otherwise, the new `TensorBlockHolder` will increase the reference count
+    /// of the values and labels and return a shallow copy.
+    TensorBlock copy(bool deep = true) const;
 
     /// Get a view in the values in this block
     torch::Tensor values() const;

--- a/metatensor-torch/include/metatensor/torch/tensor.hpp
+++ b/metatensor-torch/include/metatensor/torch/tensor.hpp
@@ -27,8 +27,12 @@ public:
     /// Create a new `TensorMapHolder` for TorchScript.
     TensorMapHolder(Labels keys, std::vector<TensorBlock> blocks);
 
-    /// Make a copy of this `TensorMap`, including all the data contained inside
-    TensorMap copy() const;
+    /// Make a copy of this `TensorMap`.
+    ///
+    /// If `deep` is `true`, the blocks and their data will be copied as well;
+    /// otherwise, the new `TensorMap` will increase the reference count of the
+    /// blocks' data and return a shallow copy.
+    TensorMap copy(bool deep = true);
 
     /// Get the keys for this `TensorMap`
     Labels keys() const;

--- a/metatensor-torch/src/block.cpp
+++ b/metatensor-torch/src/block.cpp
@@ -71,8 +71,28 @@ TensorBlockHolder::TensorBlockHolder(metatensor::TensorBlock block, std::string 
     parent_(std::move(parent))
 {}
 
-TensorBlock TensorBlockHolder::copy() const {
-    return torch::make_intrusive<TensorBlockHolder>(this->block_.clone(), torch::IValue());
+TensorBlock TensorBlockHolder::copy(bool deep) const {
+    if (deep) {
+        return torch::make_intrusive<TensorBlockHolder>(this->block_.clone(), torch::IValue());
+    } else {
+        auto new_block = torch::make_intrusive<TensorBlockHolder>(TensorBlockHolder(
+            this->values(),
+            this->samples(),
+            this->components(),
+            this->properties()
+        ));
+
+        for (const auto& parameter: this->gradients_list()) {
+            auto gradient = TensorBlockHolder(
+                this->block_.gradient(parameter),
+                torch::IValue()
+            );
+
+            new_block->add_gradient(parameter, gradient.copy(/*deep=*/false));
+        }
+
+        return new_block;
+    }
 }
 
 TensorBlock TensorBlockHolder::to(

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -204,7 +204,7 @@ TORCH_LIBRARY(metatensor, m) {
         .def("__repr__", &TensorBlockHolder::repr)
         .def("__str__", &TensorBlockHolder::repr)
         .def("__len__", &TensorBlockHolder::len )
-        .def("copy", &TensorBlockHolder::copy)
+        .def("copy", &TensorBlockHolder::copy, DOCSTRING, {torch::arg("deep") = true})
         .def_property("values", &TensorBlockHolder::values, block_values_setter)
         .def_property("samples", &TensorBlockHolder::samples)
         .def_property("components", &TensorBlockHolder::components)
@@ -253,7 +253,7 @@ TORCH_LIBRARY(metatensor, m) {
         .def("__getitem__", &TensorMapHolder::block_torch, DOCSTRING,
             {torch::arg("selection")}
         )
-        .def("copy", &TensorMapHolder::copy)
+        .def("copy", &TensorMapHolder::copy, DOCSTRING, {torch::arg("deep") = true})
         .def("save", &TensorMapHolder::save, DOCSTRING, {torch::arg("file")})
         .def("save_buffer", &TensorMapHolder::save_buffer)
         .def_static("load", &TensorMapHolder::load)

--- a/metatensor-torch/src/tensor.cpp
+++ b/metatensor-torch/src/tensor.cpp
@@ -46,8 +46,18 @@ TensorMapHolder::TensorMapHolder(Labels keys, std::vector<TensorBlock> blocks):
     tensor_(keys->as_metatensor(), blocks_from_torch(keys, std::move(blocks)))
 {}
 
-TensorMap TensorMapHolder::copy() const {
-    return torch::make_intrusive<TensorMapHolder>(TensorMapHolder(this->tensor_.clone()));
+TensorMap TensorMapHolder::copy(bool deep) {
+    if (deep) {
+        return torch::make_intrusive<TensorMapHolder>(TensorMapHolder(this->tensor_.clone()));
+    } else {
+        auto blocks = std::vector<TensorBlock>();
+        for (size_t i=0; i<this->keys()->count(); i++) {
+            auto block = this->tensor_.block_by_id(i);
+            auto torch_block = TensorBlockHolder(std::move(block), /*parent=*/torch::IValue());
+            blocks.push_back(torch_block.copy(/*deep=*/false));
+        }
+        return torch::make_intrusive<TensorMapHolder>(this->keys(), std::move(blocks));
+    }
 }
 
 Labels TensorMapHolder::keys() const {

--- a/python/metatensor_core/metatensor/_block.py
+++ b/python/metatensor_core/metatensor/_block.py
@@ -175,13 +175,10 @@ class TensorBlock:
                 self._lib.mts_block_free(self._actual_ptr)
 
     def __copy__(self):
-        raise ValueError(
-            "shallow copies of TensorBlock are not possible, use a deepcopy instead"
-        )
+        return self.copy(deep=False)
 
     def __deepcopy__(self, _memodict):
-        new_ptr = self._lib.mts_block_copy(self._ptr)
-        return TensorBlock._from_ptr(new_ptr, parent=None)
+        return self.copy(deep=True)
 
     def __reduce__(self):
         raise NotImplementedError(
@@ -203,11 +200,30 @@ class TensorBlock:
         """
         return self.values.shape
 
-    def copy(self) -> "TensorBlock":
+    def copy(self, deep: bool = True) -> "TensorBlock":
         """
-        get a deep copy of this block, including all the data and metadata
+        Get a copy of this block, with the same values and labels. If ``deep`` is
+        ``True``, also make a full copy of the values; otherwise, the values in the new
+        block will share the same memory as those in this block.
+
+        :param deep: if ``True``, create a deep copy of the block
         """
-        return copy.deepcopy(self)
+        if deep:
+            new_ptr = self._lib.mts_block_copy(self._ptr)
+            return TensorBlock._from_ptr(new_ptr, parent=None)
+        else:
+            new_block = TensorBlock(
+                values=self.values,
+                samples=self.samples,
+                components=self.components,
+                properties=self.properties,
+            )
+
+            for parameter in self.gradients_list():
+                gradient = self.gradient(parameter)
+                new_block.add_gradient(parameter, gradient.copy(deep=False))
+
+            return new_block
 
     def __repr__(self) -> str:
         if self._actual_ptr is None:

--- a/python/metatensor_core/metatensor/_tensor.py
+++ b/python/metatensor_core/metatensor/_tensor.py
@@ -1,4 +1,3 @@
-import copy
 import ctypes
 import pathlib
 import warnings
@@ -131,19 +130,26 @@ class TensorMap:
             self._lib.mts_tensormap_free(self._ptr)
 
     def __copy__(self):
-        raise ValueError(
-            "shallow copies of TensorMap are not possible, use a deepcopy instead"
-        )
+        return self.copy(deep=False)
 
     def __deepcopy__(self, _memodict):
-        new_ptr = self._lib.mts_tensormap_copy(self._ptr)
-        return TensorMap._from_ptr(new_ptr)
+        return self.copy(deep=True)
 
-    def copy(self) -> "TensorMap":
+    def copy(self, deep: bool = True) -> "TensorMap":
         """
-        Get a deep copy of this TensorMap, including all the data and metadata
+        Get a copy of this :py:class:`TensorMap`, with the same keys and blocks. If
+        ``deep`` is ``True``, also make a full copy of the blocks values; otherwise, the
+        blocks values in the new :py:class:`TensorMap` will share the same memory as
+        those in this :py:class:`TensorMap`.
+
+        :param deep: if ``True``, create a deep copy of the blocks in the map
         """
-        return copy.deepcopy(self)
+        if deep:
+            new_ptr = self._lib.mts_tensormap_copy(self._ptr)
+            return TensorMap._from_ptr(new_ptr)
+        else:
+            new_blocks = [block.copy(deep=False) for block in self.blocks()]
+            return TensorMap(keys=self.keys, blocks=new_blocks)
 
     def __len__(self):
         return len(self.keys)

--- a/python/metatensor_core/tests/blocks.py
+++ b/python/metatensor_core/tests/blocks.py
@@ -269,7 +269,7 @@ def test_gradients(block_components):
     assert_equal(gradient.values, np.full((2, 3, 2, 2), 11.0))
 
 
-def test_copy():
+def test_deep_copy():
     block = TensorBlock(
         values=np.full((3, 3, 2), 2.0),
         samples=Labels(["s"], np.array([[0], [2], [4]])),
@@ -282,10 +282,58 @@ def test_copy():
     # using TensorBlock.copy
     clone = block.copy()
     block_values_id = id(block.values)
+    samples_values_id = id(block.samples.values)
+    component_values_id = id(block.components[0].values)
+    properties_values_id = id(block.properties.values)
 
     del block
 
     assert id(clone.values) != block_values_id
+    assert_equal(clone.values, np.full((3, 3, 2), 2.0))
+
+    # The samples are always shared
+    assert id(clone.samples.values) == samples_values_id
+    assert id(clone.components[0].values) == component_values_id
+    assert id(clone.properties.values) == properties_values_id
+
+    # using copy.deepcopy
+    other_clone = copy.deepcopy(clone)
+    block_values_id = id(clone.values)
+
+    del clone
+
+    assert id(other_clone.values) != block_values_id
+    assert_equal(other_clone.values, np.full((3, 3, 2), 2.0))
+
+    assert id(other_clone.samples.values) == samples_values_id
+    assert id(other_clone.components[0].values) == component_values_id
+    assert id(other_clone.properties.values) == properties_values_id
+
+
+def test_shallow_copy():
+    block = TensorBlock(
+        values=np.full((3, 3, 2), 2.0),
+        samples=Labels(["s"], np.array([[0], [2], [4]])),
+        components=[
+            Labels(["c_1"], np.array([[-1], [0], [1]])),
+        ],
+        properties=Labels(["p"], np.array([[5], [3]])),
+    )
+
+    # using TensorBlock.copy
+    clone = block.copy(deep=False)
+    block_values_id = id(block.values)
+    samples_values_id = id(block.samples.values)
+    component_values_id = id(block.components[0].values)
+    properties_values_id = id(block.properties.values)
+
+    del block
+
+    assert id(clone.values) == block_values_id
+    # The samples are always shared
+    assert id(clone.samples.values) == samples_values_id
+    assert id(clone.components[0].values) == component_values_id
+    assert id(clone.properties.values) == properties_values_id
 
     assert_equal(clone.values, np.full((3, 3, 2), 2.0))
     assert clone.samples.names == ["s"]
@@ -294,20 +342,17 @@ def test_copy():
     assert tuple(clone.samples[1]) == (2,)
     assert tuple(clone.samples[2]) == (4,)
 
-    # using copy.deepcopy
-    other_clone = clone.copy()
-    block_values_id = id(clone.values)
+    # using copy.copy
+    other_clone = copy.copy(clone)
 
     del clone
 
-    assert id(other_clone.values) != block_values_id
+    assert id(other_clone.values) == block_values_id
     assert_equal(other_clone.values, np.full((3, 3, 2), 2.0))
 
-
-def test_shallow_copy_error(block):
-    msg = "shallow copies of TensorBlock are not possible, use a deepcopy instead"
-    with pytest.raises(ValueError, match=msg):
-        copy.copy(block)
+    assert id(other_clone.samples.values) == samples_values_id
+    assert id(other_clone.components[0].values) == component_values_id
+    assert id(other_clone.properties.values) == properties_values_id
 
 
 def test_nested_gradients():

--- a/python/metatensor_core/tests/tensor.py
+++ b/python/metatensor_core/tests/tensor.py
@@ -94,8 +94,8 @@ def test_constructor_errors():
         TensorMap(keys, ["block"])
 
 
-def test_copy():
-    # Do not use a fixture here because we want exactly on reference in the copy test.
+def test_deep_copy():
+    # Do not use a fixture here because we want exactly one reference in the copy test.
     tensor = _tests_utils.tensor()
     # Using TensorMap.copy
     clone = tensor.copy()
@@ -124,10 +124,34 @@ def test_copy():
     assert_equal(other_clone.block(0).values, np.full((3, 1, 1), 1.0))
 
 
-def test_shallow_copy_error(tensor):
-    msg = "shallow copies of TensorMap are not possible, use a deepcopy instead"
-    with pytest.raises(ValueError, match=msg):
-        copy.copy(tensor)
+def test_shallow_copy():
+    # Do not use a fixture here because we want exactly on reference in the copy test.
+    tensor = _tests_utils.tensor()
+    # Using TensorMap.copy
+    clone = tensor.copy(deep=False)
+    block_1_values_id = id(tensor.block(0).values)
+
+    # We should have exactly 2 references to the object: one in this function,
+    # and one passed to `sys.getrefcount`
+    if sys.version_info >= (3, 14):
+        # Python 3.14 has an optimization to avoid temporary references
+        assert sys.getrefcount(tensor) == 1
+    else:
+        assert sys.getrefcount(tensor) == 2
+
+    del tensor
+
+    # The values should have the same id
+    assert id(clone.block(0).values) == block_1_values_id
+    assert_equal(clone.block(0).values, np.full((3, 1, 1), 1.0))
+
+    # Using copy.copy
+    other_clone = copy.copy(clone)
+
+    del clone
+
+    assert id(other_clone.block(0).values) == block_1_values_id
+    assert_equal(other_clone.block(0).values, np.full((3, 1, 1), 1.0))
 
 
 def test_keys(tensor):

--- a/python/metatensor_torch/metatensor_torch/_documentation.py
+++ b/python/metatensor_torch/metatensor_torch/_documentation.py
@@ -772,8 +772,14 @@ class TensorBlock:
         """
         raise THIS_CODE_SHOULD_NOT_RUN
 
-    def copy(self) -> "TensorBlock":
-        """get a deep copy of this block, including all the data and metadata"""
+    def copy(self, deep: bool = True) -> "TensorBlock":
+        """
+        Get a copy of this block, with the same values and labels. If ``deep`` is
+        ``True``, also make a full copy of the values; otherwise, the values in the new
+        block will share the same memory as those in this block.
+
+        :param deep: if ``True``, create a deep copy of the block
+        """
         raise THIS_CODE_SHOULD_NOT_RUN
 
     def add_gradient(self, parameter: str, gradient: "TensorBlock"):
@@ -1092,10 +1098,14 @@ class TensorMap:
         """
         raise THIS_CODE_SHOULD_NOT_RUN
 
-    def copy(self) -> "TensorMap":
+    def copy(self, deep: bool = True) -> "TensorMap":
         """
-        get a deep copy of this :py:class:`TensorMap`, including all the data
-        and metadata
+        Get a copy of this :py:class:`TensorMap`, with the same keys and blocks. If
+        ``deep`` is ``True``, also make a full copy of the blocks values; otherwise, the
+        blocks values in the new :py:class:`TensorMap` will share the same memory as
+        those in this :py:class:`TensorMap`.
+
+        :param deep: if ``True``, create a deep copy of the blocks in the map
         """
         raise THIS_CODE_SHOULD_NOT_RUN
 

--- a/python/metatensor_torch/tests/block.py
+++ b/python/metatensor_torch/tests/block.py
@@ -112,7 +112,7 @@ def test_repr():
     assert repr(block.gradient("g")) == expected
 
 
-def test_copy():
+def test_deep_copy():
     values = torch.full((3, 2), 11)
     block = TensorBlock(
         values=values,
@@ -127,6 +127,23 @@ def test_copy():
     del block
 
     assert values.data_ptr() != clone.values.data_ptr()
+
+
+def test_shallow_copy():
+    values = torch.full((3, 2), 11)
+    block = TensorBlock(
+        values=values,
+        samples=Labels(names=["s"], values=torch.tensor([[0], [2], [1]])),
+        components=[],
+        properties=Labels(names=["p"], values=torch.tensor([[1], [0]])),
+    )
+
+    assert values.data_ptr() == block.values.data_ptr()
+
+    clone = block.copy(deep=False)
+    del block
+
+    assert values.data_ptr() == clone.values.data_ptr()
 
 
 def test_gradients():

--- a/python/metatensor_torch/tests/tensor.py
+++ b/python/metatensor_torch/tests/tensor.py
@@ -534,6 +534,42 @@ def test_to(tensor):
         moved = tensor.to(torch.tensor([0]))
 
 
+def test_deep_copy():
+    values = torch.full((3, 2), 11)
+    block = TensorBlock(
+        values=values,
+        samples=Labels(names=["s"], values=torch.tensor([[0], [2], [1]])),
+        components=[],
+        properties=Labels(names=["p"], values=torch.tensor([[1], [0]])),
+    )
+    tensor = TensorMap(keys=Labels.range("keys", 1), blocks=[block])
+
+    assert values.data_ptr() == tensor.block().values.data_ptr()
+
+    clone = tensor.copy()
+    del tensor
+
+    assert values.data_ptr() != clone.block().values.data_ptr()
+
+
+def test_shallow_copy():
+    values = torch.full((3, 2), 11)
+    block = TensorBlock(
+        values=values,
+        samples=Labels(names=["s"], values=torch.tensor([[0], [2], [1]])),
+        components=[],
+        properties=Labels(names=["p"], values=torch.tensor([[1], [0]])),
+    )
+    tensor = TensorMap(keys=Labels.range("keys", 1), blocks=[block])
+
+    assert values.data_ptr() == tensor.block().values.data_ptr()
+
+    clone = tensor.copy(deep=False)
+    del tensor
+
+    assert values.data_ptr() == clone.block().values.data_ptr()
+
+
 # This function only works in script mode, because `block.dtype` is always an `int`, and
 # `torch.dtype` is only an int in script mode.
 if os.environ.get("PYTORCH_JIT") == "0":


### PR DESCRIPTION
Ping @pfebrer who asked for it, since we are making another RC we can include the change.

The only surprising thing might be that `copy.copy(tensor)`/`copy.deepcopy(tensor)` will behave differently in -core and -torch. For metatensor-core, this will forward to `tensor.copy(deep=False)`/`tensor.copy(deep=True)`; but for metatensor-torch the deepcopy will go through a full serialization.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?
