### PR TITLE
Allow transfering ownership of metatensor pointer in all bindings

### DIFF
--- a/metatensor-core/CHANGELOG.md
+++ b/metatensor-core/CHANGELOG.md
@@ -17,6 +17,18 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 #### Removed
 -->
 
+### Added
+
+- `TensorMap::unsafe_from_ptr` to replace the `TensorMap(mts_tensormap_t*)`
+  constructor, for symmetry with the `TensorBlock` API. The constructor is now
+  deprecated and will be removed in a future version.
+- `Labels::unsafe_from_ptr` to create a C++ object from an existing
+  `mts_labels_t` pointer.
+- `TensorMap::unsafe_view_from_ptr` to create a C++ view of an existing
+  TensorMap, as well as `TensorMap::is_view` and `TensorBlock::is_view`.
+- `Labels::release`, `TensorBlock::release`, and `TensorMap::release` to take
+  back ownership of the underlying C API pointers.
+
 ## [Version 0.2.0](https://github.com/metatensor/metatensor/releases/tag/metatensor-core-v0.2.0) - 2026-05-13
 
 ### metatensor-core C

--- a/metatensor-core/CHANGELOG.md
+++ b/metatensor-core/CHANGELOG.md
@@ -17,7 +17,9 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 #### Removed
 -->
 
-### Added
+### metatensor-core C++
+
+#### Added
 
 - `TensorMap::unsafe_from_ptr` to replace the `TensorMap(mts_tensormap_t*)`
   constructor, for symmetry with the `TensorBlock` API. The constructor is now
@@ -28,6 +30,17 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
   TensorMap, as well as `TensorMap::is_view` and `TensorBlock::is_view`.
 - `Labels::release`, `TensorBlock::release`, and `TensorMap::release` to take
   back ownership of the underlying C API pointers.
+
+### metatensor-core Python
+
+#### Added
+
+- `TensorMap.unsafe_from_ptr`, `TensorBlock.unsafe_from_ptr` and
+  `Labels.unsafe_from_ptr` to create Python classes from raw ctypes pointers
+- `TensorMap.unsafe_view_from_ptr` and `TensorBlock.unsafe_view_from_ptr` to
+  create non-owning views of existing raw pointers.
+- `Labels.release`, `TensorBlock.release`, and `TensorMap.release` to take
+  back ownership of the underlying pointers.
 
 ## [Version 0.2.0](https://github.com/metatensor/metatensor/releases/tag/metatensor-core-v0.2.0) - 2026-05-13
 

--- a/metatensor-core/include/metatensor/block.hpp
+++ b/metatensor-core/include/metatensor/block.hpp
@@ -17,6 +17,32 @@ namespace metatensor_torch {
 }
 
 namespace metatensor {
+
+namespace details {
+    inline mts_block_t* create_block(
+        std::unique_ptr<DataArrayBase> values,
+        const Labels& samples,
+        const std::vector<Labels>& components,
+        const Labels& properties
+    ) {
+        auto c_components = std::vector<const mts_labels_t*>();
+        for (const auto& component: components) {
+            c_components.push_back(component.as_mts_labels_t());
+        }
+        auto* block = mts_block(
+            DataArrayBase::to_mts_array(std::move(values)).release(),
+            samples.as_mts_labels_t(),
+            c_components.data(),
+            c_components.size(),
+            properties.as_mts_labels_t()
+        );
+
+        check_pointer(block);
+
+        return block;
+    }
+}
+
 /// Basic building block for a tensor map.
 ///
 /// A single block contains an n-dimensional `mts_array_t` (or `DataArrayBase`),
@@ -43,24 +69,7 @@ public:
         const Labels& samples,
         const std::vector<Labels>& components,
         const Labels& properties
-    ):
-        block_(nullptr),
-        is_view_(false)
-    {
-        auto c_components = std::vector<const mts_labels_t*>();
-        for (const auto& component: components) {
-            c_components.push_back(component.as_mts_labels_t());
-        }
-        block_ = mts_block(
-            DataArrayBase::to_mts_array(std::move(values)).release(),
-            samples.as_mts_labels_t(),
-            c_components.data(),
-            c_components.size(),
-            properties.as_mts_labels_t()
-        );
-
-        details::check_pointer(block_);
-    }
+    ): TensorBlock(details::create_block(std::move(values), samples, components, properties), /*view*/ false) {}
 
     ~TensorBlock() {
         if (!is_view_) {
@@ -135,6 +144,11 @@ public:
         DLDataType dtype;
         details::check_status(mts_block_dtype(this->as_mts_block_t(), &dtype));
         return dtype;
+    }
+
+    /// Check if this block is a view (i.e. does not own the underlying data).
+    bool is_view() const {
+        return is_view_;
     }
 
     /// Get the values in this block as a DLPackArray.
@@ -258,20 +272,22 @@ public:
     mts_block_t* as_mts_block_t() & {
         if (block_ == nullptr) {
             throw Error(
-                "Can not access this TensorBlock, it has been moved inside a "
-                "TensorMap or another TensorBlock"
+                "Can not access this TensorBlock, it has been released or "
+                "moved inside a TensorMap or another TensorBlock"
             );
         }
 
         return block_;
     }
 
-    /// const version of `as_mts_block_t`
+    /// Get the const `mts_block_t` pointer corresponding to this block.
+    ///
+    /// The block pointer is still managed by the current `TensorBlock`
     const mts_block_t* as_mts_block_t() const & {
         if (block_ == nullptr) {
             throw Error(
-                "Can not access this TensorBlock, it has been moved inside a "
-                "TensorMap or another TensorBlock"
+                "Can not access this TensorBlock, it has been released or "
+                "moved inside a TensorMap or another TensorBlock"
             );
         }
 
@@ -282,19 +298,29 @@ public:
 
     /// Create a new TensorBlock taking ownership of a raw `mts_block_t` pointer.
     static TensorBlock unsafe_from_ptr(mts_block_t* ptr) {
-        auto block = TensorBlock();
-        block.block_ = ptr;
-        block.is_view_ = false;
-        return block;
+        return TensorBlock(ptr, /*view=*/false);
     }
 
     /// Create a new TensorBlock which is a view corresponding to a raw
     /// `mts_block_t` pointer.
+    ///
+    /// The view does not own the underlying data and will not free the
+    /// corresponding memory. Callers of this functions are still responsible
+    /// for freeing the block pointer when it is no longer needed.
     static TensorBlock unsafe_view_from_ptr(mts_block_t* ptr) {
-        auto block = TensorBlock();
-        block.block_ = ptr;
-        block.is_view_ = true;
-        return block;
+        return TensorBlock(ptr, /*view=*/true);
+    }
+
+    /// Release the `mts_block_t` pointer corresponding to this `TensorBlock`.
+    ///
+    /// The block pointer is **no longer** managed by the current `TensorBlock`,
+    /// and should manually be freed when no longer required.
+    mts_block_t* release() {
+        this->check_not_view("release");
+        auto* ptr = block_;
+        block_ = nullptr;
+        is_view_ = true;
+        return ptr;
     }
 
     /// Get a raw `MtsArray` corresponding to the values in this block.
@@ -312,7 +338,7 @@ public:
     Labels labels(uintptr_t axis) const {
         const auto* ptr = mts_block_labels(this->as_mts_block_t(), axis);
         details::check_pointer(ptr);
-        return Labels(ptr);
+        return Labels::unsafe_from_ptr(ptr);
     }
 
     /// Get the shape of the value array for this block
@@ -419,11 +445,11 @@ public:
 
 private:
     /// Constructor of a TensorBlock not associated with anything
-    explicit TensorBlock(): block_(nullptr), is_view_(true) {}
+    explicit TensorBlock(): TensorBlock(nullptr, /*view=*/true) {}
 
     /// Create a C++ TensorBlock from a C `mts_block_t` pointer. The C++
-    /// block takes ownership of the C pointer.
-    explicit TensorBlock(mts_block_t* block): block_(block), is_view_(false) {}
+    /// block takes ownership of the C pointer if `view` is false.
+    explicit TensorBlock(mts_block_t* block, bool view): block_(block), is_view_(view) {}
 
     /// Get the `MtsArray` for this block.
     ///
@@ -448,18 +474,6 @@ private:
                 " on this block since it is inside a TensorMap or another TensorBlock"
             );
         }
-    }
-
-    /// Release the `mts_block_t` pointer corresponding to this `TensorBlock`.
-    ///
-    /// The block pointer is **no longer** managed by the current `TensorBlock`,
-    /// and should manually be freed when no longer required.
-    mts_block_t* release() {
-        this->check_not_view("release");
-        auto* ptr = block_;
-        block_ = nullptr;
-        is_view_ = false;
-        return ptr;
     }
 
     friend class TensorMap;

--- a/metatensor-core/include/metatensor/block.hpp
+++ b/metatensor-core/include/metatensor/block.hpp
@@ -272,7 +272,7 @@ public:
     mts_block_t* as_mts_block_t() & {
         if (block_ == nullptr) {
             throw Error(
-                "Can not access this TensorBlock, it has been released or "
+                "can not access this TensorBlock, it has been released or "
                 "moved inside a TensorMap or another TensorBlock"
             );
         }
@@ -286,7 +286,7 @@ public:
     const mts_block_t* as_mts_block_t() const & {
         if (block_ == nullptr) {
             throw Error(
-                "Can not access this TensorBlock, it has been released or "
+                "can not access this TensorBlock, it has been released or "
                 "moved inside a TensorMap or another TensorBlock"
             );
         }

--- a/metatensor-core/include/metatensor/io.hpp
+++ b/metatensor-core/include/metatensor/io.hpp
@@ -136,7 +136,7 @@ namespace io {
     ) {
         auto* ptr = mts_tensormap_load(path.c_str(), create_array);
         details::check_pointer(ptr);
-        return TensorMap(ptr);
+        return TensorMap::unsafe_from_ptr(ptr);
     }
 
     inline TensorMap load_buffer(
@@ -146,7 +146,7 @@ namespace io {
     ) {
         auto* ptr = mts_tensormap_load_buffer(buffer, buffer_count, create_array);
         details::check_pointer(ptr);
-        return TensorMap(ptr);
+        return TensorMap::unsafe_from_ptr(ptr);
     }
 
     template <typename Buffer>
@@ -174,7 +174,7 @@ namespace io {
     ) {
         auto* ptr = mts_block_load(path.c_str(), create_array);
         details::check_pointer(ptr);
-        return TensorBlock(ptr);
+        return TensorBlock::unsafe_from_ptr(ptr);
     }
 
     inline TensorBlock load_block_buffer(
@@ -184,7 +184,7 @@ namespace io {
     ) {
         auto* ptr = mts_block_load_buffer(buffer, buffer_count, create_array);
         details::check_pointer(ptr);
-        return TensorBlock(ptr);
+        return TensorBlock::unsafe_from_ptr(ptr);
     }
 
     template <typename Buffer>

--- a/metatensor-core/include/metatensor/labels.hpp
+++ b/metatensor-core/include/metatensor/labels.hpp
@@ -185,8 +185,30 @@ public:
     }
 
     /// Get the underlying `mts_labels_t` pointer
+    ///
+    /// The pointer is still managed by the current `Labels`
     const mts_labels_t* as_mts_labels_t() const {
+        if (labels_ == nullptr) {
+            throw Error(
+                "Can not access these Labels, they have been released"
+            );
+        }
         return labels_;
+    }
+
+    /// Create a new Labels taking ownership of a raw `mts_labels_t` pointer.
+    static Labels unsafe_from_ptr(const mts_labels_t* ptr) {
+        return Labels(ptr);
+    }
+
+    /// Release the `mts_labels_t` pointer corresponding to this `Labels`.
+    ///
+    /// The pointer is **no longer** managed by the current `Labels`,
+    /// and should manually be freed when no longer required.
+    const mts_labels_t* release() {
+        const auto* ptr = this->labels_;
+        this->labels_ = nullptr;
+        return ptr;
     }
 
     /// Get the position of the `entry` in this set of Labels, or `std::nullopt`
@@ -696,8 +718,6 @@ private:
     friend Labels details::labels_from_cxx(const std::vector<std::string>& names, const int32_t* values, size_t count, bool assume_unique);
     friend Labels io::load_labels(const std::string &path);
     friend Labels io::load_labels_buffer(const uint8_t* buffer, size_t buffer_count);
-    friend class TensorMap;
-    friend class TensorBlock;
 
     friend class metatensor_torch::LabelsHolder;
 

--- a/metatensor-core/include/metatensor/labels.hpp
+++ b/metatensor-core/include/metatensor/labels.hpp
@@ -190,7 +190,7 @@ public:
     const mts_labels_t* as_mts_labels_t() const {
         if (labels_ == nullptr) {
             throw Error(
-                "Can not access these Labels, they have been released"
+                "can not access these Labels, they have been released"
             );
         }
         return labels_;

--- a/metatensor-core/include/metatensor/tensor.hpp
+++ b/metatensor-core/include/metatensor/tensor.hpp
@@ -121,7 +121,7 @@ private:
 class TensorMap final {
 public:
     /// Create a new TensorMap with the given `keys` and `blocks`
-    TensorMap(Labels keys, std::vector<TensorBlock> blocks) {
+    TensorMap(Labels keys, std::vector<TensorBlock> blocks): tensor_(nullptr), is_view_(false) {
         auto c_blocks = std::vector<mts_block_t*>();
         for (auto& block: blocks) {
             // We will move the data inside the new map, let's release the
@@ -139,7 +139,9 @@ public:
     }
 
     ~TensorMap() {
-        mts_tensormap_free(tensor_);
+        if (!is_view_) {
+            mts_tensormap_free(tensor_);
+        }
     }
 
     /// TensorMap can NOT be copy constructed, use TensorMap::clone instead
@@ -148,16 +150,20 @@ public:
     TensorMap& operator=(const TensorMap&) = delete;
 
     /// TensorMap can be move constructed
-    TensorMap(TensorMap&& other) noexcept : TensorMap(nullptr) {
+    TensorMap(TensorMap&& other) noexcept : TensorMap() {
         *this = std::move(other);
     }
 
     /// TensorMap can be move assigned
     TensorMap& operator=(TensorMap&& other) noexcept {
-        mts_tensormap_free(tensor_);
+        if (!is_view_) {
+            mts_tensormap_free(tensor_);
+        }
 
         this->tensor_ = other.tensor_;
+        this->is_view_ = other.is_view_;
         other.tensor_ = nullptr;
+        other.is_view_ = true;
 
         return *this;
     }
@@ -166,7 +172,7 @@ public:
     TensorMap clone() const {
         auto* copy = mts_tensormap_copy(this->tensor_);
         details::check_pointer(copy);
-        return TensorMap(copy);
+        return TensorMap::unsafe_from_ptr(copy);
     }
 
     /// Get a copy of the metadata in this `TensorMap` (i.e. keys, samples,
@@ -209,11 +215,16 @@ public:
         return dtype;
     }
 
+    /// Check if this TensorMap is a view (i.e. does not own the underlying data).
+    bool is_view() const {
+        return is_view_;
+    }
+
     /// Get the set of keys labeling the blocks in this tensor map
     Labels keys() const {
         const auto* ptr = mts_tensormap_keys(tensor_);
         details::check_pointer(ptr);
-        return Labels(ptr);
+        return Labels::unsafe_from_ptr(ptr);
     }
 
     /// Get a block inside this TensorMap by its index/the index of the
@@ -276,7 +287,7 @@ public:
         );
 
         details::check_pointer(ptr);
-        return TensorMap(ptr);
+        return TensorMap::unsafe_from_ptr(ptr);
     }
 
     /// This function calls `keys_to_properties` with an empty set of `Labels`
@@ -372,7 +383,7 @@ public:
         );
 
         details::check_pointer(ptr);
-        return TensorMap(ptr);
+        return TensorMap::unsafe_from_ptr(ptr);
     }
 
     /// This function calls `keys_to_samples` with an empty set of `Labels`
@@ -451,7 +462,7 @@ public:
             c_dimensions.size()
         );
         details::check_pointer(ptr);
-        return TensorMap(ptr);
+        return TensorMap::unsafe_from_ptr(ptr);
     }
 
     /// Call `components_to_properties` with a single dimension
@@ -463,7 +474,7 @@ public:
             1
         );
         details::check_pointer(ptr);
