### PR TITLE
Release metatensor-learn v0.6.0

### DIFF
--- a/docs/src/learn/reference/index.rst
+++ b/docs/src/learn/reference/index.rst
@@ -12,7 +12,7 @@ API reference
     :tag-prefix: metatensor-learn-v
     :url-suffix: learn/reference/index.html
 
-    .. version:: 0.5.1
+    .. version:: 0.6.0
     .. version:: 0.5.0
     .. version:: 0.4.0
     .. version:: 0.3.2

--- a/metatensor-torch/CHANGELOG.md
+++ b/metatensor-torch/CHANGELOG.md
@@ -26,7 +26,7 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 ### Changed:
 
 - `metatensor_torch::Module` now supports the new format used by
-  metatensor-learn v0.5.1
+  metatensor-learn v0.6
 
 ## [Version 0.10.1](https://github.com/metatensor/metatensor/releases/tag/metatensor-torch-v0.10.1) - 2026-07-09
 

--- a/python/metatensor_learn/CHANGELOG.md
+++ b/python/metatensor_learn/CHANGELOG.md
@@ -17,7 +17,7 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
-## [Version 0.5.1](https://github.com/metatensor/metatensor/releases/tag/metatensor-operations-v0.5.1) - 2025-07-30
+## [Version 0.6.0](https://github.com/metatensor/metatensor/releases/tag/metatensor-operations-v0.6.0) - 2025-07-31
 
 ### Added
 

--- a/python/metatensor_learn/setup.py
+++ b/python/metatensor_learn/setup.py
@@ -13,7 +13,7 @@ ROOT = pathlib.Path(__file__).parent.resolve()
 METATENSOR_CORE = (ROOT / ".." / "metatensor_core").resolve()
 METATENSOR_OPERATIONS = (ROOT / ".." / "metatensor_operations").resolve()
 
-METATENSOR_LEARN_VERSION = "0.5.1"
+METATENSOR_LEARN_VERSION = "0.6.0"
 
 
 class bdist_egg_disabled(bdist_egg):


### PR DESCRIPTION
Re-release of 0.5.1 with a semver incompatible version number