### PR TITLE
Add reserved space to all C++ classes

### DIFF
--- a/metatensor-core/include/metatensor/arrays.hpp
+++ b/metatensor-core/include/metatensor/arrays.hpp
@@ -363,6 +363,8 @@ public:
         managed_(managed),
         data_(nullptr)
     {
+        (void)reserved_;
+
         if (managed_ == nullptr) {
             shape_ = {};
             strides_ = {};
@@ -524,6 +526,10 @@ private:
     std::vector<size_t> shape_;
     /// Strides extracted from the DLTensor (in element counts)
     std::vector<int64_t> strides_;
+
+    /// reserved space for future expansion of the class without breaking
+    /// ABI compatibility
+    uint8_t reserved_[16];
 };
 
 /// Compare this `DLPackArray` with another `DLPackArray`. The arrays are equal if
@@ -554,7 +560,9 @@ template<typename T>
 class NDArray {
 public:
     /// Create a new empty `NDArray`.
-    NDArray(): NDArray(nullptr, {}, true) {}
+    NDArray(): NDArray(nullptr, {}, true) {
+        (void)reserved_;
+    }
 
     /// Create a new `NDArray` using a non-owning view in `const` memory with
     /// the given `shape`.
@@ -793,6 +801,10 @@ private:
     void* owned_data_ = nullptr;
     /// Custom delete function for the `owned_data_`.
     std::function<void(void*)> deleter_;
+
+    /// reserved space for future expansion of the class without breaking
+    /// ABI compatibility
+    uint8_t reserved_[16];
 };
 
 
@@ -846,7 +858,9 @@ bool operator!=(const NDArray<T>& lhs, const DLPackArray<T>& rhs) {
 class MtsArray final {
 public:
     /// Create an `MtsArray` that takes ownership of the given `mts_array_t`.
-    explicit MtsArray(mts_array_t array): array_(array) {}
+    explicit MtsArray(mts_array_t array): array_(array) {
+        (void)reserved_;
+    }
 
     ~MtsArray() {
         if (array_.destroy != nullptr) {
@@ -867,6 +881,10 @@ public:
 
     /// MtsArray can be copy-assigned
     MtsArray& operator=(const MtsArray& other) {
+        if (this == &other) {
+            return *this;
+        }
+
         if (other.array_.copy == nullptr) {
             throw Error("invalid mts_array_t: null copy function pointer");
         }
@@ -1072,6 +1090,10 @@ public:
 
 private:
     mts_array_t array_;
+
+    /// reserved space for future expansion of the class without breaking
+    /// ABI compatibility
+    uint8_t reserved_[24];
 };
 
 /// `DataArrayBase` manages n-dimensional arrays used as data in a block or
@@ -1341,7 +1363,10 @@ public:
     SimpleDataArray(std::vector<uintptr_t> shape, T value = T{}):
         shape_(std::move(shape)),
         strides_(details::contiguous_strides(shape_)),
-        data_(std::make_shared<std::vector<T>>(details::product(shape_), value)) {}
+        data_(std::make_shared<std::vector<T>>(details::product(shape_), value))
+    {
+        (void)reserved_;
+    }
 
     /// Create a SimpleDataArray with the given `shape` and `data`.
     ///
@@ -1730,6 +1755,10 @@ private:
     std::vector<uintptr_t> shape_;
     std::vector<int64_t> strides_;
     std::shared_ptr<std::vector<T>> data_;
+
+    /// reserved space for future expansion of the class without breaking
+    /// ABI compatibility
+    uint8_t reserved_[16];
 
     template <typename U>
     friend bool operator==(const SimpleDataArray<U>& lhs, const SimpleDataArray<U>& rhs);

--- a/metatensor-core/include/metatensor/block.hpp
+++ b/metatensor-core/include/metatensor/block.hpp
@@ -69,7 +69,10 @@ public:
         const Labels& samples,
         const std::vector<Labels>& components,
         const Labels& properties
-    ): TensorBlock(details::create_block(std::move(values), samples, components, properties), /*view*/ false) {}
+    ): TensorBlock(details::create_block(std::move(values), samples, components, properties), /*view*/ false)
+    {
+        (void)reserved_;
+    }
 
     ~TensorBlock() {
         if (!is_view_) {
@@ -490,5 +493,9 @@ private:
 
     mts_block_t* block_;
     bool is_view_;
+
+    /// reserve some space for future expansion of the class without breaking
+    /// ABI
+    uint8_t reserved_[16];
 };
 } // namespace metatensor

--- a/metatensor-core/include/metatensor/labels.hpp
+++ b/metatensor-core/include/metatensor/labels.hpp
@@ -48,6 +48,8 @@ public:
     Labels(const std::vector<std::string>& dimensions, MtsArray values):
         labels_(nullptr)
     {
+        (void)reserved_;
+
         auto c_dimensions = std::vector<const char*>();
         c_dimensions.reserve(dimensions.size());
         for (const auto& name: dimensions) {
@@ -729,6 +731,10 @@ private:
 
     /// Owning pointer to the opaque labels
     const mts_labels_t* labels_;
+
+    /// reserve some space for future expansion of the class without breaking
+    /// ABI
+    uint8_t reserved_[24];
 
     friend bool operator==(const Labels& lhs, const Labels& rhs);
 };

--- a/metatensor-core/include/metatensor/tensor.hpp
+++ b/metatensor-core/include/metatensor/tensor.hpp
@@ -40,6 +40,8 @@ class TensorMapInfo {
 public:
     /// @private Create an iterator for the given `tensor`
     explicit TensorMapInfo(mts_tensormap_t* tensor) : tensor_(tensor) {
+        (void)reserved_;
+
         details::check_status(mts_tensormap_info_keys(
             tensor_,
             &keys_,
@@ -104,6 +106,10 @@ private:
     mts_tensormap_t* tensor_;
     const char* const* keys_;
     uintptr_t count_;
+
+    /// reserved space for future expansion of the class without breaking
+    /// ABI compatibility
+    uint8_t reserved_[8];
 };
 
 }
@@ -122,6 +128,8 @@ class TensorMap final {
 public:
     /// Create a new TensorMap with the given `keys` and `blocks`
     TensorMap(Labels keys, std::vector<TensorBlock> blocks): tensor_(nullptr), is_view_(false) {
+        (void)reserved_;
+
         auto c_blocks = std::vector<mts_block_t*>();
         for (auto& block: blocks) {
             // We will move the data inside the new map, let's release the
@@ -668,6 +676,10 @@ private:
 
     mts_tensormap_t* tensor_;
     bool is_view_;
+
+    /// reserved space for future expansion of the class without breaking
+    /// ABI compatibility
+    uint8_t reserved_[16];
 };
 
 } // namespace metatensor

--- a/metatensor-core/src/labels/array.rs
+++ b/metatensor-core/src/labels/array.rs
@@ -234,7 +234,7 @@ unsafe extern "C" fn labels_array_as_dlpack(
             return Err(Error::InvalidParameter(
                 format!(
                     "invalid `max_version` in LabelsArray::as_dlpack: \
-                    we got v{}.{}, but we support v{}.{})",
+                    we got v{}.{}, but we support v{}.{}",
                     max_version.major, max_version.minor, current.major, current.minor
                 )
             ));

--- a/metatensor-core/tests/cpp/blocks.cpp
+++ b/metatensor-core/tests/cpp/blocks.cpp
@@ -9,6 +9,10 @@ using namespace metatensor;
 static void check_loaded_block(metatensor::TensorBlock& block);
 
 TEST_CASE("Blocks") {
+    // Any change here means the ABI will break and the new version will need to
+    // be a major version bump.
+    CHECK(sizeof(TensorBlock) == 32);
+
     SECTION("no components") {
         auto block = TensorBlock(
             std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({3, 2})),

--- a/metatensor-core/tests/cpp/data.cpp
+++ b/metatensor-core/tests/cpp/data.cpp
@@ -6,6 +6,37 @@
 #include <metatensor.hpp>
 using namespace metatensor;
 
+TEST_CASE("Array sizes") {
+    // Any change here means the ABI will break and the new version will need to
+    // be a major version bump.
+    CHECK(sizeof(MtsArray) == 128);
+    CHECK(sizeof(mts_array_t) == 104);
+
+    CHECK(sizeof(DataArrayBase) == 8);
+
+    size_t base_size = sizeof(void*)
+                    + sizeof(std::vector<size_t>)
+                    + sizeof(std::vector<int64_t>)
+                    + sizeof(bool) + 7 // padding
+                    + sizeof(void*)
+                    + sizeof(std::function<void(void*)>);
+    CHECK(sizeof(NDArray<double>) == base_size + 16);
+    CHECK(sizeof(NDArray<char>) == base_size + 16);
+
+    base_size = sizeof(DataArrayBase)
+              + sizeof(std::vector<uintptr_t>)
+              + sizeof(std::vector<int64_t>)
+              + sizeof(std::shared_ptr<std::vector<double>>);
+    CHECK(sizeof(SimpleDataArray<double>) == base_size + 16);
+    CHECK(sizeof(SimpleDataArray<char>) == base_size + 16);
+
+    base_size = 2 * sizeof(void*)
+              + sizeof(std::vector<size_t>)
+              + sizeof(std::vector<int64_t>);
+    CHECK(sizeof(DLPackArray<double>) == base_size + 16);
+    CHECK(sizeof(DLPackArray<char>) == base_size + 16);
+}
+
 TEST_CASE("Data Array") {
     auto data = std::make_unique<SimpleDataArray<double>>(SimpleDataArray<double>({2, 3, 4}));
     auto array = DataArrayBase::to_mts_array(std::move(data));

--- a/metatensor-core/tests/cpp/labels.cpp
+++ b/metatensor-core/tests/cpp/labels.cpp
@@ -7,6 +7,10 @@
 using namespace metatensor;
 
 TEST_CASE("Labels") {
+    // Any change here means the ABI will break and the new version will need to
+    // be a major version bump.
+    CHECK(sizeof(Labels) == 32);
+
     std::unique_ptr<DataArrayBase> array = std::make_unique<SimpleDataArray<int32_t>>(
         std::vector<size_t>{3, 2},
         std::vector<int32_t>{1, 2, 3, 4, 5, 6}

--- a/metatensor-core/tests/cpp/tensor.cpp
+++ b/metatensor-core/tests/cpp/tensor.cpp
@@ -18,6 +18,11 @@ static void check_loaded_tensor(metatensor::TensorMap& tensor);
 static int CUSTOM_CREATE_ARRAY_CALL_COUNT = 0;
 
 TEST_CASE("TensorMap") {
+    // Any change here means the ABI will break and the new version will need to
+    // be a major version bump.
+    CHECK(sizeof(TensorMap) == 32);
+    CHECK(sizeof(details::TensorMapInfo) == 32);
+
     SECTION("keys") {
         auto tensor = test_tensor_map();
         CHECK(tensor.keys() == Labels({"key_1", "key_2"}, {{0, 0}, {1, 0}, {2, 2}, {2, 3}}));

--- a/metatensor-torch/include/metatensor/torch/block.hpp
+++ b/metatensor-torch/include/metatensor/torch/block.hpp
@@ -226,6 +226,10 @@ private:
     /// store the parameter with respect to which the gradients are computed
     std::string parameter_;
 
+    /// reserved space for future expansion of the class without breaking
+    // ABI compatibility
+    uint8_t reserved_[32];
+
     /// Create a TensorBlockHolder containing gradients with respect to
     /// `parameter`
     TensorBlockHolder(metatensor::TensorBlock block, std::string parameter, torch::IValue parent);

--- a/metatensor-torch/include/metatensor/torch/labels.hpp
+++ b/metatensor-torch/include/metatensor/torch/labels.hpp
@@ -231,6 +231,10 @@ private:
 
     /// Underlying metatensor labels
     metatensor::Labels labels_;
+
+    /// reserved space for future expansion of the class without breaking
+    // ABI compatibility
+    uint8_t padding_[32];
 };
 
 /// Check two `LabelsHolder` for equality
@@ -314,6 +318,10 @@ private:
     torch::Tensor values_;
 
     Labels labels_;
+
+    /// reserved space for future expansion of the class without breaking
+    // ABI compatibility
+    uint8_t reserved_[32];
 };
 
 

--- a/metatensor-torch/include/metatensor/torch/tensor.hpp
+++ b/metatensor-torch/include/metatensor/torch/tensor.hpp
@@ -224,6 +224,10 @@ private:
     /// Parent for this TensorMap, used to keep a reference on the parent object
     torch::IValue parent_;
 
+    /// reserved space for future expansion of the class without breaking
+    // ABI compatibility
+    uint8_t reserved_[32];
+
     /// Wrap an existing `metatensor::TensorMap` into a `TensorMapHolder`
     explicit TensorMapHolder(metatensor::TensorMap tensor):
         tensor_(std::move(tensor)) {}

--- a/metatensor-torch/tests/block.cpp
+++ b/metatensor-torch/tests/block.cpp
@@ -6,6 +6,14 @@ using namespace metatensor_torch;
 #include <catch.hpp>
 
 TEST_CASE("Blocks") {
+    // Any change here means the ABI will break and the new version will need to
+    // be a major version bump.
+    CHECK(sizeof(TensorBlockHolder) == sizeof(torch::CustomClassHolder)
+                                     + sizeof(metatensor::TensorBlock)
+                                     + sizeof(torch::IValue)
+                                     + sizeof(std::string)
+                                     + 32);
+
     SECTION("constructors and data") {
         auto block = TensorBlockHolder(
             torch::full({3, 2}, 11.0),

--- a/metatensor-torch/tests/labels.cpp
+++ b/metatensor-torch/tests/labels.cpp
@@ -7,6 +7,18 @@ using namespace metatensor_torch;
 #include <catch.hpp>
 
 TEST_CASE("Labels") {
+    // Any change here means the ABI will break and the new version will need to
+    // be a major version bump.
+    CHECK(sizeof(LabelsHolder) == sizeof(torch::CustomClassHolder)
+                                 + sizeof(std::vector<std::string>)
+                                 + sizeof(torch::Tensor)
+                                 + sizeof(metatensor::Labels)
+                                 + 32);
+    CHECK(sizeof(LabelsEntryHolder) == sizeof(torch::CustomClassHolder)
+                                      + sizeof(torch::Tensor)
+                                      + sizeof(Labels)
+                                      + 32);
+
     SECTION("constructor") {
         auto names = std::vector<std::string>{"a", "bb"};
         auto values = std::vector<int64_t>{0, 0, 1, 0, 0, -1, 1, -2};

--- a/metatensor-torch/tests/tensor.cpp
+++ b/metatensor-torch/tests/tensor.cpp
@@ -12,6 +12,13 @@ using namespace metatensor_torch;
 static TensorMap test_tensor_map();
 
 TEST_CASE("TensorMap") {
+    // Any change here means the ABI will break and the new version will need to
+    // be a major version bump.
+    CHECK(sizeof(TensorMapHolder) == sizeof(torch::CustomClassHolder)
+                                    + sizeof(metatensor::TensorMap)
+                                    + sizeof(torch::IValue)
+                                    + 32);
+
     SECTION("keys") {
         auto tensor = test_tensor_map();
 


### PR DESCRIPTION
This will enable future updates to change the members inside classes without breaking ABI compatibility.

This is a follow up to #1141, which changed the size of metatensor-torch classes, making pre-compiled featomic-torch break due to out of bounds write. This change will thus have to be released as a new backward incompatible version, but hopefully reserving some extra space now will allow us to do such changes in the future while keeping backward compat.

<!-- What does this implement/fix? Explain your changes here. -->



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