-        return TensorMap(ptr);
+        return TensorMap::unsafe_from_ptr(ptr);
     }
 
     /*!
@@ -566,6 +577,11 @@ public:
     ///
     /// The tensor map pointer is still managed by the current `TensorMap`
     mts_tensormap_t* as_mts_tensormap_t() & {
+        if (tensor_ == nullptr) {
+            throw Error(
+                "Can not access this TensorMap, it has been released"
+            );
+        }
         return tensor_;
     }
 
@@ -573,14 +589,47 @@ public:
     ///
     /// The tensor map pointer is still managed by the current `TensorMap`
     const mts_tensormap_t* as_mts_tensormap_t() const & {
+        if (tensor_ == nullptr) {
+            throw Error(
+                "Can not access this TensorMap, it has been released"
+            );
+        }
         return tensor_;
     }
 
     mts_tensormap_t* as_mts_tensormap_t() && = delete;
 
+    /// Create a new TensorBlock taking ownership of a raw `mts_block_t` pointer.
+    static TensorMap unsafe_from_ptr(mts_tensormap_t* ptr) {
+        return TensorMap(ptr, /*view=*/false);
+    }
+
+    /// Create a new TensorMap which is a view corresponding to a raw
+    /// `mts_tensormap_t` pointer.
+    ///
+    /// The view does not own the underlying data and will not free the
+    /// corresponding memory. Callers of this functions are still responsible
+    /// for freeing the tensor map pointer when it is no longer needed.
+    static TensorMap unsafe_view_from_ptr(mts_tensormap_t* ptr) {
+        return TensorMap(ptr, /*view=*/true);
+    }
+
+    /// Release the `mts_tensormap_t` pointer corresponding to this `TensorMap`.
+    ///
+    /// The block pointer is **no longer** managed by the current `TensorMap`,
+    /// and should manually be freed when no longer required.
+    mts_tensormap_t* release() {
+        this->check_not_view("release");
+        auto* ptr = this->tensor_;
+        this->tensor_ = nullptr;
+        this->is_view_ = true;
+        return ptr;
+    }
+
     /// Create a C++ TensorMap from a C `mts_tensormap_t` pointer. The C++
     /// tensor map takes ownership of the C pointer.
-    explicit TensorMap(mts_tensormap_t* tensor): tensor_(tensor) {}
+    [[deprecated("this will be removed in the next version, use TensorMap::unsafe_from_ptr instead")]]
+    explicit TensorMap(mts_tensormap_t* tensor): tensor_(tensor), is_view_(false) {}
 
     /// Set or update the info `value` associated with `key` for this `TensorMap`.
     void set_info(const std::string& key, const std::string& value) {
@@ -605,7 +654,20 @@ public:
     }
 
 private:
+    TensorMap(): TensorMap(nullptr, true) {}
+    explicit TensorMap(mts_tensormap_t* tensor, bool view): tensor_(tensor), is_view_(view) {}
+
+    void check_not_view(const char* method_name) const {
+        if (is_view_) {
+            throw Error(
+                "can not call TensorMap::" + std::string(method_name) +
+                " on this TensorMap since it is a view"
+            );
+        }
+    }
+
     mts_tensormap_t* tensor_;
+    bool is_view_;
 };
 
 } // namespace metatensor

