### PR TITLE
Use function pointers for array creation instead of Fn closures

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -64,7 +64,7 @@ jobs:
           target: ${{ matrix.rust-target }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.14"
           enable-cache: true
@@ -169,7 +169,7 @@ jobs:
           target: ${{ matrix.rust-target }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.14"
           enable-cache: true
@@ -258,7 +258,7 @@ jobs:
           path: dist
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.14"
           enable-cache: true
@@ -311,7 +311,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.14"
           enable-cache: true
@@ -479,7 +479,7 @@ jobs:
           target: ${{ matrix.rust-target }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.14"
           enable-cache: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,7 +36,7 @@ jobs:
             sudo ./llvm.sh ${{ matrix.llvm-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.14"
           enable-cache: true
@@ -94,7 +94,7 @@ jobs:
             PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
             UV_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
             UV_INDEX_STRATEGY: unsafe-best-match
- 
+
       - name: locate cargo-llvm-cov environment
         id: covenv
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
           sweep-cache: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.14"
           enable-cache: true

--- a/.github/workflows/julia-tests.yml
+++ b/.github/workflows/julia-tests.yml
@@ -54,7 +54,7 @@ jobs:
         if: ${{ !env.ACT }}
         uses: mozilla-actions/sccache-action@v0.0.10
         with:
-          version: "v0.15.0"
+          version: "v0.16.0"
 
       - name: Setup sccache environnement variables
         if: ${{ !env.ACT }}

--- a/.github/workflows/misc-tests.yml
+++ b/.github/workflows/misc-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.14"
           enable-cache: true
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -109,7 +109,7 @@ jobs:
         if: ${{ !env.ACT }}
         uses: mozilla-actions/sccache-action@v0.0.10
         with:
-          version: "v0.10.0"
+          version: "v0.16.0"
 
       - name: setup MSVC command prompt
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -64,7 +64,7 @@ jobs:
         if: ${{ !env.ACT }}
         uses: mozilla-actions/sccache-action@v0.0.10
         with:
-          version: "v0.15.0"
+          version: "v0.16.0"
 
       - name: setup MSVC command prompt
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -119,7 +119,7 @@ jobs:
         if: ${{ !env.ACT }}
         uses: mozilla-actions/sccache-action@v0.0.10
         with:
-          version: "v0.15.0"
+          version: "v0.16.0"
 
       - name: Setup sccache environnement variables
         if: ${{ !env.ACT }}

--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -71,7 +71,7 @@ jobs:
 
       # we get torch from pip to run the C++ test
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.11"
           enable-cache: true
@@ -86,7 +86,7 @@ jobs:
         if: ${{ !env.ACT }}
         uses: mozilla-actions/sccache-action@v0.0.10
         with:
-          version: "v0.15.0"
+          version: "v0.16.0"
 
       - name: Setup sccache environnement variables
         if: ${{ !env.ACT }}

--- a/metatensor-core/src/c_api/io/block.rs
+++ b/metatensor-core/src/c_api/io/block.rs
@@ -3,16 +3,13 @@ use std::ffi::CStr;
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
 
-use dlpk::sys::DLDataType;
-
 use crate::Error;
-use crate::data::mts_array_t;
 
 use super::{ExternalBuffer, mts_realloc_buffer_t};
 
 use super::super::status::{mts_status_t, catch_unwind};
 use super::super::blocks::mts_block_t;
-use super::mts_create_array_callback_t;
+use super::{mts_create_array_callback_t, wrap_create_array};
 
 
 /// Load a tensor block from the file at the given path.
@@ -108,13 +105,15 @@ pub unsafe extern "C" fn mts_block_load_buffer(
     let mut result = std::ptr::null_mut();
     let unwind_wrapper = std::panic::AssertUnwindSafe(&mut result);
     let status = catch_unwind(move || {
+        if buffer_count == 0 {
+            return Err(Error::Serialization("unable to load TensorBlock from empty buffer".into()));
+        }
+
         check_pointers_non_null!(buffer);
-        assert!(buffer_count > 0);
-
-        let create_array = wrap_create_array(&create_array);
-
         let slice = std::slice::from_raw_parts(buffer.cast::<u8>(), buffer_count);
         let cursor = std::io::Cursor::new(slice);
+
+        let create_array = wrap_create_array(&create_array);
 
         let block = crate::io::load_block(cursor, create_array)
             .map_err(|err| match err {
@@ -150,27 +149,6 @@ pub unsafe extern "C" fn mts_block_load_buffer(
     }
 
     return result;
-}
-
-fn wrap_create_array(create_array: &mts_create_array_callback_t) -> impl Fn(Vec<usize>, DLDataType) -> Result<mts_array_t, Error> + '_ {
-    |shape: Vec<usize>, dtype: DLDataType| {
-        let mut array = mts_array_t::null();
-        let status = unsafe {
-            create_array(
-                shape.as_ptr(),
-                shape.len(),
-                dtype,
-                &mut array
-            )
-        };
-
-        if status.is_success() {
-            return Ok(array);
-        } else {
-            crate::c_api::add_error_context("failed to create a new array in mts_block_load");
-            return Err(Error::CallbackError);
-        }
-    }
 }
 
 

--- a/metatensor-core/src/c_api/io/labels.rs
+++ b/metatensor-core/src/c_api/io/labels.rs
@@ -88,8 +88,11 @@ pub unsafe extern "C" fn mts_labels_load_buffer(
     let unwind_wrapper = std::panic::AssertUnwindSafe(&mut result);
 
     let status = catch_unwind(move || {
-        check_pointers_non_null!(buffer);
+        if buffer_count == 0 {
+            return Err(Error::Serialization("unable to load Labels from empty buffer".into()));
+        }
 
+        check_pointers_non_null!(buffer);
         let slice = std::slice::from_raw_parts(buffer.cast::<u8>(), buffer_count);
         let cursor = std::io::Cursor::new(slice);
 

--- a/metatensor-core/src/c_api/io/mod.rs
+++ b/metatensor-core/src/c_api/io/mod.rs
@@ -2,7 +2,7 @@ use std::os::raw::c_void;
 
 use dlpk::sys::DLDataType;
 
-use crate::data::mts_array_t;
+use crate::{Error, data::mts_array_t};
 use super::status::mts_status_t;
 
 mod labels;
@@ -31,6 +31,29 @@ type mts_create_array_callback_t = unsafe extern "C" fn(
     dtype: DLDataType,
     array: *mut mts_array_t,
 ) -> mts_status_t;
+
+/// Wrap a `mts_create_array_callback_t` into a Rust closure
+fn wrap_create_array(create_array: &mts_create_array_callback_t) -> impl Fn(&[usize], DLDataType) -> Result<mts_array_t, Error> + '_ {
+    |shape: &[usize], dtype: DLDataType| {
+        let mut array = mts_array_t::null();
+        let status = unsafe {
+            create_array(
+                shape.as_ptr(),
+                shape.len(),
+                dtype,
+                &mut array
+            )
+        };
+
+        if status.is_success() {
+            return Ok(array);
+        } else {
+            crate::c_api::add_error_context("failed to create a new array");
+            return Err(Error::CallbackError);
+        }
+    }
+}
+
 
 /// Function pointer to grow in-memory buffers for `mts_tensormap_save_buffer`
 /// and `mts_labels_save_buffer`.

--- a/metatensor-core/src/c_api/io/tensor.rs
+++ b/metatensor-core/src/c_api/io/tensor.rs
@@ -3,16 +3,14 @@ use std::ffi::CStr;
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
 
-use dlpk::sys::DLDataType;
-
 use crate::Error;
-use crate::data::mts_array_t;
 
 use super::{ExternalBuffer, mts_realloc_buffer_t};
 
 use super::super::status::{mts_status_t, catch_unwind};
 use super::super::tensor::mts_tensormap_t;
-use super::mts_create_array_callback_t;
+use super::{mts_create_array_callback_t, wrap_create_array};
+
 
 /// Load a tensor map from the file at the given path.
 ///
@@ -138,13 +136,15 @@ pub unsafe extern "C" fn mts_tensormap_load_buffer(
     let mut result = std::ptr::null_mut();
     let unwind_wrapper = std::panic::AssertUnwindSafe(&mut result);
     let status = catch_unwind(move || {
+        if buffer_count == 0 {
+            return Err(Error::Serialization("unable to load TensorMap from empty buffer".into()));
+        }
+
         check_pointers_non_null!(buffer);
-        assert!(buffer_count > 0);
-
-        let create_array = wrap_create_array(&create_array);
-
         let slice = std::slice::from_raw_parts(buffer.cast::<u8>(), buffer_count);
         let cursor = std::io::Cursor::new(slice);
+
+        let create_array = wrap_create_array(&create_array);
 
         let tensor = crate::io::load(cursor, create_array)
             .map_err(|err| match err {
@@ -181,28 +181,6 @@ pub unsafe extern "C" fn mts_tensormap_load_buffer(
 
     return result;
 }
-
-fn wrap_create_array(create_array: &mts_create_array_callback_t) -> impl Fn(Vec<usize>, DLDataType) -> Result<mts_array_t, Error> + '_ {
-    |shape: Vec<usize>, dtype: DLDataType| {
-        let mut array = mts_array_t::null();
-        let status = unsafe {
-            create_array(
-                shape.as_ptr(),
-                shape.len(),
-                dtype,
-                &mut array
-            )
-        };
-
-        if status.is_success() {
-            return Ok(array);
-        } else {
-            crate::c_api::add_error_context("failed to create a new array in mts_tensormap_load");
-            return Err(Error::CallbackError);
-        }
-    }
-}
-
 
 /// Save a tensor map to the file at the given path.
 ///

--- a/metatensor-core/src/io/block.rs
+++ b/metatensor-core/src/io/block.rs
@@ -46,7 +46,7 @@ pub fn looks_like_block_data(mut data: PathOrBuffer) -> bool {
 /// `TensorBlock`.
 pub fn load_block<R, F>(reader: R, create_array: F) -> Result<TensorBlock, Error>
     where R: std::io::Read + std::io::Seek,
-          F: Fn(Vec<usize>, DLDataType) -> Result<mts_array_t, Error>
+          F: Fn(&[usize], DLDataType) -> Result<mts_array_t, Error>
 {
     let mut archive = ZipArchive::new(reader).map_err(|e| ("<root>".into(), e))?;
 
@@ -77,7 +77,7 @@ pub(super) fn read_single_block<R, F>(
     create_array: &F,
 ) -> Result<TensorBlock, Error>
     where R: std::io::Read + std::io::Seek,
-          F: Fn(Vec<usize>, DLDataType) -> Result<mts_array_t, Error>
+          F: Fn(&[usize], DLDataType) -> Result<mts_array_t, Error>
 {
     let path = format!("{}values.npy", prefix);
     let data_file = archive.by_name(&path).map_err(|e| (path, e))?;
@@ -190,7 +190,7 @@ where R: std::io::Read,
 // Read a data array from the given reader, using numpy's NPY format
 #[allow(clippy::too_many_lines)]
 fn read_data<R, F>(mut reader: R, create_array: &F) -> Result<(mts_array_t, Vec<usize>), Error>
-    where R: std::io::Read, F: Fn(Vec<usize>, DLDataType) -> Result<mts_array_t, Error>
+    where R: std::io::Read, F: Fn(&[usize], DLDataType) -> Result<mts_array_t, Error>
 {
     let header = Header::from_reader(&mut reader)?;
     if header.fortran_order {
@@ -208,7 +208,7 @@ fn read_data<R, F>(mut reader: R, create_array: &F) -> Result<(mts_array_t, Vec<
     let dl_dtype = DLDataType { code: file_code, bits: file_bits, lanes: 1 };
 
     let shape = header.shape;
-    let array = create_array(shape.clone(), dl_dtype)?;
+    let array = create_array(&shape, dl_dtype)?;
 
     let num_elements: usize = shape.iter().product();
     if num_elements == 0 {

--- a/metatensor-core/src/io/tensor.rs
+++ b/metatensor-core/src/io/tensor.rs
@@ -50,7 +50,7 @@ pub fn looks_like_tensormap_data(mut data: PathOrBuffer) -> bool {
 /// See the C API documentation for more information on the file format.
 pub fn load<R, F>(reader: R, create_array: F) -> Result<TensorMap, Error>
     where R: std::io::Read + std::io::Seek,
-          F: Fn(Vec<usize>, DLDataType) -> Result<mts_array_t, Error>
+          F: Fn(&[usize], DLDataType) -> Result<mts_array_t, Error>
 {
     let mut archive = ZipArchive::new(reader).map_err(|e| ("<root>".into(), e))?;
 

--- a/rust/metatensor/src/errors.rs
+++ b/rust/metatensor/src/errors.rs
@@ -50,7 +50,9 @@ unsafe extern "C" fn error_deleter(data: *mut std::ffi::c_void) {
     let _ = unsafe { Box::from_raw(data.cast::<Error>()) };
 }
 
-fn store_last_error(error: Error) -> mts_status_t {
+/// Store the last error in the metatensor-core C API, and return
+/// `MTS_CALLBACK_ERROR`
+pub(crate) fn store_last_error(error: Error) -> mts_status_t {
     let c_message = std::ffi::CString::new(error.message.clone()).expect("found NULL byte in error message");
     let c_origin = std::ffi::CString::new("Rust Error").expect("found NULL byte in error origin");
     let status = unsafe {

--- a/rust/metatensor/src/io/block.rs
+++ b/rust/metatensor/src/io/block.rs
@@ -1,43 +1,33 @@
 use std::ffi::CString;
 
-use dlpk::DLDataType;
+use metatensor_sys::mts_create_array_callback_t;
 
 use crate::errors::{check_ptr, check_status};
-use crate::{Error, MtsArray, TensorBlock, TensorBlockRef};
+use crate::{Error, TensorBlock, TensorBlockRef};
 
-use super::{realloc_vec, create_ndarray, CREATE_ARRAY_CALLBACK, create_array_callback_wrapper};
+use super::{realloc_vec, create_ndarray};
 
 /// Load previously saved `TensorBlock` from the file at the given path.
 ///
 /// All arrays are loaded as `ndarray::ArrayD` by default. If you want to load
 /// arrays as a custom type, use [`load_block_custom_array`] instead.
 pub fn load_block(path: impl AsRef<std::path::Path>) -> Result<TensorBlock, Error> {
-    return load_block_custom_array(path, create_ndarray);
+    return load_block_custom_array(path, Some(create_ndarray));
 }
 
 /// Load previously saved `TensorBlock` from the file at the given path.
 ///
 /// All arrays will be created through the `create_array` callback.
-pub fn load_block_custom_array<F>(path: impl AsRef<std::path::Path>, create_array: F) -> Result<TensorBlock, Error>
-    where F: Fn(&[usize], DLDataType) -> Result<MtsArray, Error> + 'static
-{
+pub fn load_block_custom_array(path: impl AsRef<std::path::Path>, create_array: mts_create_array_callback_t) -> Result<TensorBlock, Error> {
     let path = path.as_ref().as_os_str().to_str().expect("this path is not valid UTF8");
     let path = CString::new(path).expect("this path contains a NULL byte");
-
-    CREATE_ARRAY_CALLBACK.with(|callback| {
-        *callback.borrow_mut() = Some(Box::new(create_array));
-    });
 
     let ptr = unsafe {
         crate::c_api::mts_block_load(
             path.as_ptr(),
-            Some(create_array_callback_wrapper)
+            create_array
         )
     };
-
-    CREATE_ARRAY_CALLBACK.with(|callback| {
-        *callback.borrow_mut() = None;
-    });
 
     check_ptr(ptr)?;
 
@@ -49,30 +39,20 @@ pub fn load_block_custom_array<F>(path: impl AsRef<std::path::Path>, create_arra
 /// All arrays are loaded as `ndarray::ArrayD` by default. If you want to load
 /// arrays as a custom type, use [`load_block_buffer_custom_array`] instead.
 pub fn load_block_buffer(buffer: &[u8]) -> Result<TensorBlock, Error> {
-    return load_block_buffer_custom_array(buffer, create_ndarray);
+    return load_block_buffer_custom_array(buffer, Some(create_ndarray));
 }
 
 /// Load a serialized `TensorBlock` from a `buffer`.
 ///
 /// All arrays will be created through the `create_array` callback.
-pub fn load_block_buffer_custom_array<F>(buffer: &[u8], create_array: F) -> Result<TensorBlock, Error>
-    where F: Fn(&[usize], DLDataType) -> Result<MtsArray, Error> + 'static
-{
-    CREATE_ARRAY_CALLBACK.with(|callback| {
-        *callback.borrow_mut() = Some(Box::new(create_array));
-    });
-
+pub fn load_block_buffer_custom_array(buffer: &[u8], create_array: mts_create_array_callback_t) -> Result<TensorBlock, Error> {
     let ptr = unsafe {
         crate::c_api::mts_block_load_buffer(
             buffer.as_ptr(),
             buffer.len(),
-            Some(create_array_callback_wrapper)
+            create_array
         )
     };
-
-    CREATE_ARRAY_CALLBACK.with(|callback| {
-        *callback.borrow_mut() = None;
-    });
 
     check_ptr(ptr)?;
 

--- a/rust/metatensor/src/io/mod.rs
+++ b/rust/metatensor/src/io/mod.rs
@@ -52,8 +52,13 @@ macro_rules! create_typed_array {
     }};
 }
 
-
-extern "C" fn create_ndarray(shape: *const usize, shape_count: usize, dtype: DLDataType, array: *mut mts_array_t) -> mts_status_t {
+/// Callback function to create a new `mts_array_t` when loading `TensorMap` or
+/// `TensorBlock` from a buffer or a file.
+///
+/// This is an implementation of `mts_create_array_callback_t` that creates a
+/// new `ndarray::ArrayD` as the backing array for the `mts_array_t`. It is used
+/// by default in [`load_buffer`] and [`load_block_buffer`].
+pub unsafe extern "C" fn create_ndarray(shape: *const usize, shape_count: usize, dtype: DLDataType, array: *mut mts_array_t) -> mts_status_t {
     if dtype.lanes != 1 {
         let error = crate::Error {
             code: None,
@@ -65,7 +70,7 @@ extern "C" fn create_ndarray(shape: *const usize, shape_count: usize, dtype: DLD
         return crate::errors::store_last_error(error);
     }
 
-    let shape = unsafe { std::slice::from_raw_parts(shape, shape_count) };
+    let shape = std::slice::from_raw_parts(shape, shape_count);
 
     let new_array = match (dtype.code, dtype.bits) {
         (DLDataTypeCode::kDLFloat, 32) => create_typed_array!(shape, c_array, f32),
@@ -94,9 +99,7 @@ extern "C" fn create_ndarray(shape: *const usize, shape_count: usize, dtype: DLD
         }
     };
 
-    unsafe {
-        *array = new_array.into_raw();
-    }
+    *array = new_array.into_raw();
 
     return MTS_SUCCESS;
 }

--- a/rust/metatensor/src/io/mod.rs
+++ b/rust/metatensor/src/io/mod.rs
@@ -1,16 +1,12 @@
 //! Input/Output facilities for storing [`crate::TensorMap`] and
 //! [`crate::Labels`] on disk
 
-use std::cell::RefCell;
 use std::os::raw::c_void;
 
 use dlpk::sys::{DLDataType, DLDataTypeCode};
 
 use crate::c_api::{MTS_SUCCESS, mts_array_t, mts_status_t};
 use crate::MtsArray;
-
-use crate::Error;
-use crate::errors::catch_unwind;
 
 mod tensor;
 pub use self::tensor::{load, load_custom_array, load_buffer, load_buffer_custom_array};
@@ -57,18 +53,21 @@ macro_rules! create_typed_array {
 }
 
 
-fn create_ndarray(shape: &[usize], dtype: DLDataType) -> Result<MtsArray, Error> {
+extern "C" fn create_ndarray(shape: *const usize, shape_count: usize, dtype: DLDataType, array: *mut mts_array_t) -> mts_status_t {
     if dtype.lanes != 1 {
-        return Err(crate::Error {
+        let error = crate::Error {
             code: None,
             message: format!(
                 "unsupported dtype in create_ndarray: lanes={} (expected 1)",
                 dtype.lanes
             ),
-        });
+        };
+        return crate::errors::store_last_error(error);
     }
 
-    let array = match (dtype.code, dtype.bits) {
+    let shape = unsafe { std::slice::from_raw_parts(shape, shape_count) };
+
+    let new_array = match (dtype.code, dtype.bits) {
         (DLDataTypeCode::kDLFloat, 32) => create_typed_array!(shape, c_array, f32),
         (DLDataTypeCode::kDLFloat, 64) => create_typed_array!(shape, c_array, f64),
         (DLDataTypeCode::kDLInt, 8) => create_typed_array!(shape, c_array, i8),
@@ -84,46 +83,20 @@ fn create_ndarray(shape: &[usize], dtype: DLDataType) -> Result<MtsArray, Error>
         (DLDataTypeCode::kDLComplex, 64) => create_typed_array!(shape, c_array, [f32; 2]),
         (DLDataTypeCode::kDLComplex, 128) => create_typed_array!(shape, c_array, [f64; 2]),
         _ => {
-            return Err(crate::Error {
+            let error = crate::Error {
                 code: None,
                 message: format!(
                     "unsupported dtype in create_ndarray: code={:?} bits={}",
                     dtype.code, dtype.bits
                 ),
-            });
+            };
+            return crate::errors::store_last_error(error);
         }
     };
 
-    return Ok(array);
-}
+    unsafe {
+        *array = new_array.into_raw();
+    }
 
-type CreateArrayCallback = dyn Fn(&[usize], DLDataType) -> Result<MtsArray, Error>;
-thread_local! {
-    static CREATE_ARRAY_CALLBACK: RefCell<Option<Box<CreateArrayCallback>>> = RefCell::new(None);
-}
-
-/// Wrap the function in `CREATE_ARRAY_CALLBACK` as a C-compatible callback
-unsafe extern "C" fn create_array_callback_wrapper(
-    shape: *const usize,
-    shape_count: usize,
-    dtype: DLDataType,
-    array: *mut mts_array_t,
-) -> mts_status_t {
-    catch_unwind(|| {
-        let shape = unsafe {
-            std::slice::from_raw_parts(shape, shape_count)
-        };
-
-        let new_array = CREATE_ARRAY_CALLBACK.with(|callback| {
-            let borrow = callback.borrow();
-            let callback = borrow.as_ref().expect("no custom array callback set in thread-local storage");
-            callback(shape, dtype)
-        })?;
-
-        unsafe {
-            *array = new_array.into_raw();
-        }
-
-        Ok(())
-    })
+    return MTS_SUCCESS;
 }

--- a/rust/metatensor/src/io/tensor.rs
+++ b/rust/metatensor/src/io/tensor.rs
@@ -1,11 +1,11 @@
 use std::ffi::CString;
 
-use dlpk::DLDataType;
+use metatensor_sys::mts_create_array_callback_t;
 
 use crate::errors::{check_status, check_ptr};
-use crate::{TensorMap, Error, MtsArray};
+use crate::{TensorMap, Error};
 
-use super::{realloc_vec, create_ndarray, CREATE_ARRAY_CALLBACK, create_array_callback_wrapper};
+use super::{realloc_vec, create_ndarray};
 
 /// Load the serialized tensor map from the given path.
 ///
@@ -44,7 +44,7 @@ use super::{realloc_vec, create_ndarray, CREATE_ARRAY_CALLBACK, create_array_cal
 /// All arrays are loaded as `ndarray::ArrayD` by default. If you want to load
 /// arrays as a custom type, use [`load_custom_array`] instead.
 pub fn load(path: impl AsRef<std::path::Path>) -> Result<TensorMap, Error> {
-    return load_custom_array(path, create_ndarray);
+    return load_custom_array(path, Some(create_ndarray));
 }
 
 /// Load the serialized tensor map from the given path.
@@ -52,26 +52,13 @@ pub fn load(path: impl AsRef<std::path::Path>) -> Result<TensorMap, Error> {
 /// See the [`load`] function for more information on the data format.
 ///
 /// All arrays will be created through the `create_array` callback.
-pub fn load_custom_array<F>(path: impl AsRef<std::path::Path>, create_array: F) -> Result<TensorMap, Error>
-    where F: Fn(&[usize], DLDataType) -> Result<MtsArray, Error> + 'static
-{
+pub fn load_custom_array(path: impl AsRef<std::path::Path>, create_array: mts_create_array_callback_t) -> Result<TensorMap, Error> {
     let path = path.as_ref().as_os_str().to_str().expect("this path is not valid UTF8");
     let path = CString::new(path).expect("this path contains a NULL byte");
 
-    CREATE_ARRAY_CALLBACK.with(|callback| {
-        *callback.borrow_mut() = Some(Box::new(create_array));
-    });
-
     let ptr = unsafe {
-        crate::c_api::mts_tensormap_load(
-            path.as_ptr(),
-            Some(create_array_callback_wrapper)
-        )
+        crate::c_api::mts_tensormap_load(path.as_ptr(), create_array)
     };
-
-    CREATE_ARRAY_CALLBACK.with(|callback| {
-        *callback.borrow_mut() = None;
-    });
 
     check_ptr(ptr)?;
 
@@ -85,31 +72,21 @@ pub fn load_custom_array<F>(path: impl AsRef<std::path::Path>, create_array: F) 
 /// All arrays are loaded as `ndarray::ArrayD` by default. If you want to load
 /// arrays as a custom type, use [`load_buffer_custom_array`] instead.
 pub fn load_buffer(buffer: &[u8]) -> Result<TensorMap, Error> {
-    return load_buffer_custom_array(buffer, create_ndarray);
+    return load_buffer_custom_array(buffer, Some(create_ndarray));
 }
 
 /// Load a serialized `TensorMap` from a `buffer` using a custom array
 /// creation function.
 ///
 /// All arrays will be created through the `create_array` callback.
-pub fn load_buffer_custom_array<F>(buffer: &[u8], create_array: F) -> Result<TensorMap, Error>
-    where F: Fn(&[usize], DLDataType) -> Result<MtsArray, Error> + 'static
-{
-    CREATE_ARRAY_CALLBACK.with(|callback| {
-        *callback.borrow_mut() = Some(Box::new(create_array));
-    });
-
+pub fn load_buffer_custom_array(buffer: &[u8], create_array: mts_create_array_callback_t) -> Result<TensorMap, Error> {
     let ptr = unsafe {
         crate::c_api::mts_tensormap_load_buffer(
             buffer.as_ptr(),
             buffer.len(),
-            Some(create_array_callback_wrapper)
+            create_array
         )
     };
-
-    CREATE_ARRAY_CALLBACK.with(|callback| {
-        *callback.borrow_mut() = None;
-    });
 
     check_ptr(ptr)?;
 

--- a/rust/metatensor/tests/serialization.rs
+++ b/rust/metatensor/tests/serialization.rs
@@ -348,100 +348,94 @@ mod custom_array {
 
     use dlpk::sys::{DLDataTypeCode, DLDataType};
     use metatensor::MtsArray;
+    use metatensor::c_api::{MTS_CALLBACK_ERROR, MTS_SUCCESS, mts_array_t, mts_status_t};
 
     const BLOCK_DATA_PATH: &str = "../../metatensor-core/tests/block.mts";
     const TENSOR_DATA_PATH: &str = "../../metatensor-core/tests/data.mts";
 
-    fn make_array(shape: &[usize], dtype: DLDataType) -> Result<MtsArray, metatensor::Error> {
-        match (dtype.code, dtype.bits) {
+    static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+    static CREATE_ARRAY_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    extern "C" fn create_array(shape: *const usize, shape_count: usize, dtype: DLDataType, array: *mut mts_array_t) -> mts_status_t {
+        CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+
+        let shape = unsafe { std::slice::from_raw_parts(shape, shape_count) };
+
+        let new_array: MtsArray = match (dtype.code, dtype.bits) {
             (DLDataTypeCode::kDLFloat, 64) => {
-                Ok(ndarray::Array::<f64, _>::zeros(shape).into())
+                ndarray::Array::<f64, _>::zeros(shape).into()
             }
             (DLDataTypeCode::kDLFloat, 32) => {
-                Ok(ndarray::Array::<f32, _>::zeros(shape).into())
+                ndarray::Array::<f32, _>::zeros(shape).into()
             }
             (DLDataTypeCode::kDLInt, 32) => {
-                Ok(ndarray::Array::<i32, _>::zeros(shape).into())
+                ndarray::Array::<i32, _>::zeros(shape).into()
             }
             (DLDataTypeCode::kDLInt, 64) => {
-                Ok(ndarray::Array::<i64, _>::zeros(shape).into())
+                ndarray::Array::<i64, _>::zeros(shape).into()
             }
             (DLDataTypeCode::kDLUInt, 8) => {
-                Ok(ndarray::Array::<u8, _>::zeros(shape).into())
+                ndarray::Array::<u8, _>::zeros(shape).into()
             }
             _ => {
-                Err(metatensor::Error {
-                    code: None,
-                    message: format!(
-                        "unsupported dtype in test create_array: code={:?} bits={}",
-                        dtype.code, dtype.bits
-                    ),
-                })
+                return MTS_CALLBACK_ERROR;
             }
+        };
+
+        unsafe {
+            *array = new_array.into_raw();
         }
+
+        MTS_SUCCESS
     }
 
     #[test]
     fn block_load_file() {
-        static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+        let _guard = CREATE_ARRAY_MUTEX.lock().unwrap();
+        CALL_COUNT.store(0, Ordering::SeqCst);
 
-        let create_array = |shape: &[usize], dtype: DLDataType| -> Result<MtsArray, metatensor::Error> {
-            CALL_COUNT.fetch_add(1, Ordering::SeqCst);
-            make_array(shape, dtype)
-        };
-
-        let block = metatensor::io::load_block_custom_array(BLOCK_DATA_PATH, create_array).unwrap();
+        let block = metatensor::io::load_block_custom_array(BLOCK_DATA_PATH, Some(create_array)).unwrap();
         assert!(CALL_COUNT.load(Ordering::SeqCst) > 0);
         assert_eq!(block.values().shape().unwrap(), [9, 5, 3]);
     }
 
     #[test]
     fn block_load_buffer() {
-        static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+        let _guard = CREATE_ARRAY_MUTEX.lock().unwrap();
+        CALL_COUNT.store(0, Ordering::SeqCst);
 
         let mut file = std::fs::File::open(BLOCK_DATA_PATH).unwrap();
         let mut buffer = Vec::new();
         file.read_to_end(&mut buffer).unwrap();
 
-        let create_array = |shape: &[usize], dtype: DLDataType| -> Result<MtsArray, metatensor::Error> {
-            CALL_COUNT.fetch_add(1, Ordering::SeqCst);
-            make_array(shape, dtype)
-        };
+        let block = metatensor::io::load_block_buffer_custom_array(&buffer, Some(create_array)).unwrap();
 
-        let block = metatensor::io::load_block_buffer_custom_array(&buffer, create_array).unwrap();
         assert!(CALL_COUNT.load(Ordering::SeqCst) > 0);
         assert_eq!(block.values().shape().unwrap(), [9, 5, 3]);
     }
 
     #[test]
     fn tensor_load_file() {
-        static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+        let _guard = CREATE_ARRAY_MUTEX.lock().unwrap();
+        CALL_COUNT.store(0, Ordering::SeqCst);
 
-        let create_array = |shape: &[usize], dtype: DLDataType| -> Result<MtsArray, metatensor::Error> {
-            CALL_COUNT.fetch_add(1, Ordering::SeqCst);
-            make_array(shape, dtype)
-        };
+        let tensor = metatensor::io::load_custom_array(TENSOR_DATA_PATH, Some(create_array)).unwrap();
 
-        let tensor = metatensor::io::load_custom_array(TENSOR_DATA_PATH, create_array).unwrap();
         assert!(CALL_COUNT.load(Ordering::SeqCst) > 0);
         assert_eq!(tensor.keys().count(), 27);
     }
 
     #[test]
     fn tensor_load_buffer() {
-        use std::io::Read;
-        static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+        let _guard = CREATE_ARRAY_MUTEX.lock().unwrap();
+        CALL_COUNT.store(0, Ordering::SeqCst);
 
         let mut file = std::fs::File::open(TENSOR_DATA_PATH).unwrap();
         let mut buffer = Vec::new();
         file.read_to_end(&mut buffer).unwrap();
 
-        let create_array = |shape: &[usize], dtype: DLDataType| -> Result<MtsArray, metatensor::Error> {
-            CALL_COUNT.fetch_add(1, Ordering::SeqCst);
-            make_array(shape, dtype)
-        };
+        let tensor = metatensor::io::load_buffer_custom_array(&buffer, Some(create_array)).unwrap();
 
-        let tensor = metatensor::io::load_buffer_custom_array(&buffer, create_array).unwrap();
         assert!(CALL_COUNT.load(Ordering::SeqCst) > 0);
         assert_eq!(tensor.keys().count(), 27);
     }

--- a/rust/metatensor/tests/serialization.rs
+++ b/rust/metatensor/tests/serialization.rs
@@ -445,40 +445,49 @@ mod error_paths {
     #[test]
     fn load_invalid_buffer_as_tensor() {
         let data = b"this is not a valid mts file";
-        let err = metatensor::io::load_buffer(data);
-        assert!(err.is_err());
+        let result = metatensor::io::load_buffer(data);
+        assert_eq!(
+            result.unwrap_err().message,
+            "serialization format error: unable to load a TensorMap from buffer: invalid Zip archive: Could not find central directory end: at '<root>'"
+        );
     }
 
     #[test]
     fn load_invalid_buffer_as_block() {
         let data = b"this is not a valid mts file";
-        let err = metatensor::io::load_block_buffer(data);
-        assert!(err.is_err());
+        let result = metatensor::io::load_block_buffer(data);
+        assert_eq!(
+            result.unwrap_err().message,
+            "serialization format error: unable to load a TensorBlock from buffer: invalid Zip archive: Could not find central directory end: at '<root>'"
+        );
     }
 
     #[test]
     fn load_invalid_buffer_as_labels() {
         let data = b"this is not a valid mts file";
-        let err = metatensor::io::load_labels_buffer(data);
-        assert!(err.is_err());
+        let result = metatensor::io::load_labels_buffer(data);
+        assert_eq!(
+            result.unwrap_err().message,
+            "serialization format error: unable to load Labels from buffer: start does not match magic string"
+        );
     }
 
     #[test]
     fn load_nonexistent_file() {
-        let err = metatensor::io::load("/nonexistent/path/to/file.mts");
-        assert!(err.is_err());
+        let result = metatensor::io::load("/nonexistent/path/to/file.mts");
+        assert!(result.unwrap_err().message.starts_with("io error:"));
     }
 
     #[test]
     fn load_block_nonexistent_file() {
-        let err = metatensor::io::load_block("/nonexistent/path/to/file.mts");
-        assert!(err.is_err());
+        let result = metatensor::io::load_block("/nonexistent/path/to/file.mts");
+        assert!(result.unwrap_err().message.starts_with("io error:"));
     }
 
     #[test]
     fn load_labels_nonexistent_file() {
-        let err = metatensor::io::load_labels("/nonexistent/path/to/file.mts");
-        assert!(err.is_err());
+        let result = metatensor::io::load_labels("/nonexistent/path/to/file.mts");
+        assert!(result.unwrap_err().message.starts_with("io error:"));
     }
 
     #[test]
@@ -526,8 +535,11 @@ mod error_paths {
         let mut buffer = Vec::new();
         std::io::Read::read_to_end(&mut file, &mut buffer).unwrap();
         let result = metatensor::io::load_buffer(&buffer);
-        // block data does not have keys.npy, so loading as tensor should fail
-        assert!(result.is_err());
+
+        assert_eq!(
+            result.unwrap_err().message,
+            "serialization format error: unable to load a TensorMap from buffer, use `load_block_buffer` to load TensorBlock: specified file not found in archive: at 'keys.npy'"
+        );
     }
 
     #[test]
@@ -537,20 +549,32 @@ mod error_paths {
         let mut buffer = Vec::new();
         std::io::Read::read_to_end(&mut file, &mut buffer).unwrap();
         let result = metatensor::io::load_block_buffer(&buffer);
-        // tensor data does not have values.npy at the root, so loading as block should fail
-        assert!(result.is_err());
+
+        assert_eq!(
+            result.unwrap_err().message,
+            "serialization format error: unable to load a TensorBlock from buffer, use `load` to load TensorMap: specified file not found in archive: at 'values.npy'"
+        );
     }
 
     #[test]
     fn empty_buffer_fails() {
         let result = metatensor::io::load_buffer(b"");
-        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().message,
+            "serialization format error: unable to load TensorMap from empty buffer"
+        );
 
         let result = metatensor::io::load_block_buffer(b"");
-        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().message,
+            "serialization format error: unable to load TensorBlock from empty buffer"
+        );
 
         let result = metatensor::io::load_labels_buffer(b"");
-        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().message,
+            "serialization format error: unable to load Labels from empty buffer"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow up to #1154. The solution in there was too restrictive and did not allow re-using the same callback across calls. We will need #1156 to implement it in a convenient way, so in the mean time we'll just have to pass a low-level C callback.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
