### PR TITLE
 Make sure operations are available as `mts.xxx()` even when metatensor_operations is imported first

### DIFF
--- a/python/metatensor_core/metatensor/__init__.py
+++ b/python/metatensor_core/metatensor/__init__.py
@@ -53,14 +53,27 @@ if HAS_METATENSOR_OPERATIONS:
     from . import operations  # noqa: F401
     from .operations import *  # noqa: F401, F403
 
-else:
-    # __getattr__ is called when a module attribute can not be found, we use it to give
-    # the user a better error message if they don't have metatensor-operations
-    def __getattr__(name):
-        raise AttributeError(
-            f"metatensor.{name} is not defined, are you sure you have the "
-            "metatensor-operations package installed?"
-        )
+
+# __getattr__ is called when a module attribute can not be found. We use it to provide
+# access to symbols from metatensor-operations even if this module was imported while
+# metatensor-operations was still initializing, and to provide a clearer error message
+# when metatensor-operations is not installed.
+def __getattr__(name):
+    if HAS_METATENSOR_OPERATIONS:
+        from . import operations
+
+        try:
+            # Mimic the behavior of "from .operations import *"
+            value = getattr(operations, name)
+            globals()[name] = value
+            return value
+        except AttributeError:
+            pass
+
+    raise AttributeError(
+        f"metatensor.{name} is not defined, are you sure you have the "
+        "metatensor-operations package installed?"
+    )
 
 
 try:

--- a/python/metatensor_operations/tests/import_order.py
+++ b/python/metatensor_operations/tests/import_order.py
@@ -1,0 +1,22 @@
+# Make sure operations are properly re-exported when metatensor_operations is imported
+# before metatensor.
+import subprocess
+import sys
+
+
+def test_import_order():
+    # run in a subprocess since the current one may have already loaded the modules
+
+    code = """
+import metatensor_operations
+import metatensor as mts
+
+assert hasattr(mts, "allclose")
+assert hasattr(mts, "allclose_block")
+assert hasattr(mts, "block_from_array")
+assert hasattr(mts, "join")
+assert hasattr(mts, "split")
+assert hasattr(mts, "zeros_like")
+"""
+
+    subprocess.run([sys.executable, "-c", code], check=True)

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ packaging_deps =
 testing_deps =
     pytest
     pytest-cov
+    pytest-custom_exit_code
     toml
     vesin
 
@@ -202,9 +203,16 @@ commands =
 
     # metatensor-core is installed by tox
     # install metatensor and other dependencies
-    uv pip install . python/metatensor_operations python/metatensor_learn python/metatensor_torch {[testenv]build_single_wheel} --force-reinstall
+    uv pip install {[testenv]build_single_wheel} --force-reinstall \
+        python/metatensor_operations \
+        python/metatensor_learn \
+        python/metatensor_torch
+
     # run documentation tests
-    pytest --doctest-modules --pyargs metatensor
+    pytest --suppress-no-test-exit-code --doctest-modules --pyargs metatensor
+    pytest --suppress-no-test-exit-code --doctest-modules --pyargs metatensor_operations
+    pytest --suppress-no-test-exit-code --doctest-modules --pyargs metatensor_learn
+    pytest --suppress-no-test-exit-code --doctest-modules --pyargs metatensor_torch
 
 
 [testenv:lint]


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
