### PR TITLE
Fix linting of Python code in README

### DIFF
--- a/python/metatensor_operations/tests/data/README.md
+++ b/python/metatensor_operations/tests/data/README.md
@@ -6,13 +6,13 @@
   hyper-parameters:
 
 ```py
-cutoff=3.5,
-max_radial=4,
-max_angular=4,
-atomic_gaussian_width=0.3,
-radial_basis={"Gto": {}},
-center_atom_weight=1.0,
-cutoff_function={"ShiftedCosine": {"width": 0.5}},
+cutoff = 3.5
+max_radial = 4
+max_angular = 4
+atomic_gaussian_width = 0.3
+radial_basis = {"Gto": {}}
+center_atom_weight = 1.0
+cutoff_function = {"ShiftedCosine": {"width": 0.5}}
 ```
 
 - **qm7-power-spectrum**: SOAP power spectrum for the first 10 structures in
@@ -20,11 +20,11 @@ cutoff_function={"ShiftedCosine": {"width": 0.5}},
   and 'positions' gradients, using the following hyper-parameters:
 
 ```py
-cutoff=3.5,
-max_radial=4,
-max_angular=4,
-atomic_gaussian_width=0.3,
-radial_basis={"Gto": {}},
-center_atom_weight=1.0,
-cutoff_function={"ShiftedCosine": {"width": 0.5}},
+cutoff = 3.5
+max_radial = 4
+max_angular = 4
+atomic_gaussian_width = 0.3
+radial_basis = {"Gto": {}}
+center_atom_weight = 1.0
+cutoff_function = {"ShiftedCosine": {"width": 0.5}}
 ```


### PR DESCRIPTION
ruff is now linting python blocks in markdown files as well.



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
