### PR TITLE
Rust: load TensorBlock/TensorMap with custom arrays

### DIFF
--- a/rust/metatensor/CHANGELOG.md
+++ b/rust/metatensor/CHANGELOG.md
@@ -16,6 +16,12 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
+### Added
+
+- `load_custom_array`, `load_buffer_custom_array`, `load_block_custom_array`,
+  and `load_block_buffer_custom_array` functions to load TensorMaps and
+  TensorBlocks with custom array types.
+
 ## [Version 0.4.1](https://github.com/metatensor/metatensor/releases/tag/metatensor-rust-v0.4.1) - 2026-06-24
 
 ### Fixed

--- a/rust/metatensor/src/io/block.rs
+++ b/rust/metatensor/src/io/block.rs
@@ -1,21 +1,43 @@
 use std::ffi::CString;
 
-use crate::errors::{check_ptr, check_status};
-use crate::{Error, TensorBlock, TensorBlockRef};
+use dlpk::DLDataType;
 
-use super::{realloc_vec, create_ndarray};
+use crate::errors::{check_ptr, check_status};
+use crate::{Error, MtsArray, TensorBlock, TensorBlockRef};
+
+use super::{realloc_vec, create_ndarray, CREATE_ARRAY_CALLBACK, create_array_callback_wrapper};
 
 /// Load previously saved `TensorBlock` from the file at the given path.
+///
+/// All arrays are loaded as `ndarray::ArrayD` by default. If you want to load
+/// arrays as a custom type, use [`load_block_custom_array`] instead.
 pub fn load_block(path: impl AsRef<std::path::Path>) -> Result<TensorBlock, Error> {
+    return load_block_custom_array(path, create_ndarray);
+}
+
+/// Load previously saved `TensorBlock` from the file at the given path.
+///
+/// All arrays will be created through the `create_array` callback.
+pub fn load_block_custom_array<F>(path: impl AsRef<std::path::Path>, create_array: F) -> Result<TensorBlock, Error>
+    where F: Fn(&[usize], DLDataType) -> Result<MtsArray, Error> + 'static
+{
     let path = path.as_ref().as_os_str().to_str().expect("this path is not valid UTF8");
     let path = CString::new(path).expect("this path contains a NULL byte");
+
+    CREATE_ARRAY_CALLBACK.with(|callback| {
+        *callback.borrow_mut() = Some(Box::new(create_array));
+    });
 
     let ptr = unsafe {
         crate::c_api::mts_block_load(
             path.as_ptr(),
-            Some(create_ndarray)
+            Some(create_array_callback_wrapper)
         )
     };
+
+    CREATE_ARRAY_CALLBACK.with(|callback| {
+        *callback.borrow_mut() = None;
+    });
 
     check_ptr(ptr)?;
 
@@ -23,14 +45,34 @@ pub fn load_block(path: impl AsRef<std::path::Path>) -> Result<TensorBlock, Erro
 }
 
 /// Load a serialized `TensorBlock` from a `buffer`.
