### PR TITLE
Release metatensor-rust v0.4.2

### DIFF
--- a/rust/metatensor/CHANGELOG.md
+++ b/rust/metatensor/CHANGELOG.md
@@ -16,6 +16,8 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
+## [Version 0.4.2](https://github.com/metatensor/metatensor/releases/tag/metatensor-rust-v0.4.2) - 2026-07-03
+
 ### Added
 
 - `load_custom_array`, `load_buffer_custom_array`, `load_block_custom_array`,

--- a/rust/metatensor/Cargo.toml
+++ b/rust/metatensor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metatensor"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.74"
 


### PR DESCRIPTION
With the new `load_custom_array` functions.
