### PR TITLE
Error out instead of segfaulting if the buffer is not on CPU

### DIFF
--- a/metatensor-torch/src/block.cpp
+++ b/metatensor-torch/src/block.cpp
@@ -300,9 +300,21 @@ TensorBlock TensorBlockHolder::load_buffer(torch::Tensor buffer) {
         );
     }
 
+    if (buffer.device().type() != torch::kCPU) {
+        C10_THROW_ERROR(ValueError,
+            "`buffer` must be a tensor on CPU, not on " + buffer.device().str()
+        );
+    }
+
     if (buffer.sizes().size() != 1) {
         C10_THROW_ERROR(ValueError,
             "`buffer` must be a 1-dimensional tensor"
+        );
+    }
+
+    if (!buffer.is_contiguous()) {
+        C10_THROW_ERROR(ValueError,
+            "`buffer` must be a contiguous tensor"
         );
     }
 

--- a/metatensor-torch/src/labels.cpp
+++ b/metatensor-torch/src/labels.cpp
@@ -810,9 +810,21 @@ Labels LabelsHolder::load_buffer(torch::Tensor buffer) {
         );
     }
 
+    if (buffer.device().type() != torch::kCPU) {
+        C10_THROW_ERROR(ValueError,
+            "`buffer` must be a tensor on CPU, not on " + buffer.device().str()
+        );
+    }
+
     if (buffer.sizes().size() != 1) {
         C10_THROW_ERROR(ValueError,
             "`buffer` must be a 1-dimensional tensor"
+        );
+    }
+
+    if (!buffer.is_contiguous()) {
+        C10_THROW_ERROR(ValueError,
+            "`buffer` must be a contiguous tensor"
         );
     }
 

--- a/metatensor-torch/src/tensor.cpp
+++ b/metatensor-torch/src/tensor.cpp
@@ -649,9 +649,21 @@ TensorMap TensorMapHolder::load_buffer(torch::Tensor buffer) {
         );
     }
 
+    if (buffer.device().type() != torch::kCPU) {
+        C10_THROW_ERROR(ValueError,
+            "`buffer` must be a tensor on CPU, not on " + buffer.device().str()
+        );
+    }
+
     if (buffer.sizes().size() != 1) {
         C10_THROW_ERROR(ValueError,
             "`buffer` must be a 1-dimensional tensor"
+        );
+    }
+
+    if (!buffer.is_contiguous()) {
+        C10_THROW_ERROR(ValueError,
+            "`buffer` must be a contiguous tensor"
         );
     }
 


### PR DESCRIPTION
This would catch errors like the one in https://github.com/metatensor/metatrain/pull/1239 and https://github.com/metatensor/metatrain/pull/1233 



# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
