### PR TITLE
Add missing `Tensor{Block,Map}::{device,dtype}` in Rust

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -129,13 +129,17 @@ jobs:
           echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
           echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
 
-      - name: run tests
+      - name: Build the code
         run: |
-          cargo test --package metatensor --package metatensor-core --target ${{ matrix.rust-target }} ${{ matrix.cargo-build-flags }}
+          cargo build --package metatensor --package metatensor-core --target ${{ matrix.rust-target }} ${{ matrix.cargo-build-flags }}
 
       - name: check that the header is already generated and up to date
         run: |
           git diff --exit-code
+
+      - name: run tests
+        run: |
+          cargo test --package metatensor --package metatensor-core --target ${{ matrix.rust-target }} ${{ matrix.cargo-build-flags }}
 
       - name: check that the code can be compiled as a standalone crate
         if: matrix.os != 'windows-2022'

--- a/metatensor-core/include/metatensor.h
+++ b/metatensor-core/include/metatensor.h
@@ -21,9 +21,9 @@
  * The value 0 (`MTS_SUCCESS`) is used to indicate successful operations.
  */
 enum mts_status_t
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : int32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   /**
    * Status code used when a function succeeded
@@ -62,7 +62,11 @@ enum mts_status_t
   MTS_INTERNAL_ERROR = 255,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum mts_status_t mts_status_t;
+#else
 typedef int32_t mts_status_t;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 /**

--- a/metatensor-core/tests/utils/mod.rs
+++ b/metatensor-core/tests/utils/mod.rs
@@ -5,6 +5,54 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+fn cargo_target_dirs() -> Vec<PathBuf> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir.parent().unwrap_or(&manifest_dir);
+
+    let mut target_dirs = vec![workspace_root.join("target")];
+    if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR") {
+        let target_dir = PathBuf::from(target_dir);
+        if target_dir.is_absolute() {
+            target_dirs.push(target_dir);
+        } else {
+            target_dirs.push(workspace_root.join(target_dir));
+        }
+    }
+
+    return target_dirs;
+}
+
+fn remove_cargo_paths_from_dynamic_library_env(command: &mut Command) {
+    let target_dirs = cargo_target_dirs();
+
+    for var in ["LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH", "DYLD_FALLBACK_LIBRARY_PATH"] {
+        let Some(value) = std::env::var_os(var) else {
+            continue;
+        };
+
+        let mut entries = Vec::new();
+        let mut removed_path = false;
+        for entry in std::env::split_paths(&value) {
+            if target_dirs.iter().any(|root| entry.starts_with(root)) {
+                removed_path = true;
+            } else {
+                entries.push(entry);
+            }
+        }
+
+        if !removed_path {
+            continue;
+        }
+
+        if entries.is_empty() {
+            command.env_remove(var);
+        } else {
+            let joined = std::env::join_paths(entries).unwrap_or_else(|_| panic!("failed to rebuild {}", var));
+            command.env(var, joined);
+        }
+    }
+}
+
 fn build_type() -> &'static str {
     // assume that debug assertion means that we are building the code in
     // debug mode, even if that could be not true in some cases
@@ -76,6 +124,10 @@ pub fn ctest(build_dir: &Path) -> Command {
     ctest.arg("--output-on-failure");
     ctest.arg("--build-config");
     ctest.arg(build_type());
+
+    // `cargo test` injects dynamic-library search paths for the cargo target
+    // dir. Remove only these injected entries and keep any user-provided paths.
+    remove_cargo_paths_from_dynamic_library_env(&mut ctest);
 
     return ctest
 }

--- a/rust/metatensor/CHANGELOG.md
+++ b/rust/metatensor/CHANGELOG.md
@@ -16,6 +16,12 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
+### Added
+
+- `TensorMap::device`, `TensorMap::dtype`, `TensorBlock::device`, and
+  `TensorBlock::dtype` for retrieving the device and data type of the underlying
+  arrays.
+
 ## [Version 0.3.0](https://github.com/metatensor/metatensor/releases/tag/metatensor-rust-v0.3.0) - 2026-05-13
 
 ### Added

--- a/rust/metatensor/src/block/block_mut.rs
+++ b/rust/metatensor/src/block/block_mut.rs
@@ -112,6 +112,18 @@ impl<'a> TensorBlockRefMut<'a> {
         }
     }
 
+    /// Get the device on which the values of this block are stored.
+    #[inline]
+    pub fn device(&self) -> Result<dlpk::sys::DLDevice, Error> {
+        self.as_ref().device()
+    }
+
+    /// Get the data type of the values of this block.
+    #[inline]
+    pub fn dtype(&self) -> Result<dlpk::sys::DLDataType, Error> {
+        self.as_ref().dtype()
+    }
+
     /// Get a mutable reference to the values in this block
     #[inline]
     pub fn values_mut(&mut self) -> ArrayRefMut<'_> {
@@ -300,5 +312,23 @@ mod tests {
         assert_eq!(*block.samples, Labels::new(["samples"], &[[0], [1]]));
         assert_eq!(*block.components, [Labels::new(["component"], &[[0]])]);
         assert_eq!(*block.properties, Labels::new(["properties"], &[[-2], [0], [1]]));
+    }
+
+    #[test]
+    fn device_and_dtype() {
+        let mut block = TensorBlock::new(
+            ndarray::Array::from_elem(vec![2, 3], 1.0),
+            &Labels::new(["samples"], &[[0], [1]]),
+            &[],
+            &Labels::new(["properties"], &[[-2], [0], [1]]),
+        ).unwrap();
+        let block = block.as_ref_mut();
+
+        let device = block.device().unwrap();
+        assert_eq!(device.device_type, dlpk::sys::DLDeviceType::kDLCPU);
+
+        let dtype = block.dtype().unwrap();
+        assert_eq!(dtype.code, dlpk::sys::DLDataTypeCode::kDLFloat);
+        assert_eq!(dtype.bits, 64);
     }
 }

--- a/rust/metatensor/src/block/block_ref.rs
+++ b/rust/metatensor/src/block/block_ref.rs
@@ -103,6 +103,36 @@ pub(super) fn get_properties(ptr: *const mts_block_t) -> Labels {
 }
 
 impl<'a> TensorBlockRef<'a> {
+    /// Get the device on which the values of this block are stored.
+    #[inline]
+    pub fn device(&self) -> Result<dlpk::sys::DLDevice, Error> {
+        let mut device = dlpk::sys::DLDevice::cpu();
+        unsafe {
+            check_status(crate::c_api::mts_block_device(
+                self.as_ptr(),
+                &mut device,
+            ))?;
+        }
+        return Ok(device);
+    }
+
+    /// Get the data type of the values of this block.
+    #[inline]
+    pub fn dtype(&self) -> Result<dlpk::sys::DLDataType, Error> {
+        let mut dtype = dlpk::sys::DLDataType {
+            code: dlpk::sys::DLDataTypeCode::kDLFloat,
+            bits: 0,
+            lanes: 0,
+        };
+        unsafe {
+            check_status(crate::c_api::mts_block_dtype(
+                self.as_ptr(),
+                &mut dtype,
+            ))?;
+        }
+        return Ok(dtype);
+    }
+
     /// Get all the data and metadata inside this `TensorBlockRef` as a
     /// struct with separate fields, to allow borrowing them separately.
     #[inline]
@@ -360,5 +390,23 @@ mod tests {
         assert_eq!(*block.samples, Labels::new(["samples"], &[[0], [1]]));
         assert_eq!(*block.components, [Labels::new(["component"], &[[0]])]);
         assert_eq!(*block.properties, Labels::new(["properties"], &[[-2], [0], [1]]));
+    }
+
+    #[test]
+    fn device_and_dtype() {
+        let block = TensorBlock::new(
+            ndarray::Array::from_elem(vec![2, 3], 1.0),
+            &Labels::new(["samples"], &[[0], [1]]),
+            &[],
+            &Labels::new(["properties"], &[[-2], [0], [1]]),
+        ).unwrap();
+        let block = block.as_ref();
+
+        let device = block.device().unwrap();
+        assert_eq!(device.device_type, dlpk::sys::DLDeviceType::kDLCPU);
+
+        let dtype = block.dtype().unwrap();
+        assert_eq!(dtype.code, dlpk::sys::DLDataTypeCode::kDLFloat);
+        assert_eq!(dtype.bits, 64);
     }
 }

--- a/rust/metatensor/src/block/owned.rs
+++ b/rust/metatensor/src/block/owned.rs
@@ -70,6 +70,18 @@ impl TensorBlock {
         }
     }
 
+    /// Get the device on which the values of this block are stored.
+    #[inline]
+    pub fn device(&self) -> Result<dlpk::sys::DLDevice, Error> {
+        self.as_ref().device()
+    }
+
+    /// Get the data type of the values of this block.
+    #[inline]
+    pub fn dtype(&self) -> Result<dlpk::sys::DLDataType, Error> {
+        self.as_ref().dtype()
+    }
+
     /// Get the array for the values in this block
     #[inline]
     pub fn values(&self) -> ArrayRef<'_> {
@@ -213,5 +225,22 @@ mod tests {
         // this is only legal because TensorBlock == *mut mts_block_t
         assert_eq!(std::mem::size_of::<TensorBlock>(), std::mem::size_of::<*mut mts_block_t>());
         assert_eq!(std::mem::align_of::<TensorBlock>(), std::mem::align_of::<*mut mts_block_t>());
+    }
+
+    #[test]
+    fn device_and_dtype() {
+        let block = TensorBlock::new(
+            ndarray::Array::from_elem(vec![2, 3], 1.0),
+            &Labels::new(["samples"], &[[0], [1]]),
+            &[],
+            &Labels::new(["properties"], &[[-2], [0], [1]]),
+        ).unwrap();
+
+        let device = block.device().unwrap();
+        assert_eq!(device.device_type, dlpk::sys::DLDeviceType::kDLCPU);
+
+        let dtype = block.dtype().unwrap();
+        assert_eq!(dtype.code, dlpk::sys::DLDataTypeCode::kDLFloat);
+        assert_eq!(dtype.bits, 64);
     }
 }

--- a/rust/metatensor/src/tensor.rs
+++ b/rust/metatensor/src/tensor.rs
@@ -153,6 +153,36 @@ impl TensorMap {
         return crate::io::save_buffer(self, buffer);
     }
 
+    /// Get the device on which the values of this `TensorMap` are stored.
+    #[inline]
+    pub fn device(&self) -> Result<dlpk::sys::DLDevice, Error> {
+        let mut device = dlpk::sys::DLDevice::cpu();
+        unsafe {
+            check_status(crate::c_api::mts_tensormap_device(
+                self.ptr,
+                &mut device,
+            ))?;
+        }
+        return Ok(device);
+    }
+
+    /// Get the data type of the values of this `TensorMap`.
+    #[inline]
+    pub fn dtype(&self) -> Result<dlpk::sys::DLDataType, Error> {
+        let mut dtype = dlpk::sys::DLDataType {
+            code: dlpk::sys::DLDataTypeCode::kDLFloat,
+            bits: 0,
+            lanes: 0,
+        };
+        unsafe {
+            check_status(crate::c_api::mts_tensormap_dtype(
+                self.ptr,
+                &mut dtype,
+            ))?;
+        }
+        return Ok(dtype);
+    }
+
     /// Get the keys defined in this `TensorMap`
     #[inline]
     pub fn keys(&self) -> &Labels {
@@ -806,5 +836,17 @@ mod tests {
         assert_eq!(key, "version");
         assert_eq!(value, "1.0");
         assert!(info_iter.next().is_none());
+    }
+
+    #[test]
+    fn device_and_dtype() {
+        let tensor = test_tensor();
+
+        let device = tensor.device().unwrap();
+        assert_eq!(device.device_type, dlpk::sys::DLDeviceType::kDLCPU);
+
+        let dtype = tensor.dtype().unwrap();
+        assert_eq!(dtype.code, dlpk::sys::DLDataTypeCode::kDLFloat);
+        assert_eq!(dtype.bits, 64);
     }
 }


### PR DESCRIPTION
Would be useful for https://github.com/metatensor/metatomic/pull/246

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?