+///
+/// All arrays are loaded as `ndarray::ArrayD` by default. If you want to load
+/// arrays as a custom type, use [`load_block_buffer_custom_array`] instead.
 pub fn load_block_buffer(buffer: &[u8]) -> Result<TensorBlock, Error> {
+    return load_block_buffer_custom_array(buffer, create_ndarray);
+}
+
+/// Load a serialized `TensorBlock` from a `buffer`.
+///
+/// All arrays will be created through the `create_array` callback.
+pub fn load_block_buffer_custom_array<F>(buffer: &[u8], create_array: F) -> Result<TensorBlock, Error>
+    where F: Fn(&[usize], DLDataType) -> Result<MtsArray, Error> + 'static
+{
+    CREATE_ARRAY_CALLBACK.with(|callback| {
+        *callback.borrow_mut() = Some(Box::new(create_array));
+    });
+
     let ptr = unsafe {
         crate::c_api::mts_block_load_buffer(
             buffer.as_ptr(),
             buffer.len(),
-            Some(create_ndarray)
+            Some(create_array_callback_wrapper)
         )
     };
+
+    CREATE_ARRAY_CALLBACK.with(|callback| {
+        *callback.borrow_mut() = None;
+    });
 
     check_ptr(ptr)?;
 

--- a/rust/metatensor/src/io/mod.rs
+++ b/rust/metatensor/src/io/mod.rs
@@ -1,6 +1,7 @@
 //! Input/Output facilities for storing [`crate::TensorMap`] and
 //! [`crate::Labels`] on disk
 
+use std::cell::RefCell;
 use std::os::raw::c_void;
 
 use dlpk::sys::{DLDataType, DLDataTypeCode};
@@ -8,11 +9,16 @@ use dlpk::sys::{DLDataType, DLDataTypeCode};
 use crate::c_api::{MTS_SUCCESS, mts_array_t, mts_status_t};
 use crate::MtsArray;
 
+use crate::Error;
+use crate::errors::catch_unwind;
+
 mod tensor;
-pub use self::tensor::{load, save, load_buffer, save_buffer};
+pub use self::tensor::{load, load_custom_array, load_buffer, load_buffer_custom_array};
+pub use self::tensor::{save, save_buffer};
 
 mod block;
-pub use self::block::{load_block, load_block_buffer, save_block, save_block_buffer};
+pub use self::block::{load_block, load_block_buffer_custom_array, load_block_buffer, load_block_custom_array};
+pub use self::block::{save_block, save_block_buffer};
 
 mod labels;
 pub use self::labels::{load_labels, load_labels_buffer, save_labels, save_labels_buffer};
@@ -42,7 +48,7 @@ unsafe extern "C" fn realloc_vec(user_data: *mut c_void, _ptr: *mut u8, new_size
     return result;
 }
 
-/// Create a typed `ndarray::Array<T>` and box it as `dyn Array`.
+/// Create a typed `ndarray::Array<T>` and put it in a `MtsArray`
 macro_rules! create_typed_array {
     ($shape:expr, $c_array:expr, $T:ty) => {{
         let array = ndarray::Array::<$T, _>::from_elem($shape, <$T>::default());
@@ -50,54 +56,73 @@ macro_rules! create_typed_array {
     }};
 }
 
-/// callback used to create `ndarray::ArcArray` when loading a `TensorMap`
-unsafe extern "C" fn create_ndarray(
-    shape_ptr: *const usize,
-    shape_count: usize,
-    dtype: DLDataType,
-    c_array: *mut mts_array_t,
-) -> mts_status_t {
-    crate::errors::catch_unwind(|| {
-        assert!(shape_count != 0);
-        let shape = std::slice::from_raw_parts(shape_ptr, shape_count);
 
-        if dtype.lanes != 1 {
+fn create_ndarray(shape: &[usize], dtype: DLDataType) -> Result<MtsArray, Error> {
+    if dtype.lanes != 1 {
+        return Err(crate::Error {
+            code: None,
+            message: format!(
+                "unsupported dtype in create_ndarray: lanes={} (expected 1)",
+                dtype.lanes
+            ),
+        });
+    }
+
+    let array = match (dtype.code, dtype.bits) {
+        (DLDataTypeCode::kDLFloat, 32) => create_typed_array!(shape, c_array, f32),
+        (DLDataTypeCode::kDLFloat, 64) => create_typed_array!(shape, c_array, f64),
+        (DLDataTypeCode::kDLInt, 8) => create_typed_array!(shape, c_array, i8),
+        (DLDataTypeCode::kDLInt, 16) => create_typed_array!(shape, c_array, i16),
+        (DLDataTypeCode::kDLInt, 32) => create_typed_array!(shape, c_array, i32),
+        (DLDataTypeCode::kDLInt, 64) => create_typed_array!(shape, c_array, i64),
+        (DLDataTypeCode::kDLUInt, 8) => create_typed_array!(shape, c_array, u8),
+        (DLDataTypeCode::kDLUInt, 16) => create_typed_array!(shape, c_array, u16),
+        (DLDataTypeCode::kDLUInt, 32) => create_typed_array!(shape, c_array, u32),
+        (DLDataTypeCode::kDLUInt, 64) => create_typed_array!(shape, c_array, u64),
+        (DLDataTypeCode::kDLBool, 8) => create_typed_array!(shape, c_array, bool),
+        (DLDataTypeCode::kDLFloat, 16) => create_typed_array!(shape, c_array, half::f16),
+        (DLDataTypeCode::kDLComplex, 64) => create_typed_array!(shape, c_array, [f32; 2]),
+        (DLDataTypeCode::kDLComplex, 128) => create_typed_array!(shape, c_array, [f64; 2]),
+        _ => {
             return Err(crate::Error {
                 code: None,
                 message: format!(
-                    "unsupported dtype in create_ndarray: lanes={} (expected 1)",
-                    dtype.lanes
+                    "unsupported dtype in create_ndarray: code={:?} bits={}",
+                    dtype.code, dtype.bits
                 ),
             });
         }
+    };
 
-        let array = match (dtype.code, dtype.bits) {
-            (DLDataTypeCode::kDLFloat, 32) => create_typed_array!(shape, c_array, f32),
-            (DLDataTypeCode::kDLFloat, 64) => create_typed_array!(shape, c_array, f64),
-            (DLDataTypeCode::kDLInt, 8) => create_typed_array!(shape, c_array, i8),
-            (DLDataTypeCode::kDLInt, 16) => create_typed_array!(shape, c_array, i16),
-            (DLDataTypeCode::kDLInt, 32) => create_typed_array!(shape, c_array, i32),
-            (DLDataTypeCode::kDLInt, 64) => create_typed_array!(shape, c_array, i64),
-            (DLDataTypeCode::kDLUInt, 8) => create_typed_array!(shape, c_array, u8),
-            (DLDataTypeCode::kDLUInt, 16) => create_typed_array!(shape, c_array, u16),
-            (DLDataTypeCode::kDLUInt, 32) => create_typed_array!(shape, c_array, u32),
-            (DLDataTypeCode::kDLUInt, 64) => create_typed_array!(shape, c_array, u64),
-            (DLDataTypeCode::kDLBool, 8) => create_typed_array!(shape, c_array, bool),
-            (DLDataTypeCode::kDLFloat, 16) => create_typed_array!(shape, c_array, half::f16),
-            (DLDataTypeCode::kDLComplex, 64) => create_typed_array!(shape, c_array, [f32; 2]),
-            (DLDataTypeCode::kDLComplex, 128) => create_typed_array!(shape, c_array, [f64; 2]),
-            _ => {
-                return Err(crate::Error {
-                    code: None,
-                    message: format!(
-                        "unsupported dtype in create_ndarray: code={:?} bits={}",
-                        dtype.code, dtype.bits
-                    ),
-                });
-            }
+    return Ok(array);
+}
+
+type CreateArrayCallback = dyn Fn(&[usize], DLDataType) -> Result<MtsArray, Error>;
+thread_local! {
+    static CREATE_ARRAY_CALLBACK: RefCell<Option<Box<CreateArrayCallback>>> = RefCell::new(None);
+}
+
+/// Wrap the function in `CREATE_ARRAY_CALLBACK` as a C-compatible callback
+unsafe extern "C" fn create_array_callback_wrapper(
+    shape: *const usize,
+    shape_count: usize,
+    dtype: DLDataType,
+    array: *mut mts_array_t,
+) -> mts_status_t {
+    catch_unwind(|| {
+        let shape = unsafe {
+            std::slice::from_raw_parts(shape, shape_count)
         };
 
-        *c_array = array.into_raw();
+        let new_array = CREATE_ARRAY_CALLBACK.with(|callback| {
+            let borrow = callback.borrow();
+            let callback = borrow.as_ref().expect("no custom array callback set in thread-local storage");
+            callback(shape, dtype)
+        })?;
+
+        unsafe {
+            *array = new_array.into_raw();
+        }
 
         Ok(())
     })

--- a/rust/metatensor/src/io/tensor.rs
+++ b/rust/metatensor/src/io/tensor.rs
@@ -1,9 +1,11 @@
 use std::ffi::CString;
 
-use crate::errors::{check_status, check_ptr};
-use crate::{TensorMap, Error};
+use dlpk::DLDataType;
 
-use super::{realloc_vec, create_ndarray};
+use crate::errors::{check_status, check_ptr};
+use crate::{TensorMap, Error, MtsArray};
+
+use super::{realloc_vec, create_ndarray, CREATE_ARRAY_CALLBACK, create_array_callback_wrapper};
 
 /// Load the serialized tensor map from the given path.
 ///
@@ -38,16 +40,38 @@ use super::{realloc_vec, create_ndarray};
 ///                                                                     / <n_components>.npy
 ///                                                     /   data.npy
 /// ```
+///
+/// All arrays are loaded as `ndarray::ArrayD` by default. If you want to load
+/// arrays as a custom type, use [`load_custom_array`] instead.
 pub fn load(path: impl AsRef<std::path::Path>) -> Result<TensorMap, Error> {
+    return load_custom_array(path, create_ndarray);
+}
+
+/// Load the serialized tensor map from the given path.
+///
+/// See the [`load`] function for more information on the data format.
+///
+/// All arrays will be created through the `create_array` callback.
+pub fn load_custom_array<F>(path: impl AsRef<std::path::Path>, create_array: F) -> Result<TensorMap, Error>
+    where F: Fn(&[usize], DLDataType) -> Result<MtsArray, Error> + 'static
+{
     let path = path.as_ref().as_os_str().to_str().expect("this path is not valid UTF8");
     let path = CString::new(path).expect("this path contains a NULL byte");
+
+    CREATE_ARRAY_CALLBACK.with(|callback| {
+        *callback.borrow_mut() = Some(Box::new(create_array));
+    });
 
     let ptr = unsafe {
         crate::c_api::mts_tensormap_load(
             path.as_ptr(),
-            Some(create_ndarray)
+            Some(create_array_callback_wrapper)
         )
     };
+
+    CREATE_ARRAY_CALLBACK.with(|callback| {
+        *callback.borrow_mut() = None;
+    });
 
     check_ptr(ptr)?;
 
@@ -57,14 +81,35 @@ pub fn load(path: impl AsRef<std::path::Path>) -> Result<TensorMap, Error> {
 /// Load a serialized `TensorMap` from a `buffer`.
 ///
 /// See the [`load`] function for more information on the data format.
+///
+/// All arrays are loaded as `ndarray::ArrayD` by default. If you want to load
+/// arrays as a custom type, use [`load_buffer_custom_array`] instead.
 pub fn load_buffer(buffer: &[u8]) -> Result<TensorMap, Error> {
+    return load_buffer_custom_array(buffer, create_ndarray);
+}
+
+/// Load a serialized `TensorMap` from a `buffer` using a custom array
+/// creation function.
+///
+/// All arrays will be created through the `create_array` callback.
+pub fn load_buffer_custom_array<F>(buffer: &[u8], create_array: F) -> Result<TensorMap, Error>
+    where F: Fn(&[usize], DLDataType) -> Result<MtsArray, Error> + 'static
+{
+    CREATE_ARRAY_CALLBACK.with(|callback| {
+        *callback.borrow_mut() = Some(Box::new(create_array));
+    });
+
     let ptr = unsafe {
         crate::c_api::mts_tensormap_load_buffer(
             buffer.as_ptr(),
             buffer.len(),
-            Some(create_ndarray)
+            Some(create_array_callback_wrapper)
         )
     };
+
+    CREATE_ARRAY_CALLBACK.with(|callback| {
+        *callback.borrow_mut() = None;
+    });
 
     check_ptr(ptr)?;
 

--- a/rust/metatensor/tests/serialization.rs
+++ b/rust/metatensor/tests/serialization.rs
@@ -341,6 +341,112 @@ mod labels {
     }
 }
 
+mod custom_array {
+    use std::io::Read;
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use dlpk::sys::{DLDataTypeCode, DLDataType};
+    use metatensor::MtsArray;
+
+    const BLOCK_DATA_PATH: &str = "../../metatensor-core/tests/block.mts";
+    const TENSOR_DATA_PATH: &str = "../../metatensor-core/tests/data.mts";
+
+    fn make_array(shape: &[usize], dtype: DLDataType) -> Result<MtsArray, metatensor::Error> {
+        match (dtype.code, dtype.bits) {
+            (DLDataTypeCode::kDLFloat, 64) => {
+                Ok(ndarray::Array::<f64, _>::zeros(shape).into())
+            }
+            (DLDataTypeCode::kDLFloat, 32) => {
+                Ok(ndarray::Array::<f32, _>::zeros(shape).into())
+            }
+            (DLDataTypeCode::kDLInt, 32) => {
+                Ok(ndarray::Array::<i32, _>::zeros(shape).into())
+            }
+            (DLDataTypeCode::kDLInt, 64) => {
+                Ok(ndarray::Array::<i64, _>::zeros(shape).into())
+            }
+            (DLDataTypeCode::kDLUInt, 8) => {
+                Ok(ndarray::Array::<u8, _>::zeros(shape).into())
+            }
+            _ => {
+                Err(metatensor::Error {
+                    code: None,
+                    message: format!(
+                        "unsupported dtype in test create_array: code={:?} bits={}",
+                        dtype.code, dtype.bits
+                    ),
+                })
+            }
+        }
+    }
+
+    #[test]
+    fn block_load_file() {
+        static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+        let create_array = |shape: &[usize], dtype: DLDataType| -> Result<MtsArray, metatensor::Error> {
+            CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+            make_array(shape, dtype)
+        };
+
+        let block = metatensor::io::load_block_custom_array(BLOCK_DATA_PATH, create_array).unwrap();
+        assert!(CALL_COUNT.load(Ordering::SeqCst) > 0);
+        assert_eq!(block.values().shape().unwrap(), [9, 5, 3]);
+    }
+
+    #[test]
+    fn block_load_buffer() {
+        static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+        let mut file = std::fs::File::open(BLOCK_DATA_PATH).unwrap();
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer).unwrap();
+
+        let create_array = |shape: &[usize], dtype: DLDataType| -> Result<MtsArray, metatensor::Error> {
+            CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+            make_array(shape, dtype)
+        };
+
+        let block = metatensor::io::load_block_buffer_custom_array(&buffer, create_array).unwrap();
+        assert!(CALL_COUNT.load(Ordering::SeqCst) > 0);
+        assert_eq!(block.values().shape().unwrap(), [9, 5, 3]);
+    }
+
+    #[test]
+    fn tensor_load_file() {
+        static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+        let create_array = |shape: &[usize], dtype: DLDataType| -> Result<MtsArray, metatensor::Error> {
+            CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+            make_array(shape, dtype)
+        };
+
+        let tensor = metatensor::io::load_custom_array(TENSOR_DATA_PATH, create_array).unwrap();
+        assert!(CALL_COUNT.load(Ordering::SeqCst) > 0);
+        assert_eq!(tensor.keys().count(), 27);
+    }
+
+    #[test]
+    fn tensor_load_buffer() {
+        use std::io::Read;
+        static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+        let mut file = std::fs::File::open(TENSOR_DATA_PATH).unwrap();
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer).unwrap();
+
+        let create_array = |shape: &[usize], dtype: DLDataType| -> Result<MtsArray, metatensor::Error> {
+            CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+            make_array(shape, dtype)
+        };
+
+        let tensor = metatensor::io::load_buffer_custom_array(&buffer, create_array).unwrap();
+        assert!(CALL_COUNT.load(Ordering::SeqCst) > 0);
+        assert_eq!(tensor.keys().count(), 27);
+    }
+}
+
 mod error_paths {
     #[test]
     fn load_invalid_buffer_as_tensor() {


### PR DESCRIPTION
Required for https://github.com/metatensor/metatomic/pull/252, this was already available in Python, but not yet in rust.


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?