--- a/metatensor-core/include/metatensor/tensor.hpp
+++ b/metatensor-core/include/metatensor/tensor.hpp
@@ -579,7 +579,7 @@ public:
     mts_tensormap_t* as_mts_tensormap_t() & {
         if (tensor_ == nullptr) {
             throw Error(
-                "Can not access this TensorMap, it has been released"
+                "can not access this TensorMap, it has been released"
             );
         }
         return tensor_;
@@ -591,7 +591,7 @@ public:
     const mts_tensormap_t* as_mts_tensormap_t() const & {
         if (tensor_ == nullptr) {
             throw Error(
-                "Can not access this TensorMap, it has been released"
+                "can not access this TensorMap, it has been released"
             );
         }
         return tensor_;

--- a/metatensor-core/tests/cpp/blocks.cpp
+++ b/metatensor-core/tests/cpp/blocks.cpp
@@ -78,7 +78,9 @@ TEST_CASE("Blocks") {
 
         CHECK(block.gradients_list() == std::vector<std::string>{"parameter"});
 
-        auto gradient_mts_array = block.gradient("parameter").mts_array();
+        auto gradient_view = block.gradient("parameter");
+        CHECK(gradient_view.is_view());
+        auto gradient_mts_array = gradient_view.mts_array();
         CHECK(gradient_mts_array.shape() == std::vector<size_t>{2, 1, 3, 2});
 
         gradient = block.gradient("parameter");
@@ -249,6 +251,53 @@ TEST_CASE("values<T>() with non-double types") {
             Catch::Matchers::Contains("dtype mismatch")
         );
     }
+}
+
+TEST_CASE("TensorBlock ownership transfer") {
+    auto block = TensorBlock(
+        std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({3, 2}, 1.0)),
+        Labels({"samples"}, {{0}, {1}, {4}}),
+        {},
+        Labels({"properties"}, {{5}, {3}})
+    );
+
+    auto* raw = block.release();
+    CHECK_THROWS_WITH(
+        block.as_mts_block_t(),
+        "Can not access this TensorBlock, it has been released or moved inside a TensorMap or another TensorBlock"
+    );
+
+    auto recovered = TensorBlock::unsafe_from_ptr(raw);
+    CHECK(recovered.samples() == Labels({"samples"}, {{0}, {1}, {4}}));
+    CHECK(recovered.properties() == Labels({"properties"}, {{5}, {3}}));
+
+    raw = recovered.release();
+    CHECK_THROWS_WITH(
+        recovered.as_mts_block_t(),
+        "Can not access this TensorBlock, it has been released or moved inside a TensorMap or another TensorBlock"
+    );
+    REQUIRE(mts_block_free(raw) == MTS_SUCCESS);
+}
+
+TEST_CASE("TensorBlock unsafe views") {
+    auto owner = TensorBlock(
+        std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({2, 1}, 3.0)),
+        Labels({"samples"}, {{0}, {1}}),
+        {},
+        Labels({"properties"}, {{0}})
+    );
+
+    CHECK_FALSE(owner.is_view());
+
+    auto* raw = owner.as_mts_block_t();
+    auto view = TensorBlock::unsafe_view_from_ptr(raw);
+
+    CHECK(view.is_view());
+    CHECK(view.samples() == Labels({"samples"}, {{0}, {1}}));
+    CHECK_THROWS_WITH(
+        view.release(),
+        "can not call TensorBlock::release on this block since it is inside a TensorMap or another TensorBlock"
+    );
 }
 
 TEST_CASE("Serialization") {

--- a/metatensor-core/tests/cpp/blocks.cpp
+++ b/metatensor-core/tests/cpp/blocks.cpp
@@ -264,7 +264,7 @@ TEST_CASE("TensorBlock ownership transfer") {
     auto* raw = block.release();
     CHECK_THROWS_WITH(
         block.as_mts_block_t(),
-        "Can not access this TensorBlock, it has been released or moved inside a TensorMap or another TensorBlock"
+        "can not access this TensorBlock, it has been released or moved inside a TensorMap or another TensorBlock"
     );
 
     auto recovered = TensorBlock::unsafe_from_ptr(raw);
@@ -274,7 +274,7 @@ TEST_CASE("TensorBlock ownership transfer") {
     raw = recovered.release();
     CHECK_THROWS_WITH(
         recovered.as_mts_block_t(),
-        "Can not access this TensorBlock, it has been released or moved inside a TensorMap or another TensorBlock"
+        "can not access this TensorBlock, it has been released or moved inside a TensorMap or another TensorBlock"
     );
     REQUIRE(mts_block_free(raw) == MTS_SUCCESS);
 }

--- a/metatensor-core/tests/cpp/labels.cpp
+++ b/metatensor-core/tests/cpp/labels.cpp
@@ -68,7 +68,7 @@ TEST_CASE("ownership transfer") {
     const auto* raw = original.release();
     CHECK_THROWS_WITH(
         original.as_mts_labels_t(),
-        "Can not access these Labels, they have been released"
+        "can not access these Labels, they have been released"
     );
 
     auto recovered = Labels::unsafe_from_ptr(raw);
@@ -77,7 +77,7 @@ TEST_CASE("ownership transfer") {
     raw = recovered.release();
     CHECK_THROWS_WITH(
         recovered.as_mts_labels_t(),
-        "Can not access these Labels, they have been released"
+        "can not access these Labels, they have been released"
     );
     REQUIRE(mts_labels_free(raw) == MTS_SUCCESS);
 }

--- a/metatensor-core/tests/cpp/labels.cpp
+++ b/metatensor-core/tests/cpp/labels.cpp
@@ -62,6 +62,26 @@ TEST_CASE("Labels") {
     CHECK(empty.count() == 0);
 }
 
+TEST_CASE("ownership transfer") {
+    auto original = Labels({"foo", "bar"}, {{1, 2}, {3, 4}, {5, 6}});
+
+    const auto* raw = original.release();
+    CHECK_THROWS_WITH(
+        original.as_mts_labels_t(),
+        "Can not access these Labels, they have been released"
+    );
+
+    auto recovered = Labels::unsafe_from_ptr(raw);
+    CHECK(recovered == Labels({"foo", "bar"}, {{1, 2}, {3, 4}, {5, 6}}));
+
+    raw = recovered.release();
+    CHECK_THROWS_WITH(
+        recovered.as_mts_labels_t(),
+        "Can not access these Labels, they have been released"
+    );
+    REQUIRE(mts_labels_free(raw) == MTS_SUCCESS);
+}
+
 
 TEST_CASE("Set operations") {
     SECTION("union") {

--- a/metatensor-core/tests/cpp/tensor.cpp
+++ b/metatensor-core/tests/cpp/tensor.cpp
@@ -327,7 +327,7 @@ TEST_CASE("TensorMap ownership transfer") {
     auto* raw = tensor.release();
     CHECK_THROWS_WITH(
         tensor.as_mts_tensormap_t(),
-        "Can not access this TensorMap, it has been released"
+        "can not access this TensorMap, it has been released"
     );
 
     auto recovered = TensorMap::unsafe_from_ptr(raw);
@@ -336,7 +336,7 @@ TEST_CASE("TensorMap ownership transfer") {
     raw = recovered.release();
     CHECK_THROWS_WITH(
         recovered.as_mts_tensormap_t(),
-        "Can not access this TensorMap, it has been released"
+        "can not access this TensorMap, it has been released"
     );
     REQUIRE(mts_tensormap_free(raw) == MTS_SUCCESS);
 }

--- a/metatensor-core/tests/cpp/tensor.cpp
+++ b/metatensor-core/tests/cpp/tensor.cpp
@@ -28,6 +28,7 @@ TEST_CASE("TensorMap") {
 
         // block by index
         auto block = tensor.block_by_id(2);
+        CHECK(block.is_view());
         const auto values = block.values();
         CHECK(values(0, 0, 0) == 3);
     }
@@ -318,6 +319,42 @@ TEST_CASE("TensorMap") {
         auto status = mts_set_last_error(nullptr, nullptr, nullptr, nullptr);
         CHECK(status == MTS_SUCCESS);
     }
+}
+
+TEST_CASE("TensorMap ownership transfer") {
+    auto tensor = test_tensor_map();
+
+    auto* raw = tensor.release();
+    CHECK_THROWS_WITH(
+        tensor.as_mts_tensormap_t(),
+        "Can not access this TensorMap, it has been released"
+    );
+
+    auto recovered = TensorMap::unsafe_from_ptr(raw);
+    CHECK(recovered.keys() == Labels({"key_1", "key_2"}, {{0, 0}, {1, 0}, {2, 2}, {2, 3}}));
+
+    raw = recovered.release();
+    CHECK_THROWS_WITH(
+        recovered.as_mts_tensormap_t(),
+        "Can not access this TensorMap, it has been released"
+    );
+    REQUIRE(mts_tensormap_free(raw) == MTS_SUCCESS);
+}
+
+TEST_CASE("TensorMap unsafe views") {
+    auto owner = test_tensor_map();
+
+    CHECK_FALSE(owner.is_view());
+
+    auto* raw = owner.as_mts_tensormap_t();
+    auto view = TensorMap::unsafe_view_from_ptr(raw);
+
+    CHECK(view.is_view());
+    CHECK(view.keys() == owner.keys());
+    CHECK_THROWS_WITH(
+        view.release(),
+        "can not call TensorMap::release on this TensorMap since it is a view"
+    );
 }
 
 

--- a/metatensor-torch/include/metatensor/torch/block.hpp
+++ b/metatensor-torch/include/metatensor/torch/block.hpp
@@ -137,6 +137,11 @@ public:
         return this->values().scalar_type();
     }
 
+    /// Check if this block is a view (i.e. does not own the underlying data).
+    bool is_view() const {
+        return !parent_.isNone();
+    }
+
     /// Move all arrays in this block to the given `dtype` and `device`.
     TensorBlock to(
         torch::optional<torch::Dtype> dtype = torch::nullopt,
@@ -185,12 +190,31 @@ public:
     /// longer be used.
     metatensor::TensorBlock release();
 
-private:
-    /// Create a TensorBlockHolder containing gradients with respect to
-    /// `parameter`
-    TensorBlockHolder(metatensor::TensorBlock block, std::string parameter, torch::IValue parent);
-    friend class torch::intrusive_ptr<TensorBlockHolder>;
+    /// Get a mutable reference to the underlying `metatensor::TensorBlock`
+    metatensor::TensorBlock& as_metatensor() {
+        return block_;
+    }
 
+    /// Get a const reference to the underlying `metatensor::TensorBlock`
+    const metatensor::TensorBlock& as_metatensor() const {
+        return block_;
+    }
+
+    /// Create a `TensorBlockHolder` from a pre-existing
+    /// `metatensor::TensorBlock`.
+    ///
+    /// The block is moved into the new holder, taking ownership of the
+    /// underlying data.
+    static TensorBlock from_metatensor(metatensor::TensorBlock block);
+
+    /// Create a `TensorBlockHolder` which is a view of a pre-existing
+    /// `metatensor::TensorBlock`.
+    ///
+    /// The view does not own the underlying data. The `parent` is kept alive
+    /// as long as this block is alive.
+    static TensorBlock view_from_metatensor(metatensor::TensorBlock block, torch::IValue parent);
+
+private:
     /// Underlying metatensor TensorBlock
     metatensor::TensorBlock block_;
 
@@ -198,9 +222,15 @@ private:
     /// block contains gradients), or a `TensorMap`.
     torch::IValue parent_;
 
-    /// If this TensorBlock contains gradients, these are gradients w.r.t. this
-    /// parameter
+    /// If this TensorBlock is storing gradients inside another TensorBlock
+    /// store the parameter with respect to which the gradients are computed
     std::string parameter_;
+
+    /// Create a TensorBlockHolder containing gradients with respect to
+    /// `parameter`
+    TensorBlockHolder(metatensor::TensorBlock block, std::string parameter, torch::IValue parent);
+
+    friend class torch::intrusive_ptr<TensorBlockHolder>;
 };
 
 }

--- a/metatensor-torch/include/metatensor/torch/labels.hpp
+++ b/metatensor-torch/include/metatensor/torch/labels.hpp
@@ -157,6 +157,18 @@ public:
     /// Get the underlying metatensor::Labels
     const metatensor::Labels& as_metatensor() const;
 
+    /// Move the `metatensor::Labels` out of this class.
+    ///
+    /// This leaves the `LabelsHolder` in an empty state that should no
+    /// longer be used.
+    metatensor::Labels release();
+
+    /// Create a `LabelsHolder` from a pre-existing `metatensor::Labels`.
+    ///
+    /// The labels are moved into the new holder, taking ownership of the
+    /// underlying data.
+    static Labels from_metatensor(metatensor::Labels labels);
+
     /// Get the union of `this` and `other`
     Labels set_union(const Labels& other) const;
 

--- a/metatensor-torch/include/metatensor/torch/tensor.hpp
+++ b/metatensor-torch/include/metatensor/torch/tensor.hpp
@@ -134,6 +134,11 @@ public:
     /// Get the dtype for the values stored in this `TensorMap`
     torch::Dtype scalar_type() const;
 
+    /// Check if this TensorMap is a view (i.e. does not own the underlying data).
+    bool is_view() const {
+        return !parent_.isNone();
+    }
+
     /// Move this `TensorMap` to the given `dtype` and `device`.
     TensorMap to(
         torch::optional<torch::Dtype> dtype = torch::nullopt,
@@ -162,6 +167,30 @@ public:
     const metatensor::TensorMap& as_metatensor() const {
         return tensor_;
     }
+
+    /// Get a mutable reference to the underlying `metatensor::TensorMap`
+    metatensor::TensorMap& as_metatensor() {
+        return tensor_;
+    }
+
+    /// Move the `metatensor::TensorMap` out of this class.
+    ///
+    /// This leaves the `TensorMapHolder` in an empty state that should no
+    /// longer be used.
+    metatensor::TensorMap release();
+
+    /// Create a `TensorMapHolder` from a pre-existing `metatensor::TensorMap`.
+    ///
+    /// The tensor map is moved into the new holder, taking ownership of the
+    /// underlying data.
+    static TensorMap from_metatensor(metatensor::TensorMap tensor);
+
+    /// Create a `TensorMapHolder` which is a view of a pre-existing
+    /// `metatensor::TensorMap`.
+    ///
+    /// The view does not own the underlying data. The `parent` is kept alive
+    /// as long as this tensor map is alive.
+    static TensorMap view_from_metatensor(metatensor::TensorMap tensor, torch::IValue parent);
 
     /// Load a serialized TensorMap from the given path
     static TensorMap load(const std::string& path);
@@ -192,9 +221,18 @@ private:
     /// Underlying metatensor TensorMap
     metatensor::TensorMap tensor_;
 
+    /// Parent for this TensorMap, used to keep a reference on the parent object
+    torch::IValue parent_;
+
     /// Wrap an existing `metatensor::TensorMap` into a `TensorMapHolder`
     explicit TensorMapHolder(metatensor::TensorMap tensor):
         tensor_(std::move(tensor)) {}
+
+    /// Wrap an existing `metatensor::TensorMap` into a `TensorMapHolder` with a parent
+    explicit TensorMapHolder(metatensor::TensorMap tensor, torch::IValue parent):
+        tensor_(std::move(tensor)), parent_(std::move(parent)) {}
+
+    friend class torch::intrusive_ptr<TensorMapHolder>;
 };
 
 

--- a/metatensor-torch/src/block.cpp
+++ b/metatensor-torch/src/block.cpp
@@ -381,6 +381,33 @@ torch::Tensor TensorBlockHolder::save_buffer() const {
 }
 
 metatensor::TensorBlock TensorBlockHolder::release() {
-    auto block = std::move(block_);
-    return block;
+    if (!parent_.isNone()) {
+        throw std::runtime_error(
+            "can not release this TensorBlock, it is a view inside another"
+            " TensorBlock or a TensorMap"
+        );
+    }
+
+    return std::move(block_);
+}
+
+TensorBlock TensorBlockHolder::from_metatensor(metatensor::TensorBlock block) {
+    return torch::make_intrusive<TensorBlockHolder>(std::move(block), torch::IValue());
+}
+
+TensorBlock TensorBlockHolder::view_from_metatensor(metatensor::TensorBlock block, torch::IValue parent) {
+    if (parent.isNone()) {
+        C10_THROW_ERROR(ValueError,
+            "`parent` cannot be None when creating a TensorBlock view"
+        );
+    }
+
+    if (!block.is_view()) {
+        C10_THROW_ERROR(ValueError,
+            "the provided metatensor::TensorBlock is not a view, "
+            "cannot create a metatensor_torch::TensorBlock view from it"
+        );
+    }
+
+    return torch::make_intrusive<TensorBlockHolder>(std::move(block), std::move(parent));
 }

--- a/metatensor-torch/src/labels.cpp
+++ b/metatensor-torch/src/labels.cpp
@@ -256,7 +256,20 @@ torch::Tensor LabelsHolder::column(std::string dimension) {
 }
 
 const metatensor::Labels& LabelsHolder::as_metatensor() const {
+    if (labels_.as_mts_labels_t() == nullptr) {
+        throw std::runtime_error(
+            "can not access this Labels, it has been released"
+        );
+    }
     return labels_;
+}
+
+metatensor::Labels LabelsHolder::release() {
+    return std::move(labels_);
+}
+
+Labels LabelsHolder::from_metatensor(metatensor::Labels labels) {
+    return torch::make_intrusive<LabelsHolder>(std::move(labels));
 }
 
 Labels LabelsHolder::append(std::string name, torch::Tensor values) const {

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -161,6 +161,19 @@ TORCH_LIBRARY(metatensor, m) {
         .def("save_buffer", &LabelsHolder::save_buffer)
         .def_static("load", &LabelsHolder::load)
         .def_static("load_buffer", &LabelsHolder::load_buffer)
+        .def_static("unsafe_from_ptr", [](int64_t ptr) -> Labels {
+            auto* labels_ptr = reinterpret_cast<mts_labels_t*>(ptr);
+            auto labels = metatensor::Labels::unsafe_from_ptr(labels_ptr);
+            return LabelsHolder::from_metatensor(std::move(labels));
+        })
+        .def("release", [](Labels self) -> int64_t {
+            const auto* ptr = self->release().release();
+            return reinterpret_cast<int64_t>(ptr);
+        })
+        .def("as_mts_labels_t", [](const Labels& self) -> int64_t {
+            const auto* ptr = self->as_metatensor().as_mts_labels_t();
+            return reinterpret_cast<int64_t>(ptr);
+        })
         .def("entry", labels_entry, DOCSTRING, {torch::arg("index")})
         .def("column", &LabelsHolder::column, DOCSTRING, {torch::arg("dimension")})
         .def_property("names", &LabelsHolder::names)
@@ -223,6 +236,7 @@ TORCH_LIBRARY(metatensor, m) {
         .def("gradients", &TensorBlockHolder::gradients)
         .def_property("device", &TensorBlockHolder::device)
         .def_property("dtype", &TensorBlockHolder::scalar_type)
+        .def_property("is_view", &TensorBlockHolder::is_view)
         .def("to", &TensorBlockHolder::to_positional, DOCSTRING, {
             torch::arg("_0") = torch::IValue(),
             torch::arg("_1") = torch::IValue(),
@@ -235,6 +249,24 @@ TORCH_LIBRARY(metatensor, m) {
         .def("save_buffer", &TensorBlockHolder::save_buffer)
         .def_static("load", &TensorBlockHolder::load)
         .def_static("load_buffer", &TensorBlockHolder::load_buffer)
+        .def_static("unsafe_from_ptr", [](int64_t ptr) -> TensorBlock {
+            auto* block_ptr = reinterpret_cast<mts_block_t*>(ptr);
+            auto block = metatensor::TensorBlock::unsafe_from_ptr(block_ptr);
+            return TensorBlockHolder::from_metatensor(std::move(block));
+        })
+        .def_static("unsafe_view_from_ptr", [](int64_t ptr, torch::IValue parent) -> TensorBlock {
+            auto* block_ptr = reinterpret_cast<mts_block_t*>(ptr);
+            auto block = metatensor::TensorBlock::unsafe_view_from_ptr(block_ptr);
+            return TensorBlockHolder::view_from_metatensor(std::move(block), std::move(parent));
+        })
+        .def("release", [](TensorBlock self) -> int64_t {
+            const auto* ptr = self->release().release();
+            return reinterpret_cast<int64_t>(ptr);
+        })
+        .def("as_mts_block_t", [](const TensorBlock& self) -> int64_t {
+            const auto* ptr = self->as_metatensor().as_mts_block_t();
+            return reinterpret_cast<int64_t>(ptr);
+        })
         .def_pickle(
             // __getstate__
             [](const TensorBlock& self){ return self->save_buffer(); },
@@ -258,6 +290,24 @@ TORCH_LIBRARY(metatensor, m) {
         .def("save_buffer", &TensorMapHolder::save_buffer)
         .def_static("load", &TensorMapHolder::load)
         .def_static("load_buffer", &TensorMapHolder::load_buffer)
+        .def_static("unsafe_from_ptr", [](int64_t ptr) -> TensorMap {
+            auto* tensor_ptr = reinterpret_cast<mts_tensormap_t*>(ptr);
+            auto block = metatensor::TensorMap::unsafe_from_ptr(tensor_ptr);
+            return TensorMapHolder::from_metatensor(std::move(block));
+        })
+        .def_static("unsafe_view_from_ptr", [](int64_t ptr, torch::IValue parent) -> TensorMap {
+            auto* tensor_ptr = reinterpret_cast<mts_tensormap_t*>(ptr);
+            auto block = metatensor::TensorMap::unsafe_view_from_ptr(tensor_ptr);
+            return TensorMapHolder::view_from_metatensor(std::move(block), std::move(parent));
+        })
+        .def("release", [](TensorMap self) -> int64_t {
+            const auto* ptr = self->release().release();
+            return reinterpret_cast<int64_t>(ptr);
+        })
+        .def("as_mts_tensormap_t", [](const TensorMap& self) -> int64_t {
+            const auto* ptr = self->as_metatensor().as_mts_tensormap_t();
+            return reinterpret_cast<int64_t>(ptr);
+        })
         .def("items", &TensorMapHolder::items)
         .def_property("keys", &TensorMapHolder::keys)
         .def("block_by_id", &TensorMapHolder::block_by_id, DOCSTRING,
@@ -293,6 +343,7 @@ TORCH_LIBRARY(metatensor, m) {
         .def_property("property_names", &TensorMapHolder::property_names)
         .def_property("device", &TensorMapHolder::device)
         .def_property("dtype", &TensorMapHolder::scalar_type)
+        .def_property("is_view", &TensorMapHolder::is_view)
         .def("to", &TensorMapHolder::to_positional, DOCSTRING, {
             torch::arg("_0") = torch::IValue(),
             torch::arg("_1") = torch::IValue(),

--- a/metatensor-torch/src/tensor.cpp
+++ b/metatensor-torch/src/tensor.cpp
@@ -589,3 +589,34 @@ torch::Dict<std::string, std::string> TensorMapHolder::info() const {
     }
     return result;
 }
+
+metatensor::TensorMap TensorMapHolder::release() {
+    if (!parent_.isNone()) {
+        throw std::runtime_error(
+            "can not release this TensorMap, it is a view inside another object"
+        );
+    }
+
+    return std::move(tensor_);
+}
+
+TensorMap TensorMapHolder::from_metatensor(metatensor::TensorMap tensor) {
+    return torch::make_intrusive<TensorMapHolder>(std::move(tensor));
+}
+
+TensorMap TensorMapHolder::view_from_metatensor(metatensor::TensorMap tensor, torch::IValue parent) {
+    if (parent.isNone()) {
+        C10_THROW_ERROR(ValueError,
+            "`parent` cannot be None when creating a TensorMap view"
+        );
+    }
+
+    if (!tensor.is_view()) {
+        C10_THROW_ERROR(ValueError,
+            "the provided metatensor::TensorMap is not a view, "
+            "cannot create a metatensor_torch::TensorMap view from it"
+        );
+    }
+
+    return torch::make_intrusive<TensorMapHolder>(std::move(tensor), std::move(parent));
+}

--- a/metatensor-torch/tests/block.cpp
+++ b/metatensor-torch/tests/block.cpp
@@ -67,6 +67,7 @@ TEST_CASE("Blocks") {
         CHECK_FALSE(block->has_gradient("not-there"));
 
         auto gradient = TensorBlockHolder::gradient(block, "g");
+        CHECK(gradient->is_view());
         CHECK((gradient->values().sizes() == std::vector<int64_t>{1, 3, 2}));
 
         auto sample_names = gradient->samples()->names();
@@ -102,6 +103,7 @@ TEST_CASE("Blocks") {
             LabelsHolder::create({"p"}, {{0}, {1}})
         );
 
+        CHECK_FALSE(block->is_view());
         CHECK(block->samples()->names()[0] == "s");
 
         auto mts_block = block->release();
@@ -109,8 +111,8 @@ TEST_CASE("Blocks") {
 
         CHECK_THROWS_WITH(
             block->samples(),
-            "Can not access this TensorBlock, it has been moved inside a "
-            "TensorMap or another TensorBlock"
+            "can not access this TensorBlock, it has been released or "
+            "moved inside a TensorMap or another TensorBlock"
         );
     }
 }

--- a/metatensor-torch/tests/tensor.cpp
+++ b/metatensor-torch/tests/tensor.cpp
@@ -24,6 +24,7 @@ TEST_CASE("TensorMap") {
 
         // block by index
         auto block = TensorMapHolder::block_by_id(tensor, 2);
+        CHECK(block->is_view());
         const auto values = block->values();
         CHECK(values[0][0][0].item<double>() == 3);
     }

--- a/python/metatensor_core/metatensor/_block.py
+++ b/python/metatensor_core/metatensor/_block.py
@@ -3,7 +3,7 @@ import ctypes
 import pathlib
 import warnings
 from pickle import PickleBuffer
-from typing import BinaryIO, Generator, List, Sequence, Tuple, Union
+from typing import Any, BinaryIO, Generator, List, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -107,17 +107,17 @@ class TensorBlock:
 
         components_array = ctypes.ARRAY(ctypes.POINTER(mts_labels_t), len(components))()
         for i, component in enumerate(components):
-            components_array[i] = component._as_mts_labels_t()
+            components_array[i] = component.as_mts_labels_t()
 
         mts_array = create_mts_array(values)
-        self._actual_ptr = self._lib.mts_block(
+        self._ptr = self._lib.mts_block(
             mts_array,
-            samples._as_mts_labels_t(),
+            samples.as_mts_labels_t(),
             components_array,
             len(components_array),
-            properties._as_mts_labels_t(),
+            properties.as_mts_labels_t(),
         )
-        check_pointer(self._actual_ptr)
+        check_pointer(self._ptr)
 
         self._cached_dtype = _data.array_dtype(values)
         self._cached_device = _data.array_device(values)
@@ -133,46 +133,85 @@ class TensorBlock:
             )
 
     @staticmethod
-    def _from_ptr(ptr, parent):
+    def unsafe_from_ptr(block: ctypes.POINTER(mts_block_t)):
         """
-        create a block from a pointer, either owning its data (new block as a
-        copy of an existing one) or not (block inside a :py:class:`TensorMap`)
+        Create a :py:class:`TensorBlock` from a raw ``mts_block_t`` pointer.
+
+        The :py:class:`TensorBlock` takes ownership of the pointer, and will
+        release the corresponding memory when garbage-collected.
         """
-        check_pointer(ptr)
+        assert block, "mts_block_t pointer is null"
         obj = TensorBlock.__new__(TensorBlock)
         obj._lib = _get_library()
         obj._gradient_parameters = []
-        obj._actual_ptr = ptr
+        obj._ptr = block
         obj._cached_dtype = None
         obj._cached_device = None
+        obj._parent = None
+        return obj
+
+    @staticmethod
+    def unsafe_view_from_ptr(ptr: ctypes.POINTER(mts_block_t), parent: Any):
+        """
+        Create a :py:class:`TensorBlock` from a raw ``mts_block_t`` pointer, keeping a
+        reference to the ``parent`` to prevent garbage collection.
+
+        The :py:class:`TensorBlock` does **not** take ownership of the pointer, and will
+        not release the corresponding memory.
+        """
+        assert parent is not None, (
+            "please use TensorBlock.unsafe_from_ptr to take ownership of a pointer"
+        )
+
+        obj = TensorBlock.unsafe_from_ptr(ptr)
         # keep a reference to the parent object (usually a TensorMap) to
         # prevent it from being garbage-collected & removing this block
         obj._parent = parent
         return obj
 
-    @property
-    def _ptr(self):
-        if self._actual_ptr is None:
+    def as_mts_block_t(self) -> ctypes.POINTER(mts_block_t):
+        """
+        Get the underlying C pointer for this :py:class:`TensorBlock`.
+
+        This class still manages the block memory after the call. Use
+        :py:meth:`TensorBlock.release` to take ownership of the pointer.
+        """
+        if not self._ptr:
             raise ValueError(
-                "this block has been moved inside a TensorMap/another TensorBlock "
-                "and can no longer be used"
+                "this block has been released or moved inside a TensorBlock "
+                "or TensorMap and can no longer be used"
             )
 
-        return self._actual_ptr
+        return self._ptr
 
-    def _move_ptr(self):
-        assert self._parent is None
-        self._actual_ptr = None
+    def release(self):
+        """
+        Release the underlying C pointer of this :py:class:`TensorBlock`.
+
+        This class is no longer managing the block memory after the call, the
+        user is expected to re-create a :py:class:`TensorBlock` with
+        :py:meth:`TensorBlock.unsafe_from_ptr`, or pass the pointer to a C
+        function that will call ``mts_block_free``.
+        """
+        if self._parent is not None:
+            raise RuntimeError(
+                "can not release this TensorBlock, it is a view inside another "
+                "TensorBlock or a TensorMap"
+            )
+
+        ptr = self.as_mts_block_t()
+        self._ptr = None
+        return ptr
 
     def __del__(self):
         if (
             hasattr(self, "_lib")
             and self._lib is not None
-            and hasattr(self, "_actual_ptr")
+            and hasattr(self, "_ptr")
             and hasattr(self, "_parent")
         ):
             if self._parent is None:
-                self._lib.mts_block_free(self._actual_ptr)
+                self._lib.mts_block_free(self._ptr)
 
     def __copy__(self):
         return self.copy(deep=False)
@@ -209,8 +248,9 @@ class TensorBlock:
         :param deep: if ``True``, create a deep copy of the block
         """
         if deep:
-            new_ptr = self._lib.mts_block_copy(self._ptr)
-            return TensorBlock._from_ptr(new_ptr, parent=None)
+            new_ptr = self._lib.mts_block_copy(self.as_mts_block_t())
+            check_pointer(new_ptr)
+            return TensorBlock.unsafe_from_ptr(new_ptr)
         else:
             new_block = TensorBlock(
                 values=self.values,
@@ -226,11 +266,9 @@ class TensorBlock:
             return new_block
 
     def __repr__(self) -> str:
-        if self._actual_ptr is None:
-            return (
-                "Empty TensorBlock (data has been moved to another "
-                "TensorBlock or TensorMap)"
-            )
+        if not self._ptr:
+            # The block has been released
+            return "TensorBlock(<empty>)"
 
         if len(self._gradient_parameters) != 0:
             s = f"Gradient TensorBlock ('{'/'.join(self._gradient_parameters)}')\n"
@@ -271,7 +309,7 @@ class TensorBlock:
     def _raw_values(self) -> mts_array_t:
         """Get the raw ``mts_array_t`` corresponding to this block's values"""
         data = mts_array_t()
-        self._lib.mts_block_data(self._ptr, data)
+        self._lib.mts_block_data(self.as_mts_block_t(), data)
         return data
 
     @property
@@ -331,9 +369,9 @@ class TensorBlock:
         return self._labels(property_axis)
 
     def _labels(self, axis) -> Labels:
-        result = self._lib.mts_block_labels(self._ptr, axis)
+        result = self._lib.mts_block_labels(self.as_mts_block_t(), axis)
         check_pointer(result)
-        return Labels._from_mts_labels_t(result)
+        return Labels.unsafe_from_ptr(result)
 
     def gradient(self, parameter: str) -> "TensorBlock":
         """
@@ -393,10 +431,11 @@ class TensorBlock:
         gradient_block = ctypes.POINTER(mts_block_t)()
 
         self._lib.mts_block_gradient(
-            self._ptr, parameter.encode("utf8"), gradient_block
+            self.as_mts_block_t(), parameter.encode("utf8"), gradient_block
         )
 
-        gradient = TensorBlock._from_ptr(gradient_block, parent=self)
+        check_pointer(gradient_block)
+        gradient = TensorBlock.unsafe_view_from_ptr(gradient_block, parent=self)
 
         gradient._gradient_parameters = copy.deepcopy(self._gradient_parameters)
         gradient._gradient_parameters.append(parameter)
@@ -464,26 +503,15 @@ class TensorBlock:
                 f"got {self.device} and {gradient.device}"
             )
 
-        # mts_block_add_gradient already checks that all arrays have the same origin
-        # (i.e. they are all numpy, or all torch, or ...), so we don't need to check it
-        # again here.
-
-        gradient_ptr = gradient._ptr
-
-        # the gradient is moved inside this block, assign NULL to
-        # `gradient._ptr` to prevent accessing invalid data from Python and
-        # double free
-        gradient._move_ptr()
-
         self._lib.mts_block_add_gradient(
-            self._ptr, parameter.encode("utf8"), gradient_ptr
+            self.as_mts_block_t(), parameter.encode("utf8"), gradient.release()
         )
 
     def gradients_list(self) -> List[str]:
         """get a list of all gradients defined in this block"""
         parameters = ctypes.POINTER(ctypes.c_char_p)()
         count = c_uintptr_t()
-        self._lib.mts_block_gradients_list(self._ptr, parameters, count)
+        self._lib.mts_block_gradients_list(self.as_mts_block_t(), parameters, count)
 
         result = []
         for i in range(count.value):
@@ -525,6 +553,13 @@ class TensorBlock:
         if self._cached_device is None:
             self._cached_device = _data.array_device(self.values)
         return self._cached_device
+
+    @property
+    def is_view(self) -> bool:
+        """
+        Check if this block is a view (i.e. does not own the underlying data).
+        """
+        return self._parent is not None
 
     def to(self, *args, **kwargs) -> "TensorBlock":
         """

--- a/python/metatensor_core/metatensor/_labels.py
+++ b/python/metatensor_core/metatensor/_labels.py
@@ -311,12 +311,17 @@ class Labels:
             values=np.arange(end, dtype=np.int32).reshape(-1, 1),
         )
 
-    @classmethod
-    def _from_mts_labels_t(cls, labels):
-        """Create Labels from an opaque mts_labels_t pointer."""
-        check_pointer(labels)
+    @staticmethod
+    def unsafe_from_ptr(labels: ctypes.POINTER(mts_labels_t)):
+        """
+        Create Labels from a raw ``mts_labels_t`` pointer.
 
-        obj = cls.__new__(cls)
+        The :py:class:`Labels` take ownership of the pointer, and will release the
+        corresponding memory when garbage-collected.
+        """
+        assert labels, "mts_labels_t pointer is null"
+
+        obj = Labels.__new__(Labels)
         obj._lib = _get_library()
         obj._ptr = labels
 
@@ -333,24 +338,55 @@ class Labels:
 
         return obj
 
+    def release(self) -> ctypes.POINTER(mts_labels_t):
+        """
+        Release the underlying C pointer of these :py:class:`Labels`.
+
+        This class is no longer managing the labels memory after the call, the user is
+        expected to re-create Labels with :py:meth:`Labels.unsafe_from_ptr`, or pass the
+        pointer to a C function that will call `mts_labels_free`.
+        """
+        ptr = self.as_mts_labels_t()
+        self._ptr = None
+        return ptr
+
+    def as_mts_labels_t(self) -> ctypes.POINTER(mts_labels_t):
+        """
+        Get the underlying C pointer for these :py:class:`Labels`. This class still
+        manages the labels memory after the call. Use :py:meth:`Labels.release` to
+        take ownership of the pointerr
+        """
+        if not self._ptr:
+            raise RuntimeError("can not access these Labels, they have been released")
+
+        return self._ptr
+
     def __del__(self):
         if hasattr(self, "_lib") and self._lib is not None:
             if hasattr(self, "_labels") and self._ptr is not None:
                 self._lib.mts_labels_free(self._ptr)
 
     def __deepcopy__(self, _memodict):
-        ptr = self._lib.mts_labels_clone(self._ptr)
+        ptr = self._lib.mts_labels_clone(self.as_mts_labels_t())
         check_pointer(ptr)
-        return Labels._from_mts_labels_t(ptr)
+        return Labels.unsafe_from_ptr(ptr)
 
     def __copy__(self):
         return self.__deepcopy__({})
 
     def __str__(self) -> str:
+        if not self._ptr:
+            # The Labels have been released
+            return "Labels(<empty>)"
+
         printed = self.print(4, 3)
         return f"Labels(\n   {printed}\n)"
 
     def __repr__(self) -> str:
+        if not self._ptr:
+            # The Labels have been released
+            return "Labels(<empty>)"
+
         printed = self.print(-1, 3)
         return f"Labels(\n   {printed}\n)"
 
@@ -418,9 +454,6 @@ class Labels:
         different values)
         """
         return not self.__eq__(other)
-
-    def _as_mts_labels_t(self):
-        return self._ptr
 
     # ===== Serialization support ===== #
 
@@ -500,7 +533,7 @@ class Labels:
     def _raw_values(self) -> mts_array_t:
         """Get the raw ``mts_array_t`` corresponding to these Labels' values"""
         data = mts_array_t()
-        self._lib.mts_labels_values(self._ptr, data)
+        self._lib.mts_labels_values(self.as_mts_labels_t(), data)
         return data
 
     @property
@@ -724,7 +757,7 @@ class Labels:
             c_entry[i] = ctypes.c_int32(v)
 
         self._lib.mts_labels_position(
-            self._ptr,
+            self.as_mts_labels_t(),
             c_entry,
             c_entry._length_,
             result,
@@ -759,14 +792,15 @@ class Labels:
         """
         output = ctypes.POINTER(mts_labels_t)()
         self._lib.mts_labels_difference(
-            self._as_mts_labels_t(),
-            other._as_mts_labels_t(),
+            self.as_mts_labels_t(),
+            other.as_mts_labels_t(),
             ctypes.pointer(output),
             None,
             0,
         )
 
-        return Labels._from_mts_labels_t(output)
+        check_pointer(output)
+        return Labels.unsafe_from_ptr(output)
 
     def difference_and_mapping(self, other: "Labels") -> Tuple["Labels", np.ndarray]:
         """
@@ -800,14 +834,15 @@ class Labels:
         first_mapping = np.zeros(len(self), dtype=np.int64)
 
         self._lib.mts_labels_difference(
-            self._as_mts_labels_t(),
-            other._as_mts_labels_t(),
+            self.as_mts_labels_t(),
+            other.as_mts_labels_t(),
             ctypes.pointer(output),
             first_mapping.ctypes.data_as(ctypes.POINTER(ctypes.c_int64)),
             len(first_mapping),
         )
 
-        return Labels._from_mts_labels_t(output), first_mapping
+        check_pointer(output)
+        return Labels.unsafe_from_ptr(output), first_mapping
 
     def union(self, other: "Labels") -> "Labels":
         """
@@ -831,8 +866,8 @@ class Labels:
         """
         output = ctypes.POINTER(mts_labels_t)()
         self._lib.mts_labels_union(
-            self._as_mts_labels_t(),
-            other._as_mts_labels_t(),
+            self.as_mts_labels_t(),
+            other.as_mts_labels_t(),
             ctypes.pointer(output),
             None,
             0,
@@ -840,7 +875,8 @@ class Labels:
             0,
         )
 
-        return Labels._from_mts_labels_t(output)
+        check_pointer(output)
+        return Labels.unsafe_from_ptr(output)
 
     def union_and_mapping(
         self, other: "Labels"
@@ -879,8 +915,8 @@ class Labels:
         second_mapping = np.zeros(len(other), dtype=np.int64)
 
         self._lib.mts_labels_union(
-            self._as_mts_labels_t(),
-            other._as_mts_labels_t(),
+            self.as_mts_labels_t(),
+            other.as_mts_labels_t(),
             ctypes.pointer(output),
             first_mapping.ctypes.data_as(ctypes.POINTER(ctypes.c_int64)),
             len(first_mapping),
@@ -888,7 +924,8 @@ class Labels:
             len(second_mapping),
         )
 
-        return Labels._from_mts_labels_t(output), first_mapping, second_mapping
+        check_pointer(output)
+        return Labels.unsafe_from_ptr(output), first_mapping, second_mapping
 
     def intersection(self, other: "Labels") -> "Labels":
         """
@@ -910,8 +947,8 @@ class Labels:
         """
         output = ctypes.POINTER(mts_labels_t)()
         self._lib.mts_labels_intersection(
-            self._as_mts_labels_t(),
-            other._as_mts_labels_t(),
+            self.as_mts_labels_t(),
+            other.as_mts_labels_t(),
             ctypes.pointer(output),
             None,
             0,
@@ -919,7 +956,8 @@ class Labels:
             0,
         )
 
-        return Labels._from_mts_labels_t(output)
+        check_pointer(output)
+        return Labels.unsafe_from_ptr(output)
 
     def intersection_and_mapping(
         self, other: "Labels"
@@ -957,8 +995,8 @@ class Labels:
         second_mapping = np.zeros(len(other), dtype=np.int64)
 
         self._lib.mts_labels_intersection(
-            self._as_mts_labels_t(),
-            other._as_mts_labels_t(),
+            self.as_mts_labels_t(),
+            other.as_mts_labels_t(),
             ctypes.pointer(output),
             first_mapping.ctypes.data_as(ctypes.POINTER(ctypes.c_int64)),
             len(first_mapping),
@@ -966,7 +1004,8 @@ class Labels:
             len(second_mapping),
         )
 
-        return Labels._from_mts_labels_t(output), first_mapping, second_mapping
+        check_pointer(output)
+        return Labels.unsafe_from_ptr(output), first_mapping, second_mapping
 
     def select(self, selection: "Labels") -> np.ndarray:
         """
@@ -996,8 +1035,8 @@ class Labels:
         selected_count = c_uintptr_t(len(self))
 
         self._lib.mts_labels_select(
-            self._as_mts_labels_t(),
-            selection._as_mts_labels_t(),
+            self.as_mts_labels_t(),
+            selection.as_mts_labels_t(),
             selected.ctypes.data_as(ctypes.POINTER(ctypes.c_uint64)),
             ctypes.pointer(selected_count),
         )

--- a/python/metatensor_core/metatensor/_tensor.py
+++ b/python/metatensor_core/metatensor/_tensor.py
@@ -2,13 +2,13 @@ import ctypes
 import pathlib
 import warnings
 from pickle import PickleBuffer
-from typing import BinaryIO, Dict, List, Optional, Sequence, Union
+from typing import Any, BinaryIO, Dict, List, Optional, Sequence, Union
 
 import numpy as np
 
 from . import _data
 from ._block import TensorBlock, _to_arguments_parse
-from ._c_api import c_uintptr_t, mts_array_t, mts_block_t
+from ._c_api import c_uintptr_t, mts_array_t, mts_block_t, mts_tensormap_t
 from ._c_lib import _get_library
 from ._data import Device, DeviceWarning, DType
 from ._labels import Labels, LabelsEntry
@@ -59,37 +59,7 @@ class TensorMap:
                 )
 
         self._lib = _get_library()
-
-        blocks_array_t = ctypes.POINTER(mts_block_t) * len(blocks)
-        blocks_array = blocks_array_t(*[block._ptr for block in blocks])
-
-        for block in blocks:
-            if block._parent is not None:
-                raise ValueError(
-                    "can not use blocks from another TensorMap in a new one, "
-                    "use TensorBlock.copy() to make a copy of each block first"
-                )
-
-            block_origin = _data.data_origin(block._raw_values)
-            first_block_origin = _data.data_origin(blocks[0]._raw_values)
-            if block_origin != first_block_origin:
-                raise ValueError(
-                    "all blocks in a TensorMap must have the same origin, "
-                    f"got '{_data.data_origin_name(first_block_origin)}' "
-                    f"and '{_data.data_origin_name(block_origin)}'"
-                )
-
-            if block.device != blocks[0].device:
-                raise ValueError(
-                    "all blocks in a TensorMap must have the same device, "
-                    f"got '{blocks[0].device}' and '{block.device}'"
-                )
-
-            if block.dtype != blocks[0].dtype:
-                raise ValueError(
-                    "all blocks in a TensorMap must have the same dtype, "
-                    f"got {blocks[0].dtype} and {block.dtype}"
-                )
+        self._parent = None
 
         if len(blocks) > 0 and not _data.array_device_is_cpu(blocks[0].values):
             warnings.warn(
@@ -102,32 +72,88 @@ class TensorMap:
                 stacklevel=2,
             )
 
-        # all blocks are moved into the tensor map, assign NULL to `block._ptr` to
-        # prevent accessing invalid data from Python and double free
-        for block in blocks:
-            block._move_ptr()
+        blocks_array_t = ctypes.POINTER(mts_block_t) * len(blocks)
+        blocks_array = blocks_array_t(*[block.release() for block in blocks])
 
         self._ptr = self._lib.mts_tensormap(
-            keys._as_mts_labels_t(), blocks_array, len(blocks)
+            keys.as_mts_labels_t(), blocks_array, len(blocks)
         )
         check_pointer(self._ptr)
 
-        for block in blocks:
-            block._is_inside_map = True
-
     @staticmethod
-    def _from_ptr(ptr):
-        """Create a tensor map from a pointer owning its data"""
-        check_pointer(ptr)
+    def unsafe_from_ptr(tensor: ctypes.POINTER(mts_tensormap_t)):
+        """
+        Create a :py:class:`TensorMap` from a raw ``mts_tensormap_t`` pointer.
+
+        The :py:class:`TensorMap` takes ownership of the pointer, and will
+        release the corresponding memory when garbage-collected.
+        """
+        assert tensor, "mts_tensormap_t pointer is null"
         obj = TensorMap.__new__(TensorMap)
         obj._lib = _get_library()
-        obj._ptr = ptr
-        obj._blocks = []
+        obj._ptr = tensor
+        obj._parent = None
         return obj
 
+    @staticmethod
+    def unsafe_view_from_ptr(tensor: ctypes.POINTER(mts_tensormap_t), parent: Any):
+        """
+        Create a :py:class:`TensorMap` from a raw ``mts_tensormap_t`` pointer, keeping a
+        reference to the ``parent`` to prevent garbage collection.
+
+        The :py:class:`TensorMap` does **not** take ownership of the pointer, and will
+        not release the memory.
+        """
+        assert parent is not None, (
+            "please use TensorMap.unsafe_from_ptr to take ownership of a pointer"
+        )
+
+        obj = TensorMap.unsafe_from_ptr(tensor)
+        obj._parent = parent
+        return obj
+
+    def as_mts_tensormap_t(self) -> ctypes.POINTER(mts_tensormap_t):
+        """
+        Get the underlying C pointer for this :py:class:`TensorMap`.
+
+        This class still manages the tensor map memory after the call. Use
+        :py:meth:`TensorMap.release` to take ownership of the pointer.
+        """
+        if not self._ptr:
+            raise ValueError(
+                "this TensorMap has been released and can no longer be used"
+            )
+
+        return self._ptr
+
+    def release(self) -> ctypes.POINTER(mts_tensormap_t):
+        """
+        Release the underlying C pointer of this :py:class:`TensorMap`.
+
+        This class is no longer managing the tensor map memory after the call,
+        the user is expected to re-create a :py:class:`TensorMap` with
+        :py:meth:`TensorMap.unsafe_from_ptr`, or pass the pointer to a C function
+        that will call ``mts_tensormap_free``.
+        """
+        if self._parent is not None:
+            raise RuntimeError(
+                "can not release this TensorMap, it is already a view inside "
+                "another TensorMap or TensorBlock"
+            )
+
+        ptr = self.as_mts_tensormap_t()
+        self._ptr = None
+        return ptr
+
     def __del__(self):
-        if hasattr(self, "_lib") and self._lib is not None and hasattr(self, "_ptr"):
-            self._lib.mts_tensormap_free(self._ptr)
+        if (
+            hasattr(self, "_lib")
+            and self._lib is not None
+            and hasattr(self, "_ptr")
+            and hasattr(self, "_parent")
+        ):
+            if self._parent is None:
+                self._lib.mts_tensormap_free(self._ptr)
 
     def __copy__(self):
         return self.copy(deep=False)
@@ -146,7 +172,8 @@ class TensorMap:
         """
         if deep:
             new_ptr = self._lib.mts_tensormap_copy(self._ptr)
-            return TensorMap._from_ptr(new_ptr)
+            check_pointer(new_ptr)
+            return TensorMap.unsafe_from_ptr(new_ptr)
         else:
             new_blocks = [block.copy(deep=False) for block in self.blocks()]
             return TensorMap(keys=self.keys, blocks=new_blocks)
@@ -303,7 +330,7 @@ class TensorMap:
         """The set of keys labeling the blocks in this tensor map."""
         result = self._lib.mts_tensormap_keys(self._ptr)
         check_pointer(result)
-        return Labels._from_mts_labels_t(result)
+        return Labels.unsafe_from_ptr(result)
 
     def block_by_id(self, index: int) -> TensorBlock:
         """
@@ -322,7 +349,8 @@ class TensorMap:
 
         block = ctypes.POINTER(mts_block_t)()
         self._lib.mts_tensormap_block_by_id(self._ptr, block, index)
-        return TensorBlock._from_ptr(block, parent=self)
+        check_pointer(block)
+        return TensorBlock.unsafe_view_from_ptr(block, parent=self)
 
     def blocks_by_id(self, indices: Sequence[int]) -> TensorBlock:
         """
@@ -523,9 +551,10 @@ class TensorMap:
         keys_to_move = _normalize_keys_to_move(keys_to_move)
         fill_value_array = _make_fill_value_array(self, fill_value)
         ptr = self._lib.mts_tensormap_keys_to_samples(
-            self._ptr, keys_to_move._as_mts_labels_t(), fill_value_array, sort_samples
+            self._ptr, keys_to_move.as_mts_labels_t(), fill_value_array, sort_samples
         )
-        return TensorMap._from_ptr(ptr)
+        check_pointer(ptr)
+        return TensorMap.unsafe_from_ptr(ptr)
 
     def components_to_properties(
         self, dimensions: Union[str, Sequence[str]]
@@ -541,7 +570,8 @@ class TensorMap:
         ptr = self._lib.mts_tensormap_components_to_properties(
             self._ptr, c_dimensions, c_dimensions._length_
         )
-        return TensorMap._from_ptr(ptr)
+        check_pointer(ptr)
+        return TensorMap.unsafe_from_ptr(ptr)
 
     def keys_to_properties(
         self,
@@ -600,9 +630,10 @@ class TensorMap:
         keys_to_move = _normalize_keys_to_move(keys_to_move)
         fill_value_array = _make_fill_value_array(self, fill_value)
         ptr = self._lib.mts_tensormap_keys_to_properties(
-            self._ptr, keys_to_move._as_mts_labels_t(), fill_value_array, sort_samples
+            self._ptr, keys_to_move.as_mts_labels_t(), fill_value_array, sort_samples
         )
-        return TensorMap._from_ptr(ptr)
+        check_pointer(ptr)
+        return TensorMap.unsafe_from_ptr(ptr)
 
     @property
     def sample_names(self) -> List[str]:
@@ -662,6 +693,14 @@ class TensorMap:
             return None
 
         return self.block_by_id(0).dtype
+
+    @property
+    def is_view(self) -> bool:
+        """
+        Check if this :py:class:`TensorMap` is a view (i.e. does not own the
+        underlying data).
+        """
+        return self._parent is not None
 
     def to(self, *args, **kwargs) -> "TensorMap":
         """

--- a/python/metatensor_core/metatensor/io/_block.py
+++ b/python/metatensor_core/metatensor/io/_block.py
@@ -18,7 +18,7 @@ from .._c_api import (
 )
 from .._c_lib import _get_library
 from .._data._array import _is_numpy_array, _is_torch_array, create_mts_array
-from .._status import catch_exceptions
+from .._status import catch_exceptions, check_pointer
 from ._labels import _labels_from_mts, _labels_to_mts
 from ._utils import _save_buffer_raw
 
@@ -198,8 +198,8 @@ def load_block_custom_array(
         path = bytes(path)
 
     ptr = lib.mts_block_load(path, mts_create_array_callback_t(create_array))
-
-    return TensorBlock._from_ptr(ptr, parent=None)
+    check_pointer(ptr)
+    return TensorBlock.unsafe_from_ptr(ptr)
 
 
 def load_block_buffer_custom_array(
@@ -233,8 +233,8 @@ def load_block_buffer_custom_array(
         array.nbytes,
         mts_create_array_callback_t(create_array),
     )
-
-    return TensorBlock._from_ptr(ptr, parent=None)
+    check_pointer(ptr)
+    return TensorBlock.unsafe_from_ptr(ptr)
 
 
 def _save_block(

--- a/python/metatensor_core/metatensor/io/_labels.py
+++ b/python/metatensor_core/metatensor/io/_labels.py
@@ -29,7 +29,7 @@ def load_labels(file: Union[str, pathlib.Path, BinaryIO]) -> Labels:
 
         ptr = lib.mts_labels_load(path)
         check_pointer(ptr)
-        return Labels._from_mts_labels_t(ptr)
+        return Labels.unsafe_from_ptr(ptr)
 
     else:
         # assume we have a file-like object
@@ -54,7 +54,7 @@ def load_labels_buffer(buffer: Union[bytes, bytearray, memoryview]) -> Labels:
     )
     check_pointer(ptr)
 
-    return Labels._from_mts_labels_t(ptr)
+    return Labels.unsafe_from_ptr(ptr)
 
 
 def _save_labels(

--- a/python/metatensor_core/metatensor/io/_tensor.py
+++ b/python/metatensor_core/metatensor/io/_tensor.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from .._c_api import mts_create_array_callback_t
 from .._c_lib import _get_library
+from .._status import check_pointer
 from .._tensor import TensorMap
 from ._block import (
     CreateArrayCallback,
@@ -96,8 +97,8 @@ def load_custom_array(
         path = bytes(path)
 
     ptr = lib.mts_tensormap_load(path, mts_create_array_callback_t(create_array))
-
-    return TensorMap._from_ptr(ptr)
+    check_pointer(ptr)
+    return TensorMap.unsafe_from_ptr(ptr)
 
 
 def load_buffer_custom_array(
@@ -131,8 +132,8 @@ def load_buffer_custom_array(
         array.nbytes,
         mts_create_array_callback_t(create_array),
     )
-
-    return TensorMap._from_ptr(ptr)
+    check_pointer(ptr)
+    return TensorMap.unsafe_from_ptr(ptr)
 
 
 def _save_tensor(

--- a/python/metatensor_core/tests/blocks.py
+++ b/python/metatensor_core/tests/blocks.py
@@ -567,3 +567,50 @@ def test_to_torch_multiple_args():
         assert isinstance(block.gradient("g").values, torch.Tensor)
         assert block.values.dtype == torch.float32
         assert block.gradient("g").values.dtype == torch.float32
+
+
+def test_ownership_transfer(block):
+    """Test releasing and recovering a TensorBlock via ``unsafe_from_ptr``"""
+    assert not block.is_view
+    raw = block.release()
+
+    message = (
+        "this block has been released or moved inside a TensorBlock "
+        "or TensorMap and can no longer be used"
+    )
+    with pytest.raises(ValueError, match=re.escape(message)):
+        block.as_mts_block_t()
+
+    recovered = TensorBlock.unsafe_from_ptr(raw)
+    assert recovered.samples == Labels(["s"], np.array([[0], [2], [4]]))
+    assert recovered.properties == Labels(["p"], np.array([[5], [3]]))
+
+    raw = recovered.release()
+    message = (
+        "this block has been released or moved inside a TensorBlock "
+        "or TensorMap and can no longer be used"
+    )
+    with pytest.raises(ValueError, match=re.escape(message)):
+        recovered.as_mts_block_t()
+
+    TensorBlock.unsafe_from_ptr(raw)
+
+
+def test_unsafe_view(block):
+    """Test creating a non-owning view of a TensorBlock"""
+    raw = block.as_mts_block_t()
+    view = TensorBlock.unsafe_view_from_ptr(raw, parent=block)
+
+    assert view.is_view
+    assert view.samples == block.samples
+    assert view.properties == block.properties
+
+    message = (
+        "can not release this TensorBlock, it is a view inside another TensorBlock "
+        "or a TensorMap"
+    )
+    with pytest.raises(RuntimeError, match=re.escape(message)):
+        view.release()
+
+    # original block should still be usable after creating a view
+    assert block.samples == Labels(["s"], np.array([[0], [2], [4]]))

--- a/python/metatensor_core/tests/labels.py
+++ b/python/metatensor_core/tests/labels.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pytest
 
@@ -430,3 +432,24 @@ def test_equal_non_contiguous():
     labels_non_contiguous = Labels(names=["a", "b"], values=values_non_contiguous)
     labels_contiguous = Labels(names=["a", "b"], values=values_contiguous)
     assert labels_contiguous == labels_non_contiguous
+
+
+def test_ownership_transfer():
+    """Test releasing and recovering Labels via ``unsafe_from_ptr``"""
+    labels = Labels(names=["foo", "bar"], values=np.array([[1, 2], [3, 4], [5, 6]]))
+
+    raw = labels.release()
+    message = "can not access these Labels, they have been released"
+    with pytest.raises(RuntimeError, match=re.escape(message)):
+        labels.as_mts_labels_t()
+
+    recovered = Labels.unsafe_from_ptr(raw)
+    assert recovered == Labels(
+        names=["foo", "bar"], values=np.array([[1, 2], [3, 4], [5, 6]])
+    )
+
+    raw = recovered.release()
+    with pytest.raises(RuntimeError, match=re.escape(message)):
+        recovered.as_mts_labels_t()
+
+    Labels.unsafe_from_ptr(raw)

--- a/python/metatensor_core/tests/origin.py
+++ b/python/metatensor_core/tests/origin.py
@@ -1,8 +1,10 @@
+import re
+
 import numpy as np
 import pytest
 import torch
 
-from metatensor import Labels, TensorBlock, TensorMap
+from metatensor import Labels, MetatensorError, TensorBlock, TensorMap
 
 
 def test_different_origins():
@@ -27,10 +29,11 @@ def test_different_origins():
         properties=Labels.single(),
     )
 
-    message = (
-        "all blocks in a TensorMap must have the same origin, "
-        "got 'python.numpy' and 'python.torch'"
+    message = re.escape(
+        "invalid parameter: tried to build a TensorMap from blocks with "
+        "different origins: at least ('python.numpy') and ('python.torch') "
+        "were detected"
     )
 
-    with pytest.raises(ValueError, match=message):
+    with pytest.raises(MetatensorError, match=message):
         TensorMap(keys=keys, blocks=[block_numpy, block_torch])

--- a/python/metatensor_core/tests/tensor.py
+++ b/python/metatensor_core/tests/tensor.py
@@ -1,4 +1,5 @@
 import copy
+import re
 import sys
 import warnings
 
@@ -569,7 +570,7 @@ def test_different_device():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
 
-        block_1 = TensorBlock(
+        block_meta = TensorBlock(
             values=torch.tensor([[3.0, 4.0]], device="meta"),
             samples=Labels.range("s", 1),
             components=[],
@@ -578,12 +579,12 @@ def test_different_device():
 
     message = (
         "Blocks values and keys for this TensorMap are on different devices: "
-        "keys are always on CPU, and blocks values are on device 'meta'."
+        "keys are always on CPU, and blocks values are on device 'meta'"
     )
     with pytest.warns(DeviceWarning, match=message):
-        _ = TensorMap(Labels.range("k", 1), [block_1.copy()])
+        _ = TensorMap(Labels.range("k", 1), [block_meta.copy()])
 
-    block_2 = TensorBlock(
+    block_cpu = TensorBlock(
         values=torch.tensor([[3.0, 4.0]]),
         samples=Labels.range("s", 1),
         components=[],
@@ -591,10 +592,12 @@ def test_different_device():
     )
 
     message = (
-        "all blocks in a TensorMap must have the same device, got 'meta' and 'cpu'"
+        "invalid parameter: tried to build a TensorMap from blocks "
+        "on different devices: at least 'CPU:0' and 'ExtDev:0' were detected"
     )
-    with pytest.raises(ValueError, match=message):
-        _ = TensorMap(Labels.range("k", 2), [block_1, block_2])
+
+    with pytest.raises(MetatensorError, match=message):
+        _ = TensorMap(Labels.range("k", 2), [block_cpu, block_meta])
 
 
 def test_different_dtype():
@@ -612,9 +615,10 @@ def test_different_dtype():
     )
 
     message = (
-        "all blocks in a TensorMap must have the same dtype, got float64 and float32"
+        "invalid parameter: tried to build a TensorMap from blocks with "
+        "different dtypes: at least 'f64' and 'f32' were detected"
     )
-    with pytest.raises(ValueError, match=message):
+    with pytest.raises(MetatensorError, match=message):
         _ = TensorMap(Labels.range("k", 2), [block_1, block_2])
 
 
@@ -759,3 +763,63 @@ def test_keys_to_samples_fill_value_default(tensor):
 
     for i in range(len(tensor_default)):
         assert_equal(tensor_default.block(i).values, tensor_explicit.block(i).values)
+
+
+def test_ownership_transfer(tensor):
+    """Test releasing and recovering a TensorMap via ``unsafe_from_ptr``"""
+    assert not tensor.is_view
+    keys = tensor.keys
+    raw = tensor.release()
+
+    message = "this TensorMap has been released and can no longer be used"
+    with pytest.raises(ValueError, match=re.escape(message)):
+        tensor.as_mts_tensormap_t()
+
+    recovered = TensorMap.unsafe_from_ptr(raw)
+    assert recovered.keys == keys
+
+    raw = recovered.release()
+    with pytest.raises(ValueError, match=re.escape(message)):
+        recovered.as_mts_tensormap_t()
+
+    TensorMap.unsafe_from_ptr(raw)
+
+
+def test_block_view_ownership(tensor):
+    """Test that block views from a TensorMap keep the TensorMap alive"""
+    block = tensor.block(0)
+    assert block.is_view
+
+    message = (
+        "can not release this TensorBlock, it is a view inside another TensorBlock "
+        "or a TensorMap"
+    )
+    with pytest.raises(RuntimeError, match=re.escape(message)):
+        block.release()
+
+    block.samples
+    block.values
+
+    # The tensor map should still be usable
+    assert tensor.keys.names == ["key_1", "key_2"]
+
+
+def test_unsafe_view(tensor):
+    """Test creating a non-owning view of a TensorMap"""
+    assert not tensor.is_view
+
+    raw = tensor.as_mts_tensormap_t()
+    view = TensorMap.unsafe_view_from_ptr(raw, parent=tensor)
+
+    assert view.is_view
+    assert view.keys == tensor.keys
+
+    # creating a view should not prevent using the original
+    assert tensor.keys.names == ["key_1", "key_2"]
+
+    message = (
+        "can not release this TensorMap, it is already a view inside "
+        "another TensorMap or TensorBlock"
+    )
+    with pytest.raises(RuntimeError, match=re.escape(message)):
+        view.release()

--- a/python/metatensor_torch/metatensor_torch/_documentation.py
+++ b/python/metatensor_torch/metatensor_torch/_documentation.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple, Union, overload
+from typing import Any, Dict, List, Optional, Tuple, Union, overload
 
 import torch
 
@@ -648,6 +648,45 @@ class Labels:
         """
         raise THIS_CODE_SHOULD_NOT_RUN
 
+    @staticmethod
+    def unsafe_from_ptr(ptr: int) -> "Labels":
+        """
+        Create a :py:class:`Labels` from a raw ``mts_labels_t`` pointer. The
+        :py:class:`Labels` takes ownership of the pointer, and will release the
+        corresponding memory when garbage-collected.
+
+        .. warning::
+
+            PyTorch can execute ``static`` functions (like this one) coming from a
+            TorchScript extension, but fails when trying to save code calling this
+            function with :py:func:`torch.jit.save`, giving the following error:
+
+                Failed to downcast a Function to a GraphFunction
+
+            .. _pytorch-115639: https://github.com/pytorch/pytorch/issues/115639
+
+        :param ptr: the pointer as an integer, which will be reinterpreted as a
+            ``mts_labels_t*``
+        """
+        raise THIS_CODE_SHOULD_NOT_RUN
+
+    def release(self) -> int:
+        """
+        Release the underlying C pointer of these :py:class:`Labels`. The
+        holder is no longer managing the labels memory after the call. The user
+        is expected to re-create Labels with :py:func:`Labels.unsafe_from_ptr`,
+        or pass the pointer to a C function that will call ``mts_labels_free``.
+        """
+        raise THIS_CODE_SHOULD_NOT_RUN
+
+    def as_mts_labels_t(self) -> int:
+        """
+        Get the underlying ``mts_labels_t`` pointer as an integer. The holder
+        still manages the labels memory after the call. Use
+        :py:func:`Labels.release` to take ownership of the pointer.
+        """
+        raise THIS_CODE_SHOULD_NOT_RUN
+
     def entry(self, index: int) -> LabelsEntry:
         """get a single entry in these labels, see also :py:func:`Labels.__getitem__`"""
         raise THIS_CODE_SHOULD_NOT_RUN
@@ -966,6 +1005,14 @@ class TensorBlock:
         """
         raise THIS_CODE_SHOULD_NOT_RUN
 
+    @property
+    def is_view(self) -> bool:
+        """
+        Check if this :py:class:`TensorBlock` is a view (i.e. does not own the
+        underlying data).
+        """
+        raise THIS_CODE_SHOULD_NOT_RUN
+
     def to(
         self,
         dtype: Optional[torch.dtype] = None,
@@ -1051,6 +1098,71 @@ class TensorBlock:
         """
         Save this :py:class:`TensorBlock` to an in-memory buffer, this is equivalent to
         :py:func:`metatensor.torch.save_buffer`.
+        """
+        raise THIS_CODE_SHOULD_NOT_RUN
+
+    @staticmethod
+    def unsafe_from_ptr(ptr: int) -> "TensorBlock":
+        """
+        Create a :py:class:`TensorBlock` from a raw ``mts_block_t`` pointer. The
+        :py:class:`TensorBlock` takes ownership of the pointer, and will release the
+        corresponding memory when garbage-collected.
+
+        .. warning::
+
+            PyTorch can execute ``static`` functions (like this one) coming from a
+            TorchScript extension, but fails when trying to save code calling this
+            function with :py:func:`torch.jit.save`, giving the following error:
+
+                Failed to downcast a Function to a GraphFunction
+
+            .. _pytorch-115639: https://github.com/pytorch/pytorch/issues/115639
+
+        :param ptr: the pointer as an integer, which will be reinterpreted as a
+            ``mts_block_t*``
+        """
+        raise THIS_CODE_SHOULD_NOT_RUN
+
+    @staticmethod
+    def unsafe_view_from_ptr(ptr: int, parent: Any) -> "TensorBlock":
+        """
+        Create a :py:class:`TensorBlock` from a raw ``mts_block_t`` pointer, keeping a
+        reference to the ``parent`` to prevent garbage collection.
+
+        The :py:class:`TensorBlock` does **not** take ownership of the pointer, and
+        will not release the corresponding memory.
+
+        .. warning::
+
+            PyTorch can execute ``static`` functions (like this one) coming from a
+            TorchScript extension, but fails when trying to save code calling this
+            function with :py:func:`torch.jit.save`, giving the following error:
+
+                Failed to downcast a Function to a GraphFunction
+
+            .. _pytorch-115639: https://github.com/pytorch/pytorch/issues/115639
+
+        :param ptr: the pointer as an integer, which will be reinterpreted as a
+            ``mts_block_t*``
+        :param parent: the parent object to keep alive
+        """
+        raise THIS_CODE_SHOULD_NOT_RUN
+
+    def release(self) -> int:
+        """
+        Release the underlying C pointer of this :py:class:`TensorBlock`. The holder is
+        no longer managing the block memory after the call. The user is expected to
+        re-create a :py:class:`TensorBlock` with
+        :py:func:`TensorBlock.unsafe_from_ptr`, or pass the pointer to a C function
+        that will call ``mts_block_free``.
+        """
+        raise THIS_CODE_SHOULD_NOT_RUN
+
+    def as_mts_block_t(self) -> int:
+        """
+        Get the underlying ``mts_block_t`` pointer as an integer. The holder still
+        manages the block memory after the call. Use :py:func:`TensorBlock.release` to
+        take ownership of the pointer.
         """
         raise THIS_CODE_SHOULD_NOT_RUN
 
@@ -1387,6 +1499,14 @@ class TensorMap:
         """
         raise THIS_CODE_SHOULD_NOT_RUN
 
+    @property
+    def is_view(self) -> bool:
+        """
+        Check if this :py:class:`TensorMap` is a view (i.e. does not own the
+        underlying data).
+        """
+        raise THIS_CODE_SHOULD_NOT_RUN
+
     def to(
         self,
         dtype: Optional[torch.dtype] = None,
@@ -1433,6 +1553,71 @@ class TensorMap:
     def info(self) -> Dict[str, str]:
         """
         Get all the key/value info pairs stored in this :py:class:`TensorMap`.
+        """
+        raise THIS_CODE_SHOULD_NOT_RUN
+
+    @staticmethod
+    def unsafe_from_ptr(ptr: int) -> "TensorMap":
+        """
+        Create a :py:class:`TensorMap` from a raw ``mts_tensormap_t`` pointer. The
+        :py:class:`TensorMap` takes ownership of the pointer, and will release the
+        corresponding memory when garbage-collected.
+
+        .. warning::
+
+            PyTorch can execute ``static`` functions (like this one) coming from a
+            TorchScript extension, but fails when trying to save code calling this
+            function with :py:func:`torch.jit.save`, giving the following error:
+
+                Failed to downcast a Function to a GraphFunction
+
+            .. _pytorch-115639: https://github.com/pytorch/pytorch/issues/115639
+
+        :param ptr: the pointer as an integer, which will be reinterpreted as a
+            ``mts_tensormap_t*``
+        """
+        raise THIS_CODE_SHOULD_NOT_RUN
+
+    @staticmethod
+    def unsafe_view_from_ptr(ptr: int, parent: Any) -> "TensorMap":
+        """
+        Create a :py:class:`TensorMap` from a raw ``mts_tensormap_t`` pointer, keeping a
+        reference to the ``parent`` to prevent garbage collection.
+
+        The :py:class:`TensorMap` does **not** take ownership of the pointer, and
+        will not release the corresponding memory.
+
+        .. warning::
+
+            PyTorch can execute ``static`` functions (like this one) coming from a
+            TorchScript extension, but fails when trying to save code calling this
+            function with :py:func:`torch.jit.save`, giving the following error:
+
+                Failed to downcast a Function to a GraphFunction
+
+            .. _pytorch-115639: https://github.com/pytorch/pytorch/issues/115639
+
+        :param ptr: the pointer as an integer, which will be reinterpreted as a
+            ``mts_tensormap_t*``
+        :param parent: the parent object to keep alive
+        """
+        raise THIS_CODE_SHOULD_NOT_RUN
+
+    def release(self) -> int:
+        """
+        Release the underlying C pointer of this :py:class:`TensorMap`. The holder is
+        no longer managing the tensor map memory after the call. The user is expected to
+        re-create a :py:class:`TensorMap` with
+        :py:func:`TensorMap.unsafe_from_ptr`, or pass the pointer to a C function
+        that will call ``mts_tensormap_free``.
+        """
+        raise THIS_CODE_SHOULD_NOT_RUN
+
+    def as_mts_tensormap_t(self) -> int:
+        """
+        Get the underlying ``mts_tensormap_t`` pointer as an integer. The holder still
+        manages the tensor map memory after the call. Use
+        :py:func:`TensorMap.release` to take ownership of the pointer.
         """
         raise THIS_CODE_SHOULD_NOT_RUN
 

--- a/python/metatensor_torch/tests/block.py
+++ b/python/metatensor_torch/tests/block.py
@@ -452,3 +452,64 @@ def test_script():
 
     module = TestModule()
     module = torch.jit.script(module)
+
+
+def test_block_ownership_transfer():
+    """Test releasing and recovering a TensorBlock via ``unsafe_from_ptr``"""
+    block = TensorBlock(
+        values=torch.full((3, 2), 11.0),
+        samples=Labels(names=["s"], values=torch.tensor([[0], [2], [1]])),
+        components=[],
+        properties=Labels(names=["p"], values=torch.tensor([[1], [0]])),
+    )
+    assert not block.is_view
+
+    message = (
+        "can not access this TensorBlock, it has been released or moved inside a "
+        "TensorMap or another TensorBlock"
+    )
+
+    raw = block.release()
+
+    with pytest.raises(RuntimeError, match=message):
+        block.as_mts_block_t()
+
+    recovered = TensorBlock.unsafe_from_ptr(raw)
+    assert torch.all(recovered.values == torch.full((3, 2), 11.0))
+    assert recovered.samples == Labels(
+        names=["s"], values=torch.tensor([[0], [2], [1]])
+    )
+    assert recovered.properties == Labels(names=["p"], values=torch.tensor([[1], [0]]))
+
+    raw = recovered.release()
+    with pytest.raises(RuntimeError, match=message):
+        recovered.as_mts_block_t()
+
+    TensorBlock.unsafe_from_ptr(raw)
+
+
+def test_block_unsafe_view():
+    """Test creating a non-owning view of a TensorBlock"""
+    block = TensorBlock(
+        values=torch.full((3, 2), 11.0),
+        samples=Labels(names=["s"], values=torch.tensor([[0], [2], [1]])),
+        components=[],
+        properties=Labels(names=["p"], values=torch.tensor([[1], [0]])),
+    )
+
+    raw = block.as_mts_block_t()
+    view = TensorBlock.unsafe_view_from_ptr(raw, block)
+
+    assert view.is_view
+    assert torch.all(view.values == torch.full((3, 2), 11.0))
+    assert view.samples == block.samples
+
+    message = (
+        "can not release this TensorBlock, it is a view inside another "
+        "TensorBlock or a TensorMap"
+    )
+    with pytest.raises(RuntimeError, match=message):
+        view.release()
+
+    # original block should still be usable after creating a view
+    assert block.samples == Labels(names=["s"], values=torch.tensor([[0], [2], [1]]))

--- a/python/metatensor_torch/tests/labels.py
+++ b/python/metatensor_torch/tests/labels.py
@@ -682,3 +682,26 @@ def test_equal_non_contiguous():
     labels_contiguous = Labels(names=["a", "b"], values=values_contiguous)
 
     assert labels_contiguous == labels_non_contiguous
+
+
+def test_labels_ownership_transfer():
+    """Test releasing and recovering Labels via ``unsafe_from_ptr``"""
+    labels = Labels(names=["foo", "bar"], values=torch.tensor([[1, 2], [3, 4], [5, 6]]))
+
+    message = "can not access these Labels, they have been released"
+
+    raw = labels.release()
+
+    with pytest.raises(RuntimeError, match=message):
+        labels.as_mts_labels_t()
+
+    recovered = Labels.unsafe_from_ptr(raw)
+    assert recovered == Labels(
+        names=["foo", "bar"], values=torch.tensor([[1, 2], [3, 4], [5, 6]])
+    )
+
+    raw = recovered.release()
+    with pytest.raises(RuntimeError, match=message):
+        recovered.as_mts_labels_t()
+
+    Labels.unsafe_from_ptr(raw)

--- a/python/metatensor_torch/tests/tensor.py
+++ b/python/metatensor_torch/tests/tensor.py
@@ -788,3 +788,59 @@ def test_keys_to_samples_fill_value_default(tensor):
             tensor_default.block_by_id(i).values
             == tensor_explicit.block_by_id(i).values
         )
+
+
+def test_tensormap_ownership_transfer(tensor):
+    """Test releasing and recovering a TensorMap via ``unsafe_from_ptr``"""
+    assert not tensor.is_view
+    keys = tensor.keys
+
+    message = "can not access this TensorMap, it has been released"
+
+    raw = tensor.release()
+
+    with pytest.raises(RuntimeError, match=message):
+        tensor.as_mts_tensormap_t()
+
+    recovered = TensorMap.unsafe_from_ptr(raw)
+    assert recovered.keys == keys
+
+    raw = recovered.release()
+    with pytest.raises(RuntimeError, match=message):
+        recovered.as_mts_tensormap_t()
+
+    TensorMap.unsafe_from_ptr(raw)
+
+
+def test_tensormap_unsafe_view(tensor):
+    """Test creating a non-owning view of a TensorMap"""
+    assert not tensor.is_view
+
+    raw = tensor.as_mts_tensormap_t()
+    view = TensorMap.unsafe_view_from_ptr(raw, tensor)
+
+    assert view.is_view
+    assert view.keys == tensor.keys
+
+    # creating a view should not prevent using the original
+    assert tensor.keys.names == ["key_1", "key_2"]
+
+
+def test_tensormap_block_view_ownership(tensor):
+    """Test that block views from a TensorMap keep the TensorMap alive"""
+    block = tensor.block(0)
+    assert block.is_view
+
+    message = (
+        "can not release this TensorBlock, it is a view inside another "
+        "TensorBlock or a TensorMap"
+    )
+    with pytest.raises(RuntimeError, match=message):
+        block.release()
+
+    # The block should still be usable
+    block.samples
+    block.values
+
+    # The tensor map should still be usable
+    assert tensor.keys.names == ["key_1", "key_2"]

--- a/rust/metatensor/CHANGELOG.md
+++ b/rust/metatensor/CHANGELOG.md
@@ -22,6 +22,9 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `TensorBlock::dtype` for retrieving the device and data type of the underlying
   arrays.
 
+- `TensorMap::{from,into}_raw`, `TensorBlock::{from,into}_raw` and
+  `Labels::{from,into}_raw` to enable conversion between Rust and C API types.
+
 ## [Version 0.3.0](https://github.com/metatensor/metatensor/releases/tag/metatensor-rust-v0.3.0) - 2026-05-13
 
 ### Added

--- a/rust/metatensor/src/block/block_mut.rs
+++ b/rust/metatensor/src/block/block_mut.rs
@@ -68,7 +68,7 @@ impl<'a> TensorBlockRefMut<'a> {
     /// is actually constrained by the lifetime of the owner of this
     /// `mts_block_t`; and that the owner is mutably borrowed by this
     /// `TensorBlockRefMut`.
-    pub(crate) unsafe fn from_raw(ptr: *mut mts_block_t) -> TensorBlockRefMut<'a> {
+    pub unsafe fn from_raw(ptr: *mut mts_block_t) -> TensorBlockRefMut<'a> {
         assert!(!ptr.is_null(), "pointer to mts_block_t should not be NULL");
 
         TensorBlockRefMut {
@@ -78,12 +78,12 @@ impl<'a> TensorBlockRefMut<'a> {
     }
 
     /// Get the underlying raw pointer
-    pub(super) fn as_ptr(&self) -> *const mts_block_t {
+    pub fn as_ptr(&self) -> *const mts_block_t {
         self.ptr
     }
 
     /// Get the underlying (mutable) raw pointer
-    pub(super) fn as_mut_ptr(&mut self) -> *mut mts_block_t {
+    pub fn as_mut_ptr(&mut self) -> *mut mts_block_t {
         self.ptr
     }
 

--- a/rust/metatensor/src/block/block_ref.rs
+++ b/rust/metatensor/src/block/block_ref.rs
@@ -44,7 +44,7 @@ impl<'a> TensorBlockRef<'a> {
     /// This is a **VERY** unsafe function, creating a lifetime out of thin air.
     /// Make sure the lifetime is actually constrained by the lifetime of the
     /// owner of this `mts_block_t`.
-    pub(crate) unsafe fn from_raw(ptr: *const mts_block_t) -> TensorBlockRef<'a> {
+    pub unsafe fn from_raw(ptr: *const mts_block_t) -> TensorBlockRef<'a> {
         assert!(!ptr.is_null(), "pointer to mts_block_t should not be NULL");
 
         TensorBlockRef {
@@ -54,7 +54,7 @@ impl<'a> TensorBlockRef<'a> {
     }
 
     /// Get the underlying raw pointer
-    pub(crate) fn as_ptr(&self) -> *const mts_block_t {
+    pub fn as_ptr(&self) -> *const mts_block_t {
         self.ptr
     }
 }

--- a/rust/metatensor/src/block/owned.rs
+++ b/rust/metatensor/src/block/owned.rs
@@ -36,7 +36,7 @@ impl TensorBlock {
     ///
     /// The pointer must be non-null and point to a owned block, not a reference
     /// to a block from inside a [`TensorMap`](crate::TensorMap).
-    pub(crate) unsafe fn from_raw(ptr: *mut mts_block_t) -> TensorBlock {
+    pub unsafe fn from_raw(ptr: *mut mts_block_t) -> TensorBlock {
         assert!(!ptr.is_null(), "pointer to mts_block_t should not be NULL");
 
         TensorBlock {
@@ -44,13 +44,28 @@ impl TensorBlock {
         }
     }
 
-    /// Get the underlying raw pointer
-    pub(super) fn as_ptr(&self) -> *const mts_block_t {
+    /// Extract the underlying raw pointer.
+    ///
+    /// The pointer should be passed back to [`TensorBlock::from_raw`] or
+    /// [`crate::c_api::mts_block_free`] to release the memory corresponding
+    /// to this `TensorBlock`.
+    pub fn into_raw(mut block: TensorBlock) -> *mut mts_block_t {
+        return std::mem::replace(&mut block.ptr, std::ptr::null_mut());
+    }
+
+    /// Get the underlying raw pointer.
+    ///
+    /// After a call, this `TensorBlock` is still managing the corresponding
+    /// memory. To fully release the pointer, use [`TensorBlock::into_raw`].
+    pub fn as_ptr(&self) -> *const mts_block_t {
         self.ptr
     }
 
     /// Get the underlying (mutable) raw pointer
-    pub(super) fn as_mut_ptr(&mut self) -> *mut mts_block_t {
+    ///
+    /// After a call, this `TensorBlock` is still managing the corresponding
+    /// memory. To fully release the pointer, use [`TensorBlock::into_raw`].
+    pub fn as_mut_ptr(&mut self) -> *mut mts_block_t {
         self.ptr
     }
 
@@ -242,5 +257,21 @@ mod tests {
         let dtype = block.dtype().unwrap();
         assert_eq!(dtype.code, dlpk::sys::DLDataTypeCode::kDLFloat);
         assert_eq!(dtype.bits, 64);
+    }
+
+    #[test]
+    fn tensor_block_into_raw() {
+        let block = TensorBlock::new(
+            ndarray::Array::from_elem(vec![3, 2], 1.0),
+            &Labels::new(["samples"], &[[0], [1], [4]]),
+            &[],
+            &Labels::new(["properties"], &[[5], [3]]),
+        ).unwrap();
+
+        let raw = TensorBlock::into_raw(block);
+
+        let recovered = unsafe { TensorBlock::from_raw(raw) };
+        assert_eq!(recovered.samples(), Labels::new(["samples"], &[[0], [1], [4]]));
+        assert_eq!(recovered.properties(), Labels::new(["properties"], &[[5], [3]]));
     }
 }

--- a/rust/metatensor/src/labels.rs
+++ b/rust/metatensor/src/labels.rs
@@ -227,6 +227,17 @@ impl Labels {
         }
     }
 
+    /// Consume the Labels and get the underlying raw pointer.
+    ///
+    /// After calling this function, the user is responsible for free-ing the
+    /// data in `mts_labels_t`, either by re-creating labels with
+    /// [`Labels::from_raw`] or passing it to a C API function that will call
+    /// [`crate::c_api::mts_labels_free`] on it.
+    #[inline]
+    pub fn into_raw(mut labels: Labels) -> *const mts_labels_t {
+        return std::mem::replace(&mut labels.ptr, std::ptr::null());
+    }
+
     /// Create a set of `Labels` with the given names, containing no entries.
     #[inline]
     pub fn empty(names: Vec<&str>) -> Labels {
@@ -1127,5 +1138,14 @@ mod tests {
         assert_eq!(err.message,
             "invalid parameter: 'aaa' in selection is not part of these Labels"
         );
+    }
+
+    #[test]
+    fn labels_into_raw() {
+        let original = Labels::new(["foo", "bar"], &[[1, 2], [3, 4], [5, 6]]);
+        let raw = Labels::into_raw(original);
+
+        let recovered = unsafe { Labels::from_raw(raw) };
+        assert_eq!(recovered, Labels::new(["foo", "bar"], &[[1, 2], [3, 4], [5, 6]]));
     }
 }

--- a/rust/metatensor/src/tensor.rs
+++ b/rust/metatensor/src/tensor.rs
@@ -85,8 +85,8 @@ impl TensorMap {
     ///
     /// # Safety
     ///
-    /// The pointer must be non-null and created by `mts_tensormap` or
-    /// `TensorMap::into_raw`.
+    /// The pointer must be non-null and created by
+    /// [`crate::c_api::mts_tensormap`] or [`TensorMap::into_raw`].
     pub unsafe fn from_raw(ptr: *mut mts_tensormap_t) -> TensorMap {
         assert!(!ptr.is_null());
 
@@ -102,13 +102,27 @@ impl TensorMap {
 
     /// Extract the underlying raw pointer.
     ///
-    /// The pointer should be passed back to `TensorMap::from_raw` or
-    /// `mts_tensormap_free` to release the memory corresponding to this
-    /// `TensorMap`.
-    pub fn into_raw(mut map: TensorMap) -> *mut mts_tensormap_t {
-        let ptr = map.ptr;
-        map.ptr = std::ptr::null_mut();
-        return ptr;
+    /// The pointer should be passed back to [`TensorMap::from_raw`] or
+    /// [`crate::c_api::mts_tensormap_free`] to release the memory corresponding
+    /// to this `TensorMap`.
+    pub fn into_raw(mut tensor: TensorMap) -> *mut mts_tensormap_t {
+        return std::mem::replace(&mut tensor.ptr, std::ptr::null_mut());
+    }
+
+    /// Get the underlying raw pointer.
+    ///
+    /// After a call, this `TensorMap` is still managing the corresponding
+    /// memory. To fully release the pointer, use [`TensorMap::into_raw`].
+    pub fn as_ptr(&self) -> *const mts_tensormap_t {
+        self.ptr
+    }
+
+    /// Get the underlying (mutable) raw pointer
+    ///
+    /// After a call, this `TensorMap` is still managing the corresponding
+    /// memory. To fully release the pointer, use [`TensorMap::into_raw`].
+    pub fn as_mut_ptr(&mut self) -> *mut mts_tensormap_t {
+        self.ptr
     }
 
     /// Clone this `TensorMap`, cloning all the data and metadata contained inside.
@@ -848,5 +862,17 @@ mod tests {
         let dtype = tensor.dtype().unwrap();
         assert_eq!(dtype.code, dlpk::sys::DLDataTypeCode::kDLFloat);
         assert_eq!(dtype.bits, 64);
+    }
+
+    #[test]
+    fn tensor_map_into_raw() {
+        let tensor = test_tensor();
+        let raw = TensorMap::into_raw(tensor);
+
+        let recovered = unsafe { TensorMap::from_raw(raw) };
+        assert_eq!(
+            recovered.keys(),
+            &Labels::new(["key", "other"], &[[1, 0], [3, 1], [-4, 0]])
+        );
     }
 }


### PR DESCRIPTION
Every language binding now has a version of `TensorMap::from_ptr` and `TensorMap::release_ptr` (and similar for Labels/TensorBlock). This will enable e.g. Python code to create a TensorMap, and then relinquish ownership of it when passing it down to C++.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?
